### PR TITLE
invoke `man(1)` when requesting help

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -34,9 +34,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.69"
+version = "1.0.70"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "224afbd727c3d6e4b90103ece64b8d1b67fbb1973b1046c2281eed3f3803f800"
+checksum = "7de8ce5e0f9f8d88245311066a578d72b7af3e7088f32783804676302df237e4"
 dependencies = [
  "backtrace",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,9 @@ paste = "1.0.11"
 log = { version = "0.4.17", optional = true }
 env_logger = { version = "0.10.0", optional = true }
 
+[build-dependencies]
+anyhow = "1.0.70"
+
 [dev-dependencies]
 criterion = "0.3.5"
 test_bin = "0.4.0"

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,53 @@
+use anyhow::bail;
+use anyhow::Result;
+use std::env;
+use std::fs::File;
+use std::io::Write;
+use std::path::PathBuf;
+use std::process::Command;
+
+/// Invokes a troff compiler to compile a manual page
+fn render_man(compiler: &str, man: &str) -> Result<String> {
+    let out = Command::new(compiler).args(["-Tascii", man]).output()?;
+    if !out.status.success() {
+        bail!("{} returned an error", compiler);
+    }
+
+    Ok(String::from_utf8(out.stdout)?)
+}
+
+/// Generates the manual page
+fn generate_man() -> String {
+    // This function is purposely stupid and redundant
+
+    let man = render_man("mandoc", "./doc/rosenpass.1");
+    if man.is_ok() {
+        return man.unwrap();
+    }
+
+    let man = render_man("groff", "./doc/rosenpass.1");
+    if man.is_ok() {
+        return man.unwrap();
+    }
+
+    // TODO: Link to online manual here
+    "Cannot render manual page\n".into()
+}
+
+fn man() {
+    let out_dir = PathBuf::from(env::var("OUT_DIR").unwrap());
+    let man = generate_man();
+    let path = out_dir.join("rosenpass.1.ascii");
+
+    let mut file = File::create(&path).unwrap();
+    file.write_all(man.as_bytes()).unwrap();
+
+    println!("cargo:rustc-env=ROSENPASS_MAN={}", path.display());
+}
+
+fn main() {
+    // For now, rerun the build script on every time, as the build script
+    // is not very expensive right now.
+    println!("cargo:rerun-if-changed=./");
+    man();
+}

--- a/flake.nix
+++ b/flake.nix
@@ -61,6 +61,7 @@
             # source files relevant for rust
             src = pkgs.lib.sourceByRegex ./. [
               "Cargo\\.(toml|lock)"
+              "build.rs"
               "(src|benches)(/.*\\.(rs|md))?"
               "rp"
             ];
@@ -111,6 +112,7 @@
                   nativeBuildInputs = with pkgs; [
                     p.stdenv.cc
                     cmake # for oqs build in the oqs-sys crate
+                    mandoc # for the built-in manual
                     makeWrapper # for the rp shellscript
                     pkg-config # let libsodium-sys-stable find libsodium
                     removeReferencesTo

--- a/src/main.rs
+++ b/src/main.rs
@@ -287,7 +287,13 @@ pub fn rosenpass_main() -> Result<()> {
 
 /// Print the usage information
 pub fn cmd_help() -> Result<()> {
-    eprint!(include_str!("usage.md"), env!("CARGO_BIN_NAME"));
+    let man_cmd = Command::new("man").args(["1", "rosenpass"]).status();
+    if man_cmd.is_ok() && man_cmd.unwrap().success() {
+        return Ok(());
+    }
+
+    // Print the compiled manual
+    eprint!(include_str!(env!("ROSENPASS_MAN")));
     Ok(())
 }
 


### PR DESCRIPTION
This commit invokes the `man(1)` command with the rosenpass manual page, when invoking `help`.

In the future, we should handle the case, that a rosenpass manual page is not installed, somewhat better. My idea would be to render the manual page to an HTML version regularly and provide a link to it inside the error message.