### PR TITLE
Alice/doc upload

### DIFF
--- a/.github/workflows/doc-upload.yml
+++ b/.github/workflows/doc-upload.yml
@@ -1,0 +1,49 @@
+name: Update website docs
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - "doc/**"
+
+jobs:
+  update-website:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Clone rosenpass-website repository
+        uses: actions/checkout@v3
+        with:
+          repository: rosenpass/rosenpass-website
+          ref: main
+          path: rosenpass-website
+          token: ${{ secrets.PRIVACC }}
+
+      - name: Copy docs to website repo
+        run: |
+          cp -R doc/* rosenpass-website/static/docs/
+
+      - name: Install mandoc
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y mandoc
+
+      - name: Compile man pages to HTML
+        run: |
+          cd rosenpass-website/static/docs/
+          for file in *.1; do
+            mandoc -Thtml "$file" > "${file%.*}.html"
+          done
+
+      - name: Commit changes to website repo
+        uses: EndBug/add-and-commit@v9
+        with:
+          author_name: GitHub Actions
+          author_email: actions@github.com
+          message: Update docs
+          cwd: rosenpass-website/static/docs
+          github_token: ${{ secrets.PRIVACC }}


### PR DESCRIPTION
Created an implementation of an automated documentation uploader and compiler that should automatically compile files, using mandoc, into the rosenpass-website repo at /static/docs every time a change is made to rosenpass at /doc.

As this necessitated changes to both the rosenpass-website and rosenpass repo, I will copy the same changes to both pull requests:

1- added a menu item for documentation in the config file with a weight of 20
2- added a button in the “getting started” section for documentation.
3- created a “docs” directory under “/static”, where all documentation files will be stored.
4- created a shortcodes file called “htmlfile.html” to allow documentation to be printed
5- in the documentation.md file, created headers for current docs, if entirely new files are added, then new headers must be generated
6- created a new block shortcode for different documents within the webpage, need to polish layout
7- produced a doc-upload.yml file to automate the process of updating or creating new documentation files via mandoc compilation, embedded within rosenpass. Requires both an access key and for github actions to be allowed to read/write. This code will not run until those are provided. Current code assumes that the added secret will be named "PRIVACC".
8- created some custom CSS to handle the behaviour of the documentation buttons within the documentation page, with a view to eventually adding more buttons at a later date if more files are added.