### PR TITLE
fix: Disable broken CI jobs

### DIFF
--- a/.github/workflows/nix.yaml
+++ b/.github/workflows/nix.yaml
@@ -18,7 +18,7 @@ jobs:
         nix-system:
           - x86_64-linux
           - i686-linux
-          - aarch64-linux
+          #- aarch64-linux -- Broken; see https://github.com/rosenpass/rosenpass/issues/62
         derivation:
           - rosenpass
           - rosenpass-static

--- a/.github/workflows/qc.yaml
+++ b/.github/workflows/qc.yaml
@@ -62,4 +62,7 @@ jobs:
       - run: rustup component add clippy
       - name: Install libsodium
         run: sudo apt-get install -y libsodium-dev
-      - run: RUSTDOCFLAGS="-D warnings" cargo doc --document-private-items
+      # `--no-deps` used as a workaround for a rust compiler bug. See:
+      # - https://github.com/rosenpass/rosenpass/issues/62
+      # - https://github.com/rust-lang/rust/issues/108378
+      - run: RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --document-private-items

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -16,7 +16,7 @@ jobs:
       matrix:
         nix-system:
           - x86_64-linux
-          - aarch64-linux
+          #- aarch64-linux -- Broken; see https://github.com/rosenpass/rosenpass/issues/62
     steps:
       - uses: actions/checkout@v3
       - name: Build release-package for ${{ matrix.nix-system }}

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -35,19 +35,19 @@ pub enum Cli {
      * guidance on the CLI usage.
      */
     Exchange {
-        /// public-key <PATH> secret-key <PATH> [listen <ADDR>:<PORT>]... [verbose]
+        /// public-key \<PATH> secret-key \<PATH> \[listen \<ADDR>:\<PORT>]... \[verbose]
         #[clap(value_name = "OWN_CONFIG")]
         first_arg: String,
 
-        /// peer public-key <PATH> [ENDPOINT] [PSK] [OUTFILE] [WG]
+        /// peer public-key \<PATH> \[ENDPOINT] \[PSK] \[OUTFILE] \[WG]
         ///
-        /// ENDPOINT := [endpoint <HOST/IP>:<PORT>]
+        /// ENDPOINT := \[endpoint \<HOST/IP>:\<PORT>]
         ///
-        /// PSK := [preshared-key <PATH>]
+        /// PSK := \[preshared-key \<PATH>]
         ///
-        /// OUTFILE := [outfile <PATH>]
+        /// OUTFILE := \[outfile \<PATH>]
         ///
-        /// WG := [wireguard <WIREGUARD_DEV> <WIREGUARD_PEER> [WIREGUARD_EXTRA_ARGS]...]
+        /// WG := \[wireguard \<WIREGUARD_DEV> \<WIREGUARD_PEER> \[WIREGUARD_EXTRA_ARGS]...]
         #[clap(value_names = [
 "peer", "public-key", "<PATH>", "[ENDPOINT]" ,"[PSK]", "[OUTFILE]", "[WG]"            
         ])]


### PR DESCRIPTION
These are cross compilation static build jobs
which are nice to have but non-essential.