### PR TITLE
fix devshell bug introduced in #90

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -312,6 +312,7 @@
             inherit (packages.rosenpass) RUST_MIN_STACK;
             inputsFrom = [ packages.default ];
             nativeBuildInputs = with pkgs; [
+              cmake # override the fakecmake from the main step above
               cargo-release
               clippy
               nodePackages.prettier


### PR DESCRIPTION
This commit reverts the CMake change done in #90, as it broke the invocation of `cargo build`.

While this might be considered as a hotfix, it at least fixes building through `cargo build` and, in my opinion more importantly, makes it possible to run unit tests through `cargo test` again.