### PR TITLE
add smoke test for devshell and test without nix

### DIFF
--- a/.ci/gen-workflow-files.nu
+++ b/.ci/gen-workflow-files.nu
@@ -33,7 +33,7 @@ let systems_map = {
   # aarch64-linux
   
   i686-linux: ubuntu-latest,
-  x86_64-darwin: macos-latest,
+  x86_64-darwin: macos-13,
   x86_64-linux: ubuntu-latest
 }
 
@@ -64,7 +64,7 @@ let runner_setup = [
     uses: "actions/checkout@v3"
   }
   {
-    uses: "cachix/install-nix-action@v21",
+    uses: "cachix/install-nix-action@v22",
     with: { nix_path: "nixpkgs=channel:nixos-unstable" }
   }
   {

--- a/.github/workflows/nix.yaml
+++ b/.github/workflows/nix.yaml
@@ -15,7 +15,7 @@ jobs:
       - i686-linux---rosenpass
     steps:
       - uses: actions/checkout@v3
-      - uses: cachix/install-nix-action@v21
+      - uses: cachix/install-nix-action@v22
         with:
           nix_path: nixpkgs=channel:nixos-unstable
       - uses: cachix/cachix-action@v12
@@ -31,7 +31,7 @@ jobs:
     needs: []
     steps:
       - uses: actions/checkout@v3
-      - uses: cachix/install-nix-action@v21
+      - uses: cachix/install-nix-action@v22
         with:
           nix_path: nixpkgs=channel:nixos-unstable
       - uses: cachix/cachix-action@v12
@@ -48,7 +48,7 @@ jobs:
       - i686-linux---rosenpass
     steps:
       - uses: actions/checkout@v3
-      - uses: cachix/install-nix-action@v21
+      - uses: cachix/install-nix-action@v22
         with:
           nix_path: nixpkgs=channel:nixos-unstable
       - uses: cachix/cachix-action@v12
@@ -63,7 +63,7 @@ jobs:
       - ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: cachix/install-nix-action@v21
+      - uses: cachix/install-nix-action@v22
         with:
           nix_path: nixpkgs=channel:nixos-unstable
       - uses: cachix/cachix-action@v12
@@ -75,12 +75,12 @@ jobs:
   x86_64-darwin---default:
     name: Build x86_64-darwin.default
     runs-on:
-      - macos-latest
+      - macos-13
     needs:
       - x86_64-darwin---rosenpass
     steps:
       - uses: actions/checkout@v3
-      - uses: cachix/install-nix-action@v21
+      - uses: cachix/install-nix-action@v22
         with:
           nix_path: nixpkgs=channel:nixos-unstable
       - uses: cachix/cachix-action@v12
@@ -92,13 +92,13 @@ jobs:
   x86_64-darwin---release-package:
     name: Build x86_64-darwin.release-package
     runs-on:
-      - macos-latest
+      - macos-13
     needs:
       - x86_64-darwin---rosenpass
       - x86_64-darwin---rosenpass-oci-image
     steps:
       - uses: actions/checkout@v3
-      - uses: cachix/install-nix-action@v21
+      - uses: cachix/install-nix-action@v22
         with:
           nix_path: nixpkgs=channel:nixos-unstable
       - uses: cachix/cachix-action@v12
@@ -110,11 +110,11 @@ jobs:
   x86_64-darwin---rosenpass:
     name: Build x86_64-darwin.rosenpass
     runs-on:
-      - macos-latest
+      - macos-13
     needs: []
     steps:
       - uses: actions/checkout@v3
-      - uses: cachix/install-nix-action@v21
+      - uses: cachix/install-nix-action@v22
         with:
           nix_path: nixpkgs=channel:nixos-unstable
       - uses: cachix/cachix-action@v12
@@ -126,12 +126,12 @@ jobs:
   x86_64-darwin---rosenpass-oci-image:
     name: Build x86_64-darwin.rosenpass-oci-image
     runs-on:
-      - macos-latest
+      - macos-13
     needs:
       - x86_64-darwin---rosenpass
     steps:
       - uses: actions/checkout@v3
-      - uses: cachix/install-nix-action@v21
+      - uses: cachix/install-nix-action@v22
         with:
           nix_path: nixpkgs=channel:nixos-unstable
       - uses: cachix/cachix-action@v12
@@ -143,10 +143,10 @@ jobs:
   x86_64-darwin---check:
     name: Run Nix checks on x86_64-darwin
     runs-on:
-      - macos-latest
+      - macos-13
     steps:
       - uses: actions/checkout@v3
-      - uses: cachix/install-nix-action@v21
+      - uses: cachix/install-nix-action@v22
         with:
           nix_path: nixpkgs=channel:nixos-unstable
       - uses: cachix/cachix-action@v12
@@ -163,7 +163,7 @@ jobs:
       - x86_64-linux---rosenpass
     steps:
       - uses: actions/checkout@v3
-      - uses: cachix/install-nix-action@v21
+      - uses: cachix/install-nix-action@v22
         with:
           nix_path: nixpkgs=channel:nixos-unstable
       - uses: cachix/cachix-action@v12
@@ -180,7 +180,7 @@ jobs:
       - x86_64-linux---proverif-patched
     steps:
       - uses: actions/checkout@v3
-      - uses: cachix/install-nix-action@v21
+      - uses: cachix/install-nix-action@v22
         with:
           nix_path: nixpkgs=channel:nixos-unstable
       - uses: cachix/cachix-action@v12
@@ -196,7 +196,7 @@ jobs:
     needs: []
     steps:
       - uses: actions/checkout@v3
-      - uses: cachix/install-nix-action@v21
+      - uses: cachix/install-nix-action@v22
         with:
           nix_path: nixpkgs=channel:nixos-unstable
       - uses: cachix/cachix-action@v12
@@ -210,11 +210,11 @@ jobs:
     runs-on:
       - ubuntu-latest
     needs:
-      - x86_64-linux---rosenpass-static
       - x86_64-linux---rosenpass-static-oci-image
+      - x86_64-linux---rosenpass-static
     steps:
       - uses: actions/checkout@v3
-      - uses: cachix/install-nix-action@v21
+      - uses: cachix/install-nix-action@v22
         with:
           nix_path: nixpkgs=channel:nixos-unstable
       - uses: cachix/cachix-action@v12
@@ -230,7 +230,7 @@ jobs:
     needs: []
     steps:
       - uses: actions/checkout@v3
-      - uses: cachix/install-nix-action@v21
+      - uses: cachix/install-nix-action@v22
         with:
           nix_path: nixpkgs=channel:nixos-unstable
       - uses: cachix/cachix-action@v12
@@ -247,7 +247,7 @@ jobs:
       - x86_64-linux---rosenpass
     steps:
       - uses: actions/checkout@v3
-      - uses: cachix/install-nix-action@v21
+      - uses: cachix/install-nix-action@v22
         with:
           nix_path: nixpkgs=channel:nixos-unstable
       - uses: cachix/cachix-action@v12
@@ -263,7 +263,7 @@ jobs:
     needs: []
     steps:
       - uses: actions/checkout@v3
-      - uses: cachix/install-nix-action@v21
+      - uses: cachix/install-nix-action@v22
         with:
           nix_path: nixpkgs=channel:nixos-unstable
       - uses: cachix/cachix-action@v12
@@ -280,7 +280,7 @@ jobs:
       - x86_64-linux---rosenpass-static
     steps:
       - uses: actions/checkout@v3
-      - uses: cachix/install-nix-action@v21
+      - uses: cachix/install-nix-action@v22
         with:
           nix_path: nixpkgs=channel:nixos-unstable
       - uses: cachix/cachix-action@v12
@@ -296,7 +296,7 @@ jobs:
     needs: []
     steps:
       - uses: actions/checkout@v3
-      - uses: cachix/install-nix-action@v21
+      - uses: cachix/install-nix-action@v22
         with:
           nix_path: nixpkgs=channel:nixos-unstable
       - uses: cachix/cachix-action@v12
@@ -311,7 +311,7 @@ jobs:
       - ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: cachix/install-nix-action@v21
+      - uses: cachix/install-nix-action@v22
         with:
           nix_path: nixpkgs=channel:nixos-unstable
       - uses: cachix/cachix-action@v12
@@ -326,7 +326,7 @@ jobs:
     if: ${{ github.ref == 'refs/heads/main' }}
     steps:
       - uses: actions/checkout@v3
-      - uses: cachix/install-nix-action@v21
+      - uses: cachix/install-nix-action@v22
         with:
           nix_path: nixpkgs=channel:nixos-unstable
       - uses: cachix/cachix-action@v12

--- a/.github/workflows/qc.yaml
+++ b/.github/workflows/qc.yaml
@@ -66,3 +66,43 @@ jobs:
       # - https://github.com/rosenpass/rosenpass/issues/62
       # - https://github.com/rust-lang/rust/issues/108378
       - run: RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --document-private-items
+
+  cargo-test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+      - name: Install libsodium
+        run: sudo apt-get install -y libsodium-dev
+      - run: cargo test
+
+  cargo-test-nix-devshell-x86_64-linux:
+    runs-on:
+      - ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+      - uses: cachix/install-nix-action@v21
+        with:
+          nix_path: nixpkgs=channel:nixos-unstable
+      - uses: cachix/cachix-action@v12
+        with:
+          name: rosenpass
+          authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
+      - run: nix develop --command cargo test

--- a/.github/workflows/qc.yaml
+++ b/.github/workflows/qc.yaml
@@ -82,7 +82,10 @@ jobs:
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
       - name: Install libsodium
         run: sudo apt-get install -y libsodium-dev
-      - run: cargo test
+        # liboqs requires quite a lot of stack memory, thus we adjust
+        # the default stack size picked for new threads (which is used
+        # by `cargo test`) to be _big enough_. Setting it to 8 MiB
+      - run: RUST_MIN_STACK=8388608 cargo test
 
   cargo-test-nix-devshell-x86_64-linux:
     runs-on:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -12,7 +12,7 @@ jobs:
       - ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: cachix/install-nix-action@v21
+      - uses: cachix/install-nix-action@v22
         with:
           nix_path: nixpkgs=channel:nixos-unstable
       - uses: cachix/cachix-action@v12
@@ -30,10 +30,10 @@ jobs:
   x86_64-darwin---release:
     name: Build release artifacts for x86_64-darwin
     runs-on:
-      - macos-latest
+      - macos-13
     steps:
       - uses: actions/checkout@v3
-      - uses: cachix/install-nix-action@v21
+      - uses: cachix/install-nix-action@v22
         with:
           nix_path: nixpkgs=channel:nixos-unstable
       - uses: cachix/cachix-action@v12
@@ -54,7 +54,7 @@ jobs:
       - ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: cachix/install-nix-action@v21
+      - uses: cachix/install-nix-action@v22
         with:
           nix_path: nixpkgs=channel:nixos-unstable
       - uses: cachix/cachix-action@v12


### PR DESCRIPTION
This commit adds two new jobs. One checks that `cargo test` runs through, and second one checking that `cargo test` inside the nix devshell runs through as well.

fixes #98