### PR TITLE
rp: Defaults to dual-stack

### DIFF
--- a/rp
+++ b/rp
@@ -197,7 +197,7 @@ exchange() {
         lip="${listen%:*}";
         lport="${listen/*:/}";
         if [[ "$lip" = "$lport" ]]; then
-          lip="[0::0]"
+          lip="[::]"
         fi
         shift;;
       -h | -help | --help | help) usage; return 0;;


### PR DESCRIPTION
If currently no IP address, only on IPv6 is listen by default. This commit would make it listen dual-stack - i.e. IPv4 and IPv6 - by default.