### PR TITLE
doc: Clarify the assumptions about the server

### DIFF
--- a/doc/rp.1
+++ b/doc/rp.1
@@ -59,6 +59,10 @@ listening on the provided IP and port combination, allowing connections from
 .Sh EXIT STATUS
 .Ex -std
 .Sh EXAMPLES
+In this example, we will assume that the server has an interface bound to
+192.168.0.1, that accepts incoming connections on port 9999/UDP for Rosenpass
+and port 10000/UDP for WireGuard.
+.Pp
 To create a VPN connection, start by generating secret keys on both hosts.
 .Bd -literal -offset indent
 rp genkey server.rosenpass-secret


### PR DESCRIPTION
This commit clarifies the assumptions about the server/responder in the `rp.1` manual page, by specifying an IP and open UDP ports that the rest of this tutorial is going to assume.

Reported-by: Robert Clausecker <fuzxxl@gmail.com>

Fixes #116

/cc @clausecker