### PR TITLE
cli: Move `StaticKEM::keygen` out of `unsafe`

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -164,9 +164,9 @@ impl Cli {
                 // generate the keys and store them in files
                 let mut ssk = crate::protocol::SSk::random();
                 let mut spk = crate::protocol::SPk::random();
+                StaticKEM::keygen(ssk.secret_mut(), spk.secret_mut())?;
 
                 unsafe {
-                    StaticKEM::keygen(ssk.secret_mut(), spk.secret_mut())?;
                     ssk.store_secret(skf)?;
                     spk.store_secret(pkf)?;
                 }


### PR DESCRIPTION
This commit moves the `StaticKEM::keygen` call out of an `unsafe` call, because the function is not unsafe.