### PR TITLE
Implement test coverage checks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,7 @@ _markdown_*
 **/result
 **/result-*
 .direnv
+
+# Test coverage
+/coverage
+/lcov.info

--- a/maint/coverage.sh
+++ b/maint/coverage.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+#
+# In order use this, you need to have `grcov` in your path and `llvm-tools` in
+# your Rust toolchain.
+#
+# ```sh
+# cargo install grcov
+# rustup component add llvm-tools
+# ```
+
+BASEDIR=$(git rev-parse --show-toplevel)
+COVERAGE="$BASEDIR/coverage"
+FORMAT="lcov"
+OUTPUT="$BASEDIR/lcov.info"
+
+export RUST_MIN_STACK=16000000 # 16MB
+export RUSTFLAGS="-Cinstrument-coverage"
+export LLVM_PROFILE_FILE="$COVERAGE/rosenpass-%p-%m.profraw"
+
+echo "Removing data from previous runs ..."
+rm -rf "$COVERAGE"
+rm -rf "$OUTPUT"
+mkdir "$COVERAGE"
+
+cargo build --all-features
+cargo test --all-features
+
+echo "Generating report ..."
+grcov "$COVERAGE" \
+	-s "$BASEDIR/src" \
+	--binary-path "$BASEDIR/target/debug" \
+	-t "$FORMAT" \
+	--branch \
+	--ignore-not-existing \
+	--excl-start "^(pub(\((crate|super)\))? )?mod test" \
+	--excl-stop "^}" \
+	-o "$OUTPUT"


### PR DESCRIPTION
This PR adds a script `maint/coverage.sh` that provides a wrapper around `grcov` in order to execute unit tests.

For now, it only outputs in lcov, although many other formats are available as well.

Below, there is an HTML output (maybe we can integrate it to our website):
![Screenshot 2023-09-14 at 11 14 43](https://github.com/rosenpass/rosenpass/assets/12272949/7b6acae6-5c63-4c5d-b182-c567de12316e)
