### PR TITLE
test: Ensure 8MiB of stack size for key generation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -926,6 +926,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "psm"
+version = "0.1.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5787f7cda34e3033a72192c018bc5883100330f362ef279a8cbccfce8bb4e874"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1032,6 +1041,7 @@ dependencies = [
  "oqs-sys",
  "paste",
  "serde",
+ "stacker",
  "static_assertions",
  "test_bin",
  "thiserror",
@@ -1177,6 +1187,19 @@ name = "spin"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
+
+[[package]]
+name = "stacker"
+version = "0.1.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c886bd4480155fd3ef527d45e9ac8dd7118a898a46530b7b94c3e21866259fce"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "libc",
+ "psm",
+ "winapi",
+]
 
 [[package]]
 name = "static_assertions"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,7 @@ anyhow = "1.0.71"
 [dev-dependencies]
 criterion = "0.4.0"
 test_bin = "0.4.0"
+stacker = "0.1.15"
 
 [features]
 default = ["log", "env_logger"]

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -1739,7 +1739,11 @@ mod test {
 
         // initialize secret and public key for the crypto server
         let (mut sk, mut pk) = (SSk::zero(), SPk::zero());
-        StaticKEM::keygen(sk.secret_mut(), pk.secret_mut()).expect("unable to generate keys");
+
+        // Guranteed to have 16MB of stack size
+        stacker::grow(8 * 1024 * 1024, || {
+            StaticKEM::keygen(sk.secret_mut(), pk.secret_mut()).expect("unable to generate keys");
+        });
 
         CryptoServer::new(sk, pk)
     }


### PR DESCRIPTION
This commit ensures that the call to `StaticKEM::keygen` has a stack of 16MB.

Especially on Darwin system, this commit is necessary in order to prevent a stack overflow, as this system only provides stack sizes of roughly 500KB which is way to small for a Classic McEliece key.

Fixes #118