### PR TITLE
config: Default `WireGuard::extra_params` to empty `Vec`

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -55,6 +55,8 @@ pub struct RosenpassPeer {
 pub struct WireGuard {
     pub device: String,
     pub peer: String,
+
+    #[serde(default)]
     pub extra_params: Vec<String>,
 }
 


### PR DESCRIPTION
Otherwise, omitting `extra_params` in the configuration file will result in a `WireGuard` configuration object of `None`, even though not specifying `extra_params` is sane.

See also https://github.com/NixOS/nixpkgs/pull/254813#issuecomment-1738738224

The code I used to test this (which changes more than just one line) is at https://github.com/rosenpass/rosenpass/compare/main...ngi-nix:rosenpass:config ... If you want me to add the additional method to parse a configuration from a string and the test to this PR, please tell me. Thanks.