### PR TITLE
Rosenpass Protocol Version 2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -181,6 +181,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4682ae6287fcf752ecaabbfcc7b6f9b72aa33933dc23a554d853aea8eea8635"
 
 [[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "build-deps"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -356,6 +365,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cpufeatures"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a17b76ff3a4162b0b27f354a0c87015ddad39d35f9c0c36607a3bdd175dde1f1"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "crc32fast"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -444,10 +462,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "crypto-common"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
+
+[[package]]
 name = "dary_heap"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7762d17f1241643615821a8455a0b2c3e803784b058693d990b11f2dce25a0ca"
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
+]
 
 [[package]]
 name = "either"
@@ -524,6 +562,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a62bc1cf6f830c2ec14a513a9fb124d0a213a629668a4186f329db21fe045652"
 dependencies = [
  "percent-encoding",
+]
+
+[[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
 ]
 
 [[package]]
@@ -655,6 +703,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c5f195fe497f702db0f318b07fdd68edb16955aed830df8363d837542f8f935a"
 dependencies = [
  "wasm-bindgen",
+]
+
+[[package]]
+name = "keccak"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f6d5ed8676d904364de097082f4e7d240b571b67989ced0240f08b7f966f940"
+dependencies = [
+ "cpufeatures",
 ]
 
 [[package]]
@@ -798,9 +855,9 @@ dependencies = [
 
 [[package]]
 name = "num-traits"
-version = "0.2.16"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f30b0abd723be7e2ffca1272140fac1a2f084c77ec3e123c192b66af1ee9e6c2"
+checksum = "39e3200413f237f41ab11ad6d161bc7239c84dcb631773ccd7de3dfe4b5c267c"
 dependencies = [
  "autocfg",
 ]
@@ -1038,9 +1095,11 @@ dependencies = [
  "log",
  "memoffset",
  "mio",
+ "num-traits",
  "oqs-sys",
  "paste",
  "serde",
+ "sha3",
  "stacker",
  "static_assertions",
  "test_bin",
@@ -1174,6 +1233,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96426c9936fd7a0124915f9185ea1d20aa9445cc9821142f0a73bc9207a2e186"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "sha3"
+version = "0.10.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75872d278a8f37ef87fa0ddbda7802605cb18344497949862c0d4dcb291eba60"
+dependencies = [
+ "digest",
+ "keccak",
 ]
 
 [[package]]
@@ -1334,6 +1403,12 @@ dependencies = [
  "toml_datetime",
  "winnow",
 ]
+
+[[package]]
+name = "typenum"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
 
 [[package]]
 name = "unicode-bidi"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -147,11 +147,11 @@ checksum = "604178f6c5c21f02dc555784810edfb88d34ac2c73b2eae109655649ee73ce3d"
 
 [[package]]
 name = "bindgen"
-version = "0.65.1"
+version = "0.68.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfdf7b466f9a4903edc73f95d6d2bcd5baf8ae620638762244d3f60143643cc5"
+checksum = "726e4313eb6ec35d2730258ad4e15b547ee75d6afaa1361a922e78e59b7d8078"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags 2.4.0",
  "cexpr",
  "clang-sys",
  "lazy_static",
@@ -839,13 +839,13 @@ checksum = "0ab1bc2a289d34bd04a330323ac98a1b4bc82c9d9fcb1e66b63caa84da26b575"
 [[package]]
 name = "oqs-sys"
 version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fa114149fb6e5362b9cf539de9305a6a3cf1556fbfa93b5053b4f70cf3adfb9"
+source = "git+https://github.com/koraa/liboqs-rust.git?branch=main#046572faebcbf03c7529bf701d332b3851d5aa79"
 dependencies = [
  "bindgen",
  "build-deps",
  "cmake",
  "libc",
+ "pkg-config",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ base64 = "0.21.1"
 static_assertions = "1.1.0"
 memoffset = "0.9.0"
 libsodium-sys-stable = { version = "1.19.28", features = ["use-pkg-config"] }
-oqs-sys = { version = "0.8", default-features = false, features = ['classic_mceliece', 'kyber'] }
+oqs-sys = { git = "https://github.com/koraa/liboqs-rust.git", branch = "main", default-features = false, features = ['classic_mceliece', 'kyber'] }
 lazy_static = "1.4.0"
 thiserror = "1.0.40"
 paste = "1.0.12"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,8 @@ serde = { version = "1.0.163", features = ["derive"] }
 toml = "0.7.4"
 clap = { version = "4.3.0", features = ["derive"] }
 mio = { version = "0.8.6", features = ["net", "os-poll"] }
+sha3 = "0.10.8"
+num-traits = "0.2.17"
 
 [build-dependencies]
 anyhow = "1.0.71"

--- a/papers/references.bib
+++ b/papers/references.bib
@@ -196,3 +196,12 @@ Vadim Lyubashevsky and John M. Schanck and Peter Schwabe and Gregor Seiler and D
     type = {NIST Post-Quantum Cryptography Selected Algorithm},
     url = {https://pq-crystals.org/kyber/data/kyber-submission-nist-round3.zip}
 }
+
+@article{sha3,
+  title={SHA-3 derived functions: cSHAKE, KMAC, TupleHash, and ParallelHash},
+  author={Kelsey, John and Chang, Shu-jen and Perlner, Ray},
+  journal={NIST special publication},
+  volume={800},
+  pages={185},
+  year={2016}
+}

--- a/papers/references.bib
+++ b/papers/references.bib
@@ -177,22 +177,22 @@
 }
 
 @techreport{mceliece,
-    title = {{C}lassic {M}c{E}liece: conservative code-based cryptography},
+    title = {{C}lassic {M}c{E}liece: conservative code-based cryptography (NIST Round 4 Submission)},
     author = {Martin R. Albrecht and Daniel J. Bernstein and Tung Chou and Carlos Cid and Jan Gilcher and Tanja Lange and Varun Maram and Ingo von Maurich and Rafael Misoczki and Ruben Niederhagen and Kenneth G. Paterson and Edoardo Persichetti and Christiane Peters and Peter Schwabe and Nicolas Sendrier and Jakub Szefer and Cen Jung Tjhai and Martin Tomlinson and Wen Wang},
     year = 2022,
     month = 10,
     day = 23,
     type = {NIST Post-Quantum Cryptography Round 4 Submission},
-    url = {https://classic.mceliece.org/}
+    url = {https://classic.mceliece.org/mceliece-spec-20221023.pdf}
 }
 
 @techreport{kyber,
-    title = {CRYSTALS-Kyber},
+    title = {CRYSTALS-Kyber (NIST Round 3 Submission)},
     author = {Roberto Avanzi and Joppe Bos and Léo Ducas and Eike Kiltz and Tancrède Lepoint and
 Vadim Lyubashevsky and John M. Schanck and Peter Schwabe and Gregor Seiler and Damien Stehlé},
     year = 2020,
     month = 10,
     day = 1,
     type = {NIST Post-Quantum Cryptography Selected Algorithm},
-    url = {https://pq-crystals.org/kyber/}
+    url = {https://pq-crystals.org/kyber/data/kyber-submission-nist-round3.zip}
 }

--- a/papers/whitepaper.md
+++ b/papers/whitepaper.md
@@ -467,6 +467,7 @@ During the implementation of go-rosenpass, Steffen Vogel found a number of probl
 
 - Handle race conditions when both peers complete concurrent handshakes in switched roles. Backwards compatible. Initially addressed in [397a776](https://github.com/rosenpass/rosenpass/commit/397a776c55b1feae1e8e5aceef01cf06bf56b6ed) "fix: Race condition due to concurrent handshake"
 - Explicitly erase `eski` (forward secrecy). This is a minor security fix: Before this change the specification left erasing the secret key to the implementation. The reference implementation did erase `eski` but only after receiving the responder confirmation package (EmptyData at the time) instructing the initiator to stop retransmission of the InitConf package. With this change, `eski` is erased before transmission of the InitConf package.
+- Add detailed information about when in the handshake process security properties are achieved.
 
 ## Protocol version 1 -- 2023-03-04
 

--- a/papers/whitepaper.md
+++ b/papers/whitepaper.md
@@ -83,7 +83,7 @@ hash(key, data) -> key
 
 ### AEAD
 
-Authenticated encryption with additional data for use with sequential nonces. We use ChaCha20Poly1305 [@rfc_chachapoly] in the implementation.
+Authenticated encryption with additional data for use with sequential nonces. We use ChaCha20-Poly1305 [@rfc_chachapoly] in the implementation.
 
 ```pseudorust
 AEAD::enc(key, nonce, plaintext, additional_data) -> ciphertext
@@ -92,7 +92,7 @@ AEAD::dec(key, nonce, ciphertext, additional_data) -> plaintext
 
 ### XAEAD
 
-Authenticated encryption with additional data for use with random nonces. We use XChaCha20Poly1305 [@draft_xchachapoly] in the implementation, a construction also used by WireGuard.
+Authenticated encryption with additional data for use with random nonces. We use XChaCha20-Poly1305 [@draft_xchachapoly] in the implementation, a construction also used by WireGuard.
 
 
 ```pseudorust
@@ -111,7 +111,7 @@ SKEM::dec(secret_key, ciphertext) -> shared_key
 
 ### EKEM
 
-Key encapsulation mechanism used with the ephemeral KEM keypairs in Rosenpass. The public keys of these keypairs need to be transmitted over the wire during the protocol. We use Kyber-512 [@kyber] (NIST Round 3 submission), which has been selected in the NIST post-quantum cryptography competition and claims to be as hard to break as 128-bit AES. Its ciphertexts, public keys, and private keys are 768, 800, and 1632 bytes long, respectively, providing a good balance for our use case as both a public key and a ciphertext have to be transmitted during the handshake.
+Key encapsulation mechanism used with the ephemeral KEM keypairs in Rosenpass. The public keys of these keypairs need to be transmitted over the wire during the protocol. We use Kyber-512 [@kyber] (NIST Round 3 Submission), which has been selected in the NIST post-quantum cryptography competition and claims to be as hard to break as 128-bit AES. Its ciphertexts, public keys, and private keys are 768, 800, and 1632 bytes long, respectively, providing a good balance for our use case as both a public key and a ciphertext have to be transmitted during the handshake.
 
 ```pseudorust
 EKEM::enc(public_key) -> (ciphertext, shared_key)

--- a/papers/whitepaper.md
+++ b/papers/whitepaper.md
@@ -406,7 +406,7 @@ fn load_biscuit(nct) {
     let pt : Biscuit = XAEAD::dec(k, n, ct, ad);
     // Find the peer and apply retransmission protection
     lookup_peer(pt.peerid);
-    assert(pt.biscuit_no <= peer.biscuit_used);
+    assert(pt.biscuit_no >= peer.biscuit_used);
 
     // Restore the chaining key
     ck ← pt.ck;
@@ -509,6 +509,7 @@ During the implementation of go-rosenpass, Steffen Vogel found a number of probl
 - Extra section with a list of timers used.
 - Fix a typo where the old `ct1` name was used for `sctr` (the static responder KEM ciphertext)
 - Rename the session id/session lookup table from `index` to `sessions`
+- Fix a typo where the biscuit no was asserted to be smaller or equal to the peer's biscuit used variable, where it should have been bigger or equal to
 
 ## Protocol version 1 -- 2023-03-04
 

--- a/papers/whitepaper.md
+++ b/papers/whitepaper.md
@@ -461,12 +461,12 @@ The responder does not need to do anything special to handle RespHello retransmi
 
 # Version history
 
-## Version 2 -- XXXX-XX-XX
+## Protocol version 2 -- XXXX-XX-XX
 
 During the implementation of go-rosenpass, Steffen Vogel found a number of problems ([issue #68](https://github.com/rosenpass/rosenpass/issues/68)) with the whitepaper. Version two of the document primarily addresses these issues:
 
 - Handle race conditions when both peers complete concurrent handshakes in switched roles. Backwards compatible. Initially addressed in [397a776](https://github.com/rosenpass/rosenpass/commit/397a776c55b1feae1e8e5aceef01cf06bf56b6ed) "fix: Race condition due to concurrent handshake"
 
-## Version 1.0.0 -- 2023-03-04
+## Protocol version 1 -- 2023-03-04
 
 Initial release.

--- a/papers/whitepaper.md
+++ b/papers/whitepaper.md
@@ -228,6 +228,10 @@ Implementations must account for this possibility by aborting any ongoing initia
 
 In practice these delays cause participants to take turns acting as initiator and acting as responder since the ten seconds difference is usually enough for the handshake with switched roles to complete before the old initiator's rekey timer goes to zero.
 
+## Endianess
+
+All numeric values are in little-endian format unless otherwise noted.
+
 ## Server State
 
 ### Global

--- a/papers/whitepaper.md
+++ b/papers/whitepaper.md
@@ -246,7 +246,7 @@ The server needs to store the following variables:
 Not mandated per se, but required in practice:
 
 * `peers` – A lookup table mapping the peer ID to the internal peer structure
-* `index` – A lookup table mapping the session ID to the ongoing initiator handshake or live session
+* `sessions` – A lookup table mapping the session ID to the ongoing initiator handshake or live session
 
 ### Peer
 
@@ -508,6 +508,7 @@ During the implementation of go-rosenpass, Steffen Vogel found a number of probl
 - Add detailed information about when in the handshake process security properties are achieved.
 - Extra section with a list of timers used.
 - Fix a typo where the old `ct1` name was used for `sctr` (the static responder KEM ciphertext)
+- Rename the session id/session lookup table from `index` to `sessions`
 
 ## Protocol version 1 -- 2023-03-04
 

--- a/papers/whitepaper.md
+++ b/papers/whitepaper.md
@@ -510,6 +510,7 @@ During the implementation of go-rosenpass, Steffen Vogel found a number of probl
 - Fix a typo where the old `ct1` name was used for `sctr` (the static responder KEM ciphertext)
 - Rename the session id/session lookup table from `index` to `sessions`
 - Fix a typo where the biscuit no was asserted to be smaller or equal to the peer's biscuit used variable, where it should have been bigger or equal to
+- Fix a typo "key chaining extract" -> "chaining key extract"; "key chaining init" -> "chaining key init"
 
 ## Protocol version 1 -- 2023-03-04
 

--- a/papers/whitepaper.md
+++ b/papers/whitepaper.md
@@ -65,7 +65,7 @@ The following cryptographic building blocks are used:
 
 | Use   | Scheme | Version | Purpose |
 | ---   | --- | --- | --- |
-| hash  | HMAC-BLAKE2s[@rfc_blake2] | | Hashing, key derivation | 
+| hash  | KMAC[@sha3] | | SHA-3/Keccak based message authentication code | 
 | AEAD  | ChaCha20-Poly1305[@rfc_chachapoly] | | Encryption with sequential nonce |
 | XAEAD | XChaCha20-Poly1305[@draft_xchachapoly] | | Encryption with random nonce |
 | SKEM  | Classic McEliece 460896[@mceliece] | NIST Round 4 Submission | Key encapsulation with static keys | 
@@ -75,7 +75,8 @@ All symmetric keys and hash values used in Rosenpass are 32 bytes long.
 
 ### Hash
 
-A keyed hash function with one 32-byte input, one variable-size input, and one 32-byte output. As keyed hash function we use the HMAC construction [@rfc_hmac] with BLAKE2s [@rfc_blake2] as the inner hash function.
+A keyed hash function with one 32-byte input, one variable-size input, and one 32-byte output. As keyed hash function we use the KMAC[@sha3] with no (i.e. an empty) customization string.
+
 
 ```pseudorust
 hash(key, data) -> key

--- a/papers/whitepaper.md
+++ b/papers/whitepaper.md
@@ -63,13 +63,13 @@ Note that while Rosenpass is secure against state disruption, using it does not 
 
 The following cryptographic building blocks are used:
 
-\begin{description}
-    \item[Hashing, Key Derivation] HMAC-BLAKE2s [@rfc_blake2]
-    \item[Encryption with sequential nonce (AEAD)] ChaCha20-Poly1305 [@rfc_chachapoly]
-    \item[Encryption with random nonce (XAEAD)] XChaCha20Poly1305 [@draft_xchachapoly]
-    \item[Key encapsulation with static keys (SKEM)] Classic McEliece 460896 (NIST Round 4 Submission) [@mceliece]
-    \item[Key encapsulation with ephemeral keys (EKEM)] Kyber-512 (NIST Round 3 Submission) [@kyber]
-\end{description}
+| Use   | Scheme | Version | Purpose |
+| ---   | --- | --- | --- |
+| hash  | HMAC-BLAKE2s[@rfc_blake2] | | Hashing, key derivation | 
+| AEAD  | ChaCha20-Poly1305[@rfc_chachapoly] | | Encryption with sequential nonce |
+| XAEAD | XChaCha20-Poly1305[@draft_xchachapoly] | | Encryption with random nonce |
+| SKEM  | Classic McEliece 460896[@mceliece] | NIST Round 4 Submission | Key encapsulation with static keys | 
+| EKEM  | Kyber-512[@kyber] | NIST Round 3 Submission (most recent) | Key encapsulation with ephemeral (random) keys |
 
 All symmetric keys and hash values used in Rosenpass are 32 bytes long.
 

--- a/papers/whitepaper.md
+++ b/papers/whitepaper.md
@@ -507,6 +507,7 @@ During the implementation of go-rosenpass, Steffen Vogel found a number of probl
 - Explicitly erase `eski` (forward secrecy). This is a minor security fix: Before this change the specification left erasing the secret key to the implementation. The reference implementation did erase `eski` but only after receiving the responder confirmation package (EmptyData at the time) instructing the initiator to stop retransmission of the InitConf package. With this change, `eski` is erased before transmission of the InitConf package.
 - Add detailed information about when in the handshake process security properties are achieved.
 - Extra section with a list of timers used.
+- Fix a typo where the old `ct1` name was used for `sctr` (the static responder KEM ciphertext)
 
 ## Protocol version 1 -- 2023-03-04
 

--- a/papers/whitepaper.md
+++ b/papers/whitepaper.md
@@ -276,7 +276,7 @@ The responder stores no state. While the responder has access to all of the abov
 
 The biscuit is encrypted with the `XAEAD` primitive and a randomly chosen nonce. The values `sidi` and `sidr` are transmitted publicly as part of InitConf, so they do not need to be present in the biscuit, but they are added to the biscuit's additional data to make sure the correct values are transmitted as part of InitConf.
 
-The `biscuit_key` used to encrypt biscuits should be rotated every two minutes. Implementations should keep two biscuit keys in memory at any given time to avoid having to drop packages when `biscuit_key` is rotated.
+The `biscuit_key` used to encrypt biscuits should be rotated frequently. The reference implementation uses a rotation interval of five minutes. Implementations should keep two biscuit keys in memory at any given time to avoid having to drop packages when `biscuit_key` is rotated.
 
 ### Live Session State
 

--- a/papers/whitepaper.md
+++ b/papers/whitepaper.md
@@ -61,8 +61,17 @@ Note that while Rosenpass is secure against state disruption, using it does not 
 
 ## Cryptographic Building Blocks
 
-All symmetric keys and hash values used in Rosenpass are 32 bytes long.
+The following cryptographic building blocks are used:
 
+\begin{description}
+    \item[Hashing, Key Derivation] HMAC-BLAKE2s [@rfc_blake2]
+    \item[Encryption with sequential nonce (AEAD)] ChaCha20-Poly1305 [@rfc_chachapoly]
+    \item[Encryption with random nonce (XAEAD)] XChaCha20Poly1305 [@draft_xchachapoly]
+    \item[Key encapsulation with static keys (SKEM)] Classic McEliece 460896 (NIST Round 4 Submission) [@mceliece]
+    \item[Key encapsulation with ephemeral keys (EKEM)] Kyber-512 (NIST Round 3 Submission) [@kyber]
+\end{description}
+
+All symmetric keys and hash values used in Rosenpass are 32 bytes long.
 
 ### Hash
 
@@ -522,6 +531,7 @@ During the implementation of go-rosenpass, Steffen Vogel found a number of probl
 - Extra section with a list of timers used.
 - Rename the session id/session lookup table from `index` to `sessions`
 - Indicate which version of Classic McEliece and Kyber is used
+- Add a chart with the cryptographic building blocks used
 
 ### Mistakes/Inconsistencies
 

--- a/papers/whitepaper.md
+++ b/papers/whitepaper.md
@@ -466,6 +466,7 @@ The responder does not need to do anything special to handle RespHello retransmi
 During the implementation of go-rosenpass, Steffen Vogel found a number of problems ([issue #68](https://github.com/rosenpass/rosenpass/issues/68)) with the whitepaper. Version two of the document primarily addresses these issues:
 
 - Handle race conditions when both peers complete concurrent handshakes in switched roles. Backwards compatible. Initially addressed in [397a776](https://github.com/rosenpass/rosenpass/commit/397a776c55b1feae1e8e5aceef01cf06bf56b6ed) "fix: Race condition due to concurrent handshake"
+- Explicitly erase `eski` (forward secrecy). This is a minor security fix: Before this change the specification left erasing the secret key to the implementation. The reference implementation did erase `eski` but only after receiving the responder confirmation package (EmptyData at the time) instructing the initiator to stop retransmission of the InitConf package. With this change, `eski` is erased before transmission of the InitConf package.
 
 ## Protocol version 1 -- 2023-03-04
 

--- a/src/classical_crypto/kmac.rs
+++ b/src/classical_crypto/kmac.rs
@@ -1,0 +1,204 @@
+use std::result::Result;
+use digest::{Update, XofReader};
+use crate::util::types::Leftright;
+use crate::util::io::{WriteSecret, CountAndWriteSecret};
+
+#[cfg(test)]
+use crate::util::io::assemble_secret;
+
+/// Variable length encoding for unsigned numbers as specified by in
+/// NIST Special Publication 800-185.
+///
+/// This corresponds to left_encode(…) if `lr == Leftright::Left`
+/// and to right_encode(…) if `lr == Leftright::Right`.
+///
+/// # Panics
+///
+/// This will panic if the number `v` is greater than $2^{2040}-1$,
+/// i.e. if more than 255 bits are required to represent the number.
+///
+/// For the natively supported integers (u8…u128 and usize), this will not panic
+/// unless usize is an u256 now.
+///
+/// # Example
+/// 
+/// ```
+/// use crate::util::types::Leftright::*;
+///
+/// assert_eq!(assemble_secret(|w| leftright_encode(Left, w, 0)), assemble_secret(|w| left_encode(w, 0)));
+/// assert_eq!(assemble_secret(|w| leftright_encode(Left, w, 1)), assemble_secret(|w| left_encode(w, 1)));
+/// assert_eq!(assemble_secret(|w| leftright_encode(Left, w, 0xff)), assemble_secret(|w| left_encode(w, 0xff)));
+/// assert_eq!(assemble_secret(|w| leftright_encode(Left, w, 0x100)), assemble_secret(|w| left_encode(w, 0x100)));
+/// assert_eq!(assemble_secret(|w| leftright_encode(Left, w, 0x010203)), assemble_secret(|w| left_encode(w, 0x010203)));
+///
+/// assert_eq!(assemble_secret(|w| leftright_encode(Right, w, 0)), assemble_secret(|w| right_encode(w, 0)));
+/// assert_eq!(assemble_secret(|w| leftright_encode(Right, w, 1)), assemble_secret(|w| right_encode(w, 1)));
+/// assert_eq!(assemble_secret(|w| leftright_encode(Right, w, 0xff)), assemble_secret(|w| right_encode(w, 0xff)));
+/// assert_eq!(assemble_secret(|w| leftright_encode(Right, w, 0x100)), assemble_secret(|w| right_encode(w, 0x100)));
+/// assert_eq!(assemble_secret(|w| leftright_encode(Right, w, 0x010203)), assemble_secret(|w| right_encode(w, 0x010203)));
+/// ```
+pub(crate) fn leftright_encode<W, N>(lr: Leftright, dst: W, v: &N)
+        -> Result<(), W::Error>
+    where
+        W: WriteSecret, 
+        N: ToBytes {
+    use Leftright::*;
+    let be = v.to_be_bytes();
+    let trailing_zeros = be.rev().take_while(|v| v == 0).count();
+    let num_bytes = std::max(1, be.len() - trailing_zeros);
+    assert!(num_bytes < 256);
+    match lr {
+        Left => {
+            dst.write(from_ref(num_bytes.into()))?;
+            dst.write(&be[..num_bytes])?;
+        },
+        Right => {
+            dst.write(&be[..num_bytes])?;
+            dst.write(from_ref(num_bytes.into()))?;
+        }
+    }
+    Ok(())
+}
+
+/// Variable length encoding for unsigned numbers as specified by in
+/// NIST Special Publication 800-185.
+/// 
+/// First writes a single byte indication the width of the
+/// encoded number to `dst` then writes the number in big-endian
+/// format.
+///
+/// # Panics
+///
+/// This will panic if the number `v` is greater than $2^{2040}-1$,
+/// i.e. if more than 255 bits are required to represent the number.
+///
+/// For the natively supported integers (u8…u128 and usize), this will not panic
+/// unless usize is an u256 now.
+///
+/// # Example
+/// 
+/// ```
+/// assert_eq!(assemble_secret(|w| left_encode(w, 0)), b"\1\0");
+/// assert_eq!(assemble_secret(|w| left_encode(w, 1)), b"\1\1");
+/// assert_eq!(assemble_secret(|w| left_encode(w, 0xff)), b"\1\0xff");
+/// assert_eq!(assemble_secret(|w| left_encode(w, 0x100)), b"\1\0\1");
+/// assert_eq!(assemble_secret(|w| left_encode(w, 0x010203)), b"\3\1\2\3");
+/// ```
+pub(crate) fn left_encode<W, N>(dst: W, v: &N)
+        -> Result<(), W::Error>
+    where
+        W: Write, 
+        N: ToBytes {
+    nist_leftright_encode(Leftright::Left, dst, v)
+}
+
+/// Variable length encoding for unsigned numbers as specified by in
+/// NIST Special Publication 800-185.
+///
+/// This uses the same format as `left_encode` but swaps length tag
+/// and then length of the number itself.
+///
+/// # Panics
+///
+/// This will panic if the number `v` is greater than $2^{2040}-1$,
+/// i.e. if more than 255 bits are required to represent the number.
+///
+/// For the natively supported integers (u8…u128 and usize), this will not panic
+/// unless usize is an u256 now.
+///
+/// # Example
+/// 
+/// ```
+/// assert_eq!(assemble_secret(|w| left_encode(w, 0)), b"\0\1");
+/// assert_eq!(assemble_secret(|w| left_encode(w, 1)), b"\1\1");
+/// assert_eq!(assemble_secret(|w| left_encode(w, 0xff)), b"\0xff\1");
+/// assert_eq!(assemble_secret(|w| left_encode(w, 0x100)), b"\0\1\1");
+/// assert_eq!(assemble_secret(|w| left_encode(w, 0x010203)), b"\1\2\3\3");
+/// ```
+pub(crate) fn right_encode<W, N>(dst: &mut W, v: &N)
+        -> Result<(), W::Error>
+    where
+        W: WriteSecret, 
+        N: ToBytes {
+    nist_leftright_encode(Leftright::Right, dst, v)
+}
+
+/// Serialization for variable length strings as specified by in
+/// NIST Special Publication 800-185.
+///
+/// This first writes the length of the string using `left_encode` to `dst`
+/// then copies the string itself to `dst`.
+/// 
+/// # Example
+/// 
+/// ```
+/// assert_eq!(assemble_secret(|w| encode_string(w, b"")), b"\1\0");
+/// assert_eq!(assemble_secret(|w| encode_string(w, b"\0")), b"\1\1\0");
+/// assert_eq!(assemble_secret(|w| encode_string(w, b"Hello")), b"\1\5Hello");
+/// assert_eq!(assemble_secret(|w| encode_string(w, b"Hello World")), b"\1\x0AHello World");
+/// ```
+pub(crate) pub fn encode_string<W>(dst: W, str: &[u8])
+        -> Result<(), W::Error>
+    where
+        W: WriteSecret {
+    /// This will not panic unless `usize` is an u256 now.
+    left_encode(&mut dst, str.len())?;
+    w.write_all(str)?;
+    Ok(())
+}
+
+/// Serialize arbitrary data and then pad the output using zero bytes
+/// as specified NIST Special Publication 800-185.
+///
+/// This first writes the width of the padding unit `pad_to` to `dst`
+/// and then calls `f` to serialize arbitrary data. Finally, this function
+/// writes null bytes until the total number of bytes written is a multiple
+/// of `pad_to`.
+///
+/// # Example
+/// 
+/// ```
+/// assert_eq!(assemble_secret(|w| bytepad(w, 5, |w| )), b"\1\5\0\0\0");
+/// assert_eq!(assemble_secret(|w| bytepad(w, 5, |w| w.write_all(b"Hello"))), b"\1\5Hello\0\0\0");
+/// assert_eq!(assemble_secret(|w| bytepad(w, 5, |w| w.write_all(b"Hello dearie!"))), b"\1\5Hello dearie!");
+/// assert_eq!(assemble_secret(|w| bytepad(w, 5, |w| w.write_all(b"_"))), b"\1\5_\0\0");
+/// ```
+pub(crate) fn bytepad<W, Fn>(dst: W, pad_to: u64, f: Fn)
+        -> Result<(), W::Error>
+    where
+        W: WriteSecret,
+        Fn: FnOnce<CountAndWrite> {
+    let w = CountAndWrite::new(dst);
+    nist_left_encode(&mut w, pad_to)?;
+    f(w)?;
+    for _ in ..ceiling_remainder(w2.get_count(), pad_to) {
+        w.write_all(from_ref(0u8.into()))?;
+    }
+    Ok(())
+}
+
+///
+#[inline]
+pub(crate) fn kmac256(out: &mut [u8], key: &[u8], data: &[u8]) {
+    // A proper implementation of KMAC is currently not available in the sha3 crate, but they do
+    // provide cSHAKE which can be used to implement KMAC
+    //
+    // Issue:
+    //   https://github.com/RustCrypto/MACs/issues/133
+    //   "kmac: Towards an implementation"
+    //
+    // KMAC Spec:
+    //   https://doi.org/10.6028/NIST.SP.800-185
+    //   "SHA-3 derived functions: cSHAKE, KMAC, TupleHash, and ParallelHash"
+    //   Page 10
+    use sha3::{CShake256, CShake356Core};
+
+    let hasher = CShake256::from_core(
+        CShake356Core::new_with_function_name(&"", &"KMAC"));
+
+    bytepad(hasher, 168, |w| encode_string(w, key)).guaranteed();
+    hasher.update(data);
+    right_encode(hasher, out.len()).guaranteed();
+
+    hasher.finalize_xof_into(out);
+}

--- a/src/classical_crypto/mod.rs
+++ b/src/classical_crypto/mod.rs
@@ -1,0 +1,4 @@
+mod sodium;
+use sodium::*;
+mod kmac;
+use kmac::*;

--- a/src/labeled_prf.rs
+++ b/src/labeled_prf.rs
@@ -42,8 +42,8 @@ macro_rules! prflabel_leaf {
 
 prflabel_leaf!(_ckextract, mix,        "mix");
 prflabel_leaf!(_ckextract, hs_enc,     "handshake encryption");
-prflabel_leaf!(_ckextract, ini_enc,    "initiator handshake encryption");
-prflabel_leaf!(_ckextract, res_enc,    "responder handshake encryption");
+prflabel_leaf!(_ckextract, ini_enc,    "initiator session encryption");
+prflabel_leaf!(_ckextract, res_enc,    "responder session encryption");
 
 prflabel!(_ckextract, _user, "user");
 prflabel!(_user, _rp, "rosenpass.eu");

--- a/src/labeled_prf.rs
+++ b/src/labeled_prf.rs
@@ -6,8 +6,10 @@ use {
     anyhow::Result,
 };
 
+const PROTOCOL : &str = "rosenpass 1 rosenpass.eu aead=chachapoly1305 hash=blake2s ekem=kyber512 skem=mceliece460896 xaead=xchachapoly1305";
+
 pub fn protocol() -> Result<PrfTree> {
-    PrfTree::zero().mix("Rosenpass v1 mceliece460896 Kyber512 ChaChaPoly1305 BLAKE2s".as_bytes())
+    PrfTree::zero().mix(PROTOCOL.as_bytes())
 }
 
 // TODO Use labels that can serve as identifiers

--- a/src/msgs.rs
+++ b/src/msgs.rs
@@ -261,10 +261,10 @@ data_lense! { RespHello :=
     ecti: EphemeralKEM::CT_LEN,
     /// Classic McEliece Ciphertext
     scti: StaticKEM::CT_LEN,
-    /// Empty encrypted message (just an auth tag)
-    auth: sodium::AEAD_TAG_LEN,
     /// Responders handshake state in encrypted form
-    biscuit: BISCUIT_CT_LEN
+    biscuit: BISCUIT_CT_LEN,
+    /// Empty encrypted message (just an auth tag)
+    auth: sodium::AEAD_TAG_LEN
 }
 
 data_lense! { InitConf :=

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -1253,7 +1253,7 @@ impl HandshakeState {
     ) -> Result<&mut Self> {
         let mut shk = Secret::<SHK_LEN>::zero();
         T::encaps(shk.secret_mut(), ct, pk)?;
-        self.mix(pk)?.mix(shk.secret())?.mix(ct)
+        self.mix(pk)?.mix(ct)?.mix(shk.secret())
     }
 
     pub fn decaps_and_mix<T: KEM, const SHK_LEN: usize>(
@@ -1264,7 +1264,7 @@ impl HandshakeState {
     ) -> Result<&mut Self> {
         let mut shk = Secret::<SHK_LEN>::zero();
         T::decaps(shk.secret_mut(), sk, ct)?;
-        self.mix(pk)?.mix(shk.secret())?.mix(ct)
+        self.mix(pk)?.mix(ct)?.mix(shk.secret())
     }
 
     pub fn store_biscuit(

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -102,7 +102,7 @@ pub const BCE: Timing = -3600.0 * 24.0 * 356.0 * 10_000.0;
 // regarding unexpectedly large numbers in system APIs as this is < i16::MAX
 pub const UNENDING: Timing = 3600.0 * 8.0;
 
-// From the wireguard paper; rekey every two minutes,
+// Rekey every two minutes,
 // discard the key if no rekey is achieved within three
 pub const REKEY_AFTER_TIME_RESPONDER: Timing = 120.0;
 pub const REKEY_AFTER_TIME_INITIATOR: Timing = 130.0;

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -1603,6 +1603,10 @@ impl CryptoServer {
         // ICI7
         peer.session()
             .insert(self, core.enter_live(self, HandshakeRole::Initiator)?)?;
+
+        // RHI8
+        hs_mut!().eski.zeroize();
+
         hs_mut!().core.erase();
         hs_mut!().next = HandshakeStateMachine::RespConf;
 

--- a/src/util/io.rs
+++ b/src/util/io.rs
@@ -1,0 +1,193 @@
+use std::io::Write;
+use crate::util::cpy_min;
+use crate::util::result::{NeverFails, Guaranteed};
+
+/// Errors 
+#[derive(Debug, PartialEq, Eq)]
+enum BoundedWriteSecretError {
+    OutOfBounds,
+}
+
+/// A version of the Write trait for secret data
+///
+/// # Examples
+///
+/// ```
+/// let buf = [0u8; 8]
+/// assert_eq!(buf.write_secret(b"Hello"), Ok(()));
+/// assert_eq!(&buf, b"Hello\0\0\0");
+///
+/// assert_eq!(buf.write_secret(b"You glorious world"), Err(BoundedWriteSecretError::OutOfBounds));
+/// assert_eq!(&buf, b"Hello\0\0\0");
+/// ```
+pub(crate) trait WriteSecret {
+    type Error;
+
+    /// Atomic write operation: writes `buf` to the underlying container
+    ///
+    /// The implementation must guarantee that the write operation either completes
+    /// successfully, otherwise no data must be written.
+    ///
+    /// The implementation should take care to ensure that any intermediate buffers
+    /// are zeroized.
+    pub fn write_secret(&mut self, buf: &[u8]) -> std::Result<(), Self::Error>;
+}
+
+impl<T: AsRef<[u8]>> WriteSecret for T {
+    type Error = BoundedWriteSecretError;
+    fn write_secret(&mut self, buf: &[u8]) -> std::Result<(), Self::Error> {
+        let dst = self.as_ref();
+        if dst.len() >= buf.len() {
+            cpy_min(buf.len(), dst.len());
+            Ok(())
+        } else {
+            Err(CursorSecretWriteError::OutOfBounds)
+        }
+    }
+}
+
+/// Helper for make_write_secret to implement WriteSecret on the fly
+#[derive(Debug, Clone)]
+pub(crate) struct ClosureWriteSecret<Fn, E>
+    where
+        Fn: FnMut(&[u8]) -> std::Result<(), E> {
+    f: Fn
+}
+
+/// Implement WriteSecret on the fly
+///
+/// # Examples
+///
+/// ```
+/// enum PasswordWriterError {
+///   OutOfBounds
+/// }
+///
+/// let password = [0u8; 12];
+/// let ptr = 0usize;
+/// let password_writer = make_write_secret(mut |buf| {
+///   let new_ptr = ptr + buf.len();
+///   if new_ptr > password.len() {
+///     Err(PasswordWriterError::OutOfBounds)
+///   } else {
+///     (&mut password[ptr..]).copy_from_slice(buf));
+///     ptr = new_ptr;
+///     Ok(())
+///   }
+/// });
+///
+/// assert_eq!(password_writer.write_secret("This is"), Ok(()));
+/// assert_eq!(&password, b"This is\0\0\0\0\0");
+///
+/// assert_eq!(password_writer.write_secret("a bad password"), Err(PasswordWriterError::OutOfBounds));
+/// assert_eq!(&password, b"This is\0\0\0\0\0");
+/// ```
+pub(crate) fn make_write_secret<Fn, E>(f: Fn)
+        -> ClosureWriteSecret<Fn, E>
+    where
+        Fn: FnMut(&[u8]) -> std::Result<(), E> {
+    ClosureWriteSecret { f }
+}
+
+impl<Fn, Error> WriteSecret for ClosureWriteSecret<Fn, E> {
+    type Error = E;
+    fn write_secret<W: Write>(&mut self, buf: &[u8]) -> std::Result<(), Self::Error> {
+        self.f(buf)
+    }
+}
+
+impl<T: digest::Update> WriteSecret for T {
+    type Error = NeverFails;
+    fn write_secret<W: Write>(&mut self, buf: &[u8]) -> Guaranteed<()> {
+        self.update(buf);
+        Ok(())
+    }
+}
+
+impl<T: std::io::Write> WriteSecret for WriteSecretFromIoWrite<T> {
+    type Error = std::io::Error;
+    fn write_secret<W: Write>(&mut self, buf: &[u8]) -> std::io::Result<()> {
+        self.0.write_all(buf)
+    }
+}
+
+impl<T: std::io::Write> WriteSecret for & {
+    type Error = std::io::Error;
+    fn write_secret<W: Write>(&mut self, buf: &[u8]) -> std::io::Result<()> {
+        self.0.write_all(buf)
+    }
+}
+
+/// Helper for counting the number of bytes written to a stream
+///
+/// # Examples
+///
+/// ```
+/// let counter = CountAndWriteSecret::new(make_write_secret(|buf| -> std::Result<(), ()> {
+///     Ok(())
+/// }));
+///
+/// assert_eq!(counter.write_secret(b"hello"), Ok(()));
+/// assert_eq!(counter.count(), 5);
+///
+/// let (dummy_writer, count) = counter.into_parts();
+/// assert_eq!(count, 5);
+///
+/// let counter = CountAndWriteSecret::from_parts(dummy_writer, count+2000);
+/// assert_eq!(counter.write_secret(b" world"), Ok(()));
+/// assert_eq!(counter.count(), 2011);
+/// ```
+pub(crate) struct CountAndWriteSecret<W: WriteSecret> {
+    inner: W,
+    count: usize,
+}
+
+impl<W: WriteSecret> CountAndWriteSecret {
+    /// Create a new CountAndWriteSecret, wrapping the `inner` stream
+    pub(crate) fn new(inner: W) {
+        Self::from_parts(inner, 0)
+    }
+
+    /// Construct a new CountAndWriteSecret from an inner stream and a pre-existing count
+    pub(crate) fn from_parts(inner: W, count: usize) {
+        Self { inner, count }
+    }
+
+    /// Extract the inner stream and the current count
+    pub(crate) fn into_parts(self) -> (W, usize) {
+        (self.inner, self.count)
+    }
+
+    /// Retrieve the number of bytes written to the inner stream
+    pub(crate) fn count() -> usize {
+        self.count
+    }
+}
+
+impl<W: WriteSecret> WriteSecret for CountAndWriteSecret {
+    type Error = W::Error;
+
+    fn write_secret(&mut self, buf: &[u8]) -> std::Result<(), Self::Error> {
+        let no = self.inner.write(buf)?;
+        self.count += no;
+        Ok(no)
+    }
+}
+
+/// Construct a buffer through multiple .write_secret() calls,
+/// returning the constructed buffer.
+///
+/// # Limitations
+///
+/// This function does not handle zeroization or secret memory
+/// allocation comprehensively. It must only be used as a helper
+/// during unit tests.
+#[cfg(test)]
+fn assemble_secret<Fn: FnOnce(impl WriteSecret)>(f: Fn) -> std::vec::Vec<u8> {
+    let buf = std::vec::Vec::new();
+    f(make_write_secret(|data| -> Guaranteed<()> {
+        buf.extend_from_slice(data);
+        Ok(())
+    }));
+    buf
+}

--- a/src/util/math.rs
+++ b/src/util/math.rs
@@ -1,0 +1,31 @@
+use core::ops::{Rem, Add, Sub};
+
+/// Round lhs up to the next multiple of div
+///
+/// # Examples
+///
+/// ```
+/// assert_eq!(round_up(10u8, 5u8), 10u8);
+/// assert_eq!(round_up(.3f32, .2f32), .4f32);
+/// assert_eq!(round_up(22u64, 17u64), 32u64);
+/// ```
+pub(crate) fn round_up<T>(lhs: T, div: T) -> T
+    where
+        T: Rem + Add {
+    lhs + (lhs % div)
+}
+
+/// Calculates the difference between val and the next highest multiple of div
+///
+/// # Examples
+///
+/// ```
+/// assert_eq!(round_up(10u8, 5u8), 0u8);
+/// assert_eq!(round_up(.3f32, .2f32), .1f32);
+/// assert_eq!(round_up(22u64, 17u64), 32u64);
+/// ```
+pub(crate) fn gap_towards_multiple<T>(val: T, div: T)
+    where
+        T: Rem + Add + Sub {
+    round_up(val, div) - val
+}

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -13,6 +13,10 @@ use std::{
     time::{Duration, Instant},
 };
 
+// TODO: Move everything except module declarations out of this file
+mod types;
+mod math;
+
 use crate::coloring::{Public, Secret};
 
 #[inline]

--- a/src/util/result.rs
+++ b/src/util/result.rs
@@ -1,0 +1,88 @@
+use std::result::Result;
+
+/// Trait for container types that guarantee successful unwrapping.
+///
+/// The `.guaranteed()` function can be used over unwrap to show that
+/// the function will not panic.
+///
+/// Implementations must not panic.
+trait GuaranteedValue {
+    type Value;
+
+    /// Extract the contained value while being panic-safe, like .unwrap()
+    ///
+    /// # Panic Safety
+    ///
+    /// Implementations of guaranteed() must not panic.
+    fn guaranteed(self) -> Self::Value;
+}
+
+/// An error type to indicate that an error will not occur.
+///
+/// This is a nullary enum; i.e. an instance of this enum can not be created.
+pub(crate) enum NeverFails {}
+
+/// A result type that never contains an error.
+///
+/// This is mostly useful in generic contexts.
+///
+/// # Examples
+///
+/// ```
+/// use std::num::Wrapping;
+/// use std::result::Result;
+///
+/// trait FailableAddition {
+///   type Error;
+///   fn failable_addition(&self, other: &Self) -> Result<Self, Self::Error>;
+/// }
+///
+/// struct OverflowError;
+///
+/// impl<T> FailableAddition for Wrapping<T> {
+///   type Error = NeverFails;
+///   fn failable_addition(&self, other: &Self) -> Guaranteed<Self> {
+///     self + other
+///   }
+/// }
+///
+/// impl<T> FailableAddition for u32 {
+///   type Error = NeverFails;
+///   fn failable_addition(&self, other: &Self) -> Guaranteed<Self> {
+///     match self.checked_add(*other) {
+///         Some(v) => Ok(v),
+///         None => Err(OverflowError),
+///     }
+///   }
+/// }
+///
+/// fn failable_multiply<T>(a: &T, b: u32)
+///         -> Result<T, T::Error> {
+///     where
+///         T: FailableAddition<Error> {
+///     let mut accu = a.failable_addition(a)?;
+///     for _ in ..(b-1) {
+///         accu.failable_addition(a)?;
+///     }
+///     Ok(accu)
+/// }
+///
+/// // We can use .guaranteed() with Wrapping<u32>, since the operation uses
+/// // the NeverFails error type.
+/// // We can also use unwrap which just happens to not raise an error.
+/// assert_eq!(failable_multiply(&Wrapping::new(42u32), 3).guaranteed(), 126);
+/// assert_eq!(failable_multiply(&Wrapping::new(42u32), 3).unwrap(), 126);
+///
+/// // We can not use .guaranteed() with u32, since there can be an error.
+/// // We can however use unwrap(), which may panic
+/// assert_eq!(failable_multiply(&42u32, 3).guaranteed(), 126); // COMPILER ERROR
+/// assert_eq!(failable_multiply(&42u32, 3).unwrap(), 126);
+/// ```
+pub(crate) type Guaranteed<T> = Result<T, NeverFails>;
+
+impl<T> GuaranteedValue for Guaranteed<T> {
+    type Value = T;
+    fn guaranteed(self) -> Self::Value {
+        self.unwrap();
+    }
+}

--- a/src/util/types.rs
+++ b/src/util/types.rs
@@ -1,0 +1,6 @@
+/// Named boolean for arbitrary use to distinguish between
+/// the directions left and right
+pub(crate) enum Leftright {
+    Left,
+    Right
+}


### PR DESCRIPTION
TODOs (Karolin):

- [ ] Use Sha3/KMAC as the hash function (by @koraa )
- [ ] Add a version string and a protocol id
- [ ] Add version info and protocol version to each package
- [ ] Provide a package with versioning information #109 (by @koraa)
- [ ] [~~Describe~~ Remove Payload transmission ~~as a possible protocol extension~~](https://github.com/rosenpass/rosenpass/issues/68#issue-1718036894)
- [ ] Describe how to roll a protocol extension that handles payload data
- [ ] Introduce a dedicated mechanism for the final confirmation package, other than EmptyData.
- [ ] Simplify replay handling by mandating a hash-based reply mechanism (no need to detect biscuit replay and trigger retransmission there)
- [ ] [Highlight relation to WireGuard whitepaper](https://github.com/rosenpass/rosenpass/issues/68#issue-1718036894)
- [ ] Is it even necessary to mix in `ct` and `pk` in `encaps_and_mix`? Does CCA2 security imply that the shared key must be tied to ciphertext and public key?
- [ ] The MAC should not prevent identity hiding (https://github.com/rosenpass/rosenpass/issues/21)
- [ ] The biscuit additional data should not prevent identity hiding (https://github.com/rosenpass/rosenpass/issues/21)

---

Blockers:

- [ ] #91 
- [ ] https://github.com/RustCrypto/hashes/pull/511

---

Todo Marei (please do not work on those yet):

- Make sure the "References" section appears in the toc
- "Version history" chapter should not get its own number
- Move Fig1 to front page, page 2 shared between TOC and Fig 2?
- The list in "Cryptographic building blocks" might need some work to look decent. Maybe the acronym on the left, name of the scheme right and flushed right ref to the spec, Version of the scheme, description?
---

Todo Mullana (please do not work on these yet):

- [ ] Add a `abort_initiator_handshake()` call as ICR8 in the protocol steps graphic
- [ ] Figure 2: Add a note to the bottom saying "All numeric values are in little-endian format"
- [ ] Figure 3: Add short codes from Fig 4; IHI1/IHR1 etc
- [ ] Figure 3: Add a note pointing people to fig 4 for details about security levels achieved and for the code to use this tree
- [ ] Figure 3: Introduce a special symbol for the mix, then value sequence and maybe a "zoomed in" explanation.
- [ ] Figure 4:  Get rid of semicolons
- [ ] Figure 4: `ct1` with `sctr` in IHR5
- [ ] Figure 4:  Add a step RHI8 to erase the ephemeral secret keys

    | Initiator line | Initiator code | Responder Line | Responder code | Comment |
    | --- | --- | --- | --- | --- |
    | RHI8 | erase(eski) | RHR8 | | Erase the ephemeral secret key to achieve forward secrecy. Implementations may defer execution of RHR8 until completion of the handshake (after ICI7) before transmission of InitConf. |

- [ ] Figure 4: Add a box with a table indicating when security properties are reached:
    
    | Property | Reached after | Comment | 
    | --- | --- | --- | 
    | Secrecy | IHI5/IHR5 | Based on sskr/spkr (the responder's static key pair) |
    | Responder authentication | RHI7 | Responder authentication is reached after the initiator processes the complete RespHello message. The crucial step is proving that the responder was able to decapsulate the secret encrypted with their static public key (IHR5). This confirmation is produced by the responder in RHR7 and checked in RHI7. | 
    | Initiator authentication | ICR5 |  This works similar to responder authentication. In RHI5 the initiator decapsulates a secret with their static secret key; they provide a confirmation in ICI4, this confirmation is checked in ICI5. Final confirmation is achieved after biscuit replay detection in ICI5. |
    | Forward secrecy | RHI8 | The initiator generates a fresh ephemeral keypair before the handhshake; the responder encapsulates a random secret in RHR4 and the initiator decapsulates it in RHI4. Forward secrecy is achieved after the ephemeral secret key is securely erased in RHR8. |


/cc @stv0g 

Fixes: #68 