### PR TITLE
app_server: Replace `is_ok()` by `if let`

### DIFF
--- a/src/app_server.rs
+++ b/src/app_server.rs
@@ -638,8 +638,7 @@ impl AppServer {
             thread::spawn(move || {
                 let status = child.wait();
 
-                if status.is_ok() {
-                    let status = status.unwrap();
+                if let Ok(status) = status {
                     if status.success() {
                         debug!("successfully passed psk to wg")
                     } else {


### PR DESCRIPTION
This commit replaces an `is_ok()` call with a call to `if let`, thereby fixing a clippy warning.