### PR TITLE
Remove unwrap from fuzz targets that return errors

### DIFF
--- a/fuzzing/fuzz_targets/handle_msg.rs
+++ b/fuzzing/fuzz_targets/handle_msg.rs
@@ -15,5 +15,7 @@ fuzz_target!(|rx_buf: &[u8]| {
 
     let mut cs = CryptoServer::new(sk, pk);
     let mut tx_buf = [0; 10240];
-    cs.handle_msg(rx_buf, &mut tx_buf).unwrap();
+
+    // We expect errors while fuzzing therefore we do not check the result.
+    let _ = cs.handle_msg(rx_buf, &mut tx_buf);
 });

--- a/fuzzing/fuzz_targets/mceliece_encaps.rs
+++ b/fuzzing/fuzz_targets/mceliece_encaps.rs
@@ -9,5 +9,6 @@ fuzz_target!(|input: &[u8]| {
     let mut ciphertext = [0u8; 188];
     let mut shared_secret = [0u8; 32];
 
-    StaticKEM::encaps(&mut shared_secret, &mut ciphertext, input).unwrap();
+    // We expect errors while fuzzing therefore we do not check the result.
+    let _ = StaticKEM::encaps(&mut shared_secret, &mut ciphertext, input);
 });


### PR DESCRIPTION
When fuzzing we are interested in what happens inside the target function not necessarily what it returns. Functions returning errors with bogus input in generally desired behaviour.