### PR TITLE
Improve rosenpass gen-config

### DIFF
--- a/rosenpass/src/config.rs
+++ b/rosenpass/src/config.rs
@@ -345,7 +345,7 @@ impl Rosenpass {
     /// Generate an example configuration
     pub fn example_config() -> Self {
         let peer = RosenpassPeer {
-            public_key: "rp-peer-public-key".into(),
+            public_key: "/path/to/rp-peer-public-key".into(),
             endpoint: Some("my-peer.test:9999".into()),
             exchange_command: [
                 "currently",
@@ -355,7 +355,7 @@ impl Rosenpass {
             .into_iter()
             .map(|x| x.to_string())
             .collect(),
-            key_out: Some("rp-key-out".into()),
+            key_out: Some("/path/to/rp-key-out.txt".into()),
             pre_shared_key: None,
             wg: Some(WireGuard {
                 device: "wirgeguard device e.g. wg0".into(),
@@ -368,8 +368,8 @@ impl Rosenpass {
         };
 
         Self {
-            public_key: "rp-public-key".into(),
-            secret_key: "rp-secret-key".into(),
+            public_key: "/path/to/rp-public-key".into(),
+            secret_key: "/path/to/rp-secret-key".into(),
             peers: vec![peer],
             ..Self::new("", "")
         }

--- a/rosenpass/src/config.rs
+++ b/rosenpass/src/config.rs
@@ -361,7 +361,14 @@ impl Rosenpass {
             .collect(),
             key_out: Some("rp-key-out".into()),
             pre_shared_key: None,
-            wg: None,
+            wg: Some(WireGuard {
+                device: "wirgeguard device e.g. wg0".into(),
+                peer: "wireguard public key".into(),
+                extra_params: vec![
+                    "extra params".into(),
+                    "passed to".into(),
+                    "wg set".into()
+                ] }),
         };
 
         Self {

--- a/rosenpass/src/config.rs
+++ b/rosenpass/src/config.rs
@@ -348,13 +348,9 @@ impl Rosenpass {
             public_key: "rp-peer-public-key".into(),
             endpoint: Some("my-peer.test:9999".into()),
             exchange_command: [
-                "wg",
-                "set",
-                "wg0",
-                "peer",
-                "<PEER_ID>",
-                "preshared-key",
-                "/dev/stdin",
+                "currently",
+                "not",
+                "in use",
             ]
             .into_iter()
             .map(|x| x.to_string())


### PR DESCRIPTION
I find the current `rosenpass gen-config` functionality misleading and tried to improve upon it.

This PR summarizes 3 changes to config.rs 

1. I created an example for the integration with wireguard.
2. I indicated that `exchange_command` is currently not used in rosenpass.
3. I added indications to clarify what config options are file paths.