### PR TITLE
feat: Move dependencies into the workspace

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,11 +11,23 @@ members = [
     "fuzzing",
 ]
 
+default-members = [
+    "rosenpass"
+]
+
 [workspace.metadata.release]
 # ensure that adding `--package` as argument to `cargo release` still creates version tags in the form of `vx.y.z`
 tag-prefix = ""
 
 [workspace.dependencies]
+rosenpass = { path = "rosenpass" }
+rosenpass-util = { path = "util" }
+rosenpass-constant-time = { path = "constant-time" }
+rosenpass-sodium = { path = "sodium" }
+rosenpass-ciphers = { path = "ciphers" }
+rosenpass-to = { path = "to" }
+criterion = "0.4.0"
+test_bin = "0.4.0"
 libfuzzer-sys = "0.4"
 stacker = "0.1.15"
 doc-comment = "0.3.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,3 +14,25 @@ members = [
 [workspace.metadata.release]
 # ensure that adding `--package` as argument to `cargo release` still creates version tags in the form of `vx.y.z`
 tag-prefix = ""
+
+[workspace.dependencies]
+arbitrary = "1.3.2"
+libfuzzer-sys = "0.4"
+stacker = "0.1.15"
+doc-comment = "0.3.3"
+base64 = "0.21.1"
+zeroize = "1.7.0"
+memoffset = "0.9.0"
+lazy_static = "1.4.0"
+thiserror = "1.0.40"
+paste = "1.0.12"
+env_logger = "0.10.0"
+serde = "1.0.163"
+toml = "0.7.4"
+mio = "0.8.6"
+clap = "4.3.0"
+static_assertions = "1.1.0"
+log = { version = "0.4.17" }
+anyhow = { version = "1.0.71" }
+libsodium-sys-stable= { version = "1.19.28" }
+oqs-sys = {default-features = false, version = "0.8" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,6 @@ members = [
 tag-prefix = ""
 
 [workspace.dependencies]
-arbitrary = "1.3.2"
 libfuzzer-sys = "0.4"
 stacker = "0.1.15"
 doc-comment = "0.3.3"
@@ -27,12 +26,13 @@ lazy_static = "1.4.0"
 thiserror = "1.0.40"
 paste = "1.0.12"
 env_logger = "0.10.0"
-serde = "1.0.163"
 toml = "0.7.4"
-mio = "0.8.6"
-clap = "4.3.0"
 static_assertions = "1.1.0"
 log = { version = "0.4.17" }
-anyhow = { version = "1.0.71" }
-libsodium-sys-stable= { version = "1.19.28" }
-oqs-sys = {default-features = false, version = "0.8" }
+clap = { version = "4.3.0", features = ["derive"] }
+serde = { version = "1.0.163", features = ["derive"] }
+arbitrary = { version = "1.3.2", features = ["derive"] }
+anyhow = { version = "1.0.71", features = ["backtrace"] }
+mio = { version = "0.8.6", features = ["net", "os-poll"] }
+libsodium-sys-stable= { version = "1.19.28", features = ["use-pkg-config"] }
+oqs-sys = { version = "0.8", default-features = false, features = ['classic_mceliece', 'kyber']  }

--- a/ciphers/Cargo.toml
+++ b/ciphers/Cargo.toml
@@ -11,8 +11,8 @@ readme = "readme.md"
 
 [dependencies]
 anyhow = { workspace = true }
-rosenpass-sodium = { path = "../sodium" }
-rosenpass-to = { path = "../to" }
-rosenpass-constant-time = { path = "../constant-time" }
+rosenpass-sodium = { workspace = true }
+rosenpass-to = { workspace = true }
+rosenpass-constant-time = { workspace = true }
 static_assertions = { workspace = true }
 zeroize = { workspace = true }

--- a/ciphers/Cargo.toml
+++ b/ciphers/Cargo.toml
@@ -10,9 +10,9 @@ repository = "https://github.com/rosenpass/rosenpass"
 readme = "readme.md"
 
 [dependencies]
-anyhow = "1.0.75"
+anyhow = { workspace = true }
 rosenpass-sodium = { path = "../sodium" }
 rosenpass-to = { path = "../to" }
 rosenpass-constant-time = { path = "../constant-time" }
-static_assertions = "1.1.0"
-zeroize = "1.7.0"
+static_assertions = { workspace = true }
+zeroize = { workspace = true }

--- a/constant-time/Cargo.toml
+++ b/constant-time/Cargo.toml
@@ -12,4 +12,4 @@ readme = "readme.md"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-rosenpass-to = { path = "../to" }
+rosenpass-to = { workspace = true }

--- a/fuzzing/Cargo.toml
+++ b/fuzzing/Cargo.toml
@@ -8,9 +8,9 @@ edition = "2021"
 cargo-fuzz = true
 
 [dependencies]
-arbitrary = { version = "1.3.2", features = ["derive"]}
-libfuzzer-sys = "0.4"
-stacker = "0.1.15"
+arbitrary = { workspace = true, features = ["derive"]}
+libfuzzer-sys = { workspace = true }
+stacker = { workspace = true }
 
 [dependencies.rosenpass]
 path = "../rosenpass"

--- a/fuzzing/Cargo.toml
+++ b/fuzzing/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2021"
 cargo-fuzz = true
 
 [dependencies]
-arbitrary = { workspace = true, features = ["derive"]}
+arbitrary = { workspace = true }
 libfuzzer-sys = { workspace = true }
 stacker = { workspace = true }
 

--- a/fuzzing/Cargo.toml
+++ b/fuzzing/Cargo.toml
@@ -11,18 +11,10 @@ cargo-fuzz = true
 arbitrary = { workspace = true }
 libfuzzer-sys = { workspace = true }
 stacker = { workspace = true }
-
-[dependencies.rosenpass]
-path = "../rosenpass"
-
-[dependencies.rosenpass-sodium]
-path = "../sodium"
-
-[dependencies.rosenpass-ciphers]
-path = "../ciphers"
-
-[dependencies.rosenpass-to]
-path = "../to"
+rosenpass-sodium = { workspace = true }
+rosenpass-ciphers = { workspace = true }
+rosenpass-to = { workspace = true }
+rosenpass = { workspace = true }
 
 [[bin]]
 name = "fuzz_handle_msg"

--- a/rosenpass/Cargo.toml
+++ b/rosenpass/Cargo.toml
@@ -19,25 +19,25 @@ rosenpass-constant-time = { path = "../constant-time" }
 rosenpass-sodium = { path = "../sodium" }
 rosenpass-ciphers = { path = "../ciphers" }
 rosenpass-to = { path = "../to" }
-anyhow = { version = "1.0.71", features = ["backtrace"] }
-static_assertions = "1.1.0"
-memoffset = "0.9.0"
-libsodium-sys-stable = { version = "1.19.28", features = ["use-pkg-config"] }
-oqs-sys = { version = "0.8", default-features = false, features = ['classic_mceliece', 'kyber'] }
-lazy_static = "1.4.0"
-thiserror = "1.0.40"
-paste = "1.0.12"
-log = { version = "0.4.17" }
-env_logger = { version = "0.10.0" }
-serde = { version = "1.0.163", features = ["derive"] }
-toml = "0.7.4"
-clap = { version = "4.3.0", features = ["derive"] }
-mio = { version = "0.8.6", features = ["net", "os-poll"] }
+anyhow = { workspace = true, features = ["backtrace"] }
+static_assertions = { workspace = true }
+memoffset = { workspace = true }
+libsodium-sys-stable = { workspace = true, features = ["use-pkg-config"] }
+oqs-sys = { workspace = true, default-features = false, features = ['classic_mceliece', 'kyber'] }
+lazy_static = { workspace = true }
+thiserror = { workspace = true }
+paste = { workspace = true }
+log = { workspace = true }
+env_logger = { workspace = true }
+serde = { workspace = true, features = ["derive"] }
+toml = { workspace = true }
+clap = { workspace = true, features = ["derive"] }
+mio = { workspace = true, features = ["net", "os-poll"] }
 
 [build-dependencies]
-anyhow = "1.0.71"
+anyhow = { workspace = true }
 
 [dev-dependencies]
 criterion = "0.4.0"
 test_bin = "0.4.0"
-stacker = "0.1.15"
+stacker = { workspace = true }

--- a/rosenpass/Cargo.toml
+++ b/rosenpass/Cargo.toml
@@ -19,20 +19,20 @@ rosenpass-constant-time = { path = "../constant-time" }
 rosenpass-sodium = { path = "../sodium" }
 rosenpass-ciphers = { path = "../ciphers" }
 rosenpass-to = { path = "../to" }
-anyhow = { workspace = true, features = ["backtrace"] }
+anyhow = { workspace = true }
 static_assertions = { workspace = true }
 memoffset = { workspace = true }
-libsodium-sys-stable = { workspace = true, features = ["use-pkg-config"] }
-oqs-sys = { workspace = true, default-features = false, features = ['classic_mceliece', 'kyber'] }
+libsodium-sys-stable = { workspace = true }
+oqs-sys = { workspace = true }
 lazy_static = { workspace = true }
 thiserror = { workspace = true }
 paste = { workspace = true }
 log = { workspace = true }
 env_logger = { workspace = true }
-serde = { workspace = true, features = ["derive"] }
+serde = { workspace = true }
 toml = { workspace = true }
-clap = { workspace = true, features = ["derive"] }
-mio = { workspace = true, features = ["net", "os-poll"] }
+clap = { workspace = true }
+mio = { workspace = true }
 
 [build-dependencies]
 anyhow = { workspace = true }

--- a/rosenpass/Cargo.toml
+++ b/rosenpass/Cargo.toml
@@ -14,11 +14,11 @@ name = "handshake"
 harness = false
 
 [dependencies]
-rosenpass-util = { path = "../util" }
-rosenpass-constant-time = { path = "../constant-time" }
-rosenpass-sodium = { path = "../sodium" }
-rosenpass-ciphers = { path = "../ciphers" }
-rosenpass-to = { path = "../to" }
+rosenpass-util = { workspace = true }
+rosenpass-constant-time = { workspace = true }
+rosenpass-sodium = { workspace = true }
+rosenpass-ciphers = { workspace = true }
+rosenpass-to = { workspace = true }
 anyhow = { workspace = true }
 static_assertions = { workspace = true }
 memoffset = { workspace = true }
@@ -38,6 +38,6 @@ mio = { workspace = true }
 anyhow = { workspace = true }
 
 [dev-dependencies]
-criterion = "0.4.0"
-test_bin = "0.4.0"
+criterion = { workspace = true }
+test_bin = { workspace = true }
 stacker = { workspace = true }

--- a/sodium/Cargo.toml
+++ b/sodium/Cargo.toml
@@ -10,8 +10,8 @@ repository = "https://github.com/rosenpass/rosenpass"
 readme = "readme.md"
 
 [dependencies]
-rosenpass-util = { path = "../util" }
-rosenpass-to = { path = "../to" }
+rosenpass-util = { workspace = true }
+rosenpass-to = { workspace = true }
 anyhow = { workspace = true }
 libsodium-sys-stable = { workspace = true }
 log = { workspace = true }

--- a/sodium/Cargo.toml
+++ b/sodium/Cargo.toml
@@ -12,6 +12,6 @@ readme = "readme.md"
 [dependencies]
 rosenpass-util = { path = "../util" }
 rosenpass-to = { path = "../to" }
-anyhow = { workspace = true, features = ["backtrace"] }
-libsodium-sys-stable = { workspace = true, features = ["use-pkg-config"] }
+anyhow = { workspace = true }
+libsodium-sys-stable = { workspace = true }
 log = { workspace = true }

--- a/sodium/Cargo.toml
+++ b/sodium/Cargo.toml
@@ -12,6 +12,6 @@ readme = "readme.md"
 [dependencies]
 rosenpass-util = { path = "../util" }
 rosenpass-to = { path = "../to" }
-anyhow = { version = "1.0.71", features = ["backtrace"] }
-libsodium-sys-stable = { version = "1.19.28", features = ["use-pkg-config"] }
-log = { version = "0.4.17" }
+anyhow = { workspace = true, features = ["backtrace"] }
+libsodium-sys-stable = { workspace = true, features = ["use-pkg-config"] }
+log = { workspace = true }

--- a/to/Cargo.toml
+++ b/to/Cargo.toml
@@ -10,4 +10,4 @@ repository = "https://github.com/rosenpass/rosenpass"
 readme = "readme.md"
 
 [dev-dependencies]
-doc-comment = "0.3.3"
+doc-comment = { workspace = true }

--- a/util/Cargo.toml
+++ b/util/Cargo.toml
@@ -13,4 +13,4 @@ readme = "readme.md"
 
 [dependencies]
 base64 = { workspace = true }
-anyhow = { workspace = true, features = ["backtrace"] }
+anyhow = { workspace = true }

--- a/util/Cargo.toml
+++ b/util/Cargo.toml
@@ -12,5 +12,5 @@ readme = "readme.md"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-base64 = "0.21.1"
-anyhow = { version = "1.0.71", features = ["backtrace"] }
+base64 = { workspace = true }
+anyhow = { workspace = true, features = ["backtrace"] }


### PR DESCRIPTION
Move external dependencies to the workspace cargo.toml file
/claim #178 
fixes #178