### PR TITLE
Improve the safety of the secret storage mechanism

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -45,6 +45,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "allocator-api2"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0942ffc6dcaadf03badf6e6a2d0228460359d5e34b57ccdc720b7382dfbd5ec5"
+
+[[package]]
 name = "anes"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1133,6 +1139,7 @@ dependencies = [
 name = "rosenpass-sodium"
 version = "0.1.0"
 dependencies = [
+ "allocator-api2",
  "anyhow",
  "libsodium-sys-stable",
  "log",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,6 +42,7 @@ paste = "1.0.12"
 env_logger = "0.10.0"
 toml = "0.7.4"
 static_assertions = "1.1.0"
+allocator-api2 = "0.2.16"
 log = { version = "0.4.17" }
 clap = { version = "4.3.0", features = ["derive"] }
 serde = { version = "1.0.163", features = ["derive"] }

--- a/sodium/Cargo.toml
+++ b/sodium/Cargo.toml
@@ -15,3 +15,4 @@ rosenpass-to = { workspace = true }
 anyhow = { workspace = true }
 libsodium-sys-stable = { workspace = true }
 log = { workspace = true }
+allocator-api2 = { workspace = true }

--- a/sodium/src/alloc/allocator.rs
+++ b/sodium/src/alloc/allocator.rs
@@ -1,0 +1,95 @@
+use allocator_api2::alloc::{AllocError, Allocator, Layout};
+use libsodium_sys as libsodium;
+use std::fmt;
+use std::os::raw::c_void;
+use std::ptr::NonNull;
+
+#[derive(Clone, Default)]
+struct AllocatorContents;
+
+/// Memory allocation using sodium_malloc/sodium_free
+#[derive(Clone, Default)]
+pub struct Alloc {
+    _dummy_private_data: AllocatorContents,
+}
+
+impl Alloc {
+    pub fn new() -> Self {
+        Alloc {
+            _dummy_private_data: AllocatorContents,
+        }
+    }
+}
+
+unsafe impl Allocator for Alloc {
+    fn allocate(&self, layout: Layout) -> Result<NonNull<[u8]>, AllocError> {
+        // Call sodium allocator
+        let ptr = unsafe { libsodium::sodium_malloc(layout.size()) };
+
+        // Ensure the right allocation is used
+        let off = ptr.align_offset(layout.align());
+        if off != 0 {
+            log::error!("Allocation {layout:?} was requested but libsodium returned allocation \
+                with offset {off} from the requested alignment. Libsodium always allocates values \
+                at the end of a memory page for security reasons, custom alignments are not supported. \
+                You could try allocating an oversized value.");
+            return Err(AllocError);
+        }
+
+        // Convert to a pointer size
+        let ptr = core::ptr::slice_from_raw_parts_mut(ptr as *mut u8, layout.size());
+
+        // Conversion to a *const u8, then to a &[u8]
+        match NonNull::new(ptr) {
+            None => {
+                log::error!(
+                    "Allocation {layout:?} was requested but libsodium returned a null pointer"
+                );
+                Err(AllocError)
+            }
+            Some(ret) => Ok(ret),
+        }
+    }
+
+    unsafe fn deallocate(&self, ptr: NonNull<u8>, _layout: Layout) {
+        unsafe {
+            libsodium::sodium_free(ptr.as_ptr() as *mut c_void);
+        }
+    }
+}
+
+impl fmt::Debug for Alloc {
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        fmt.write_str("<libsodium based Rust allocator>")
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    /// checks that the can malloc with libsodium
+    #[test]
+    fn sodium_allocation() {
+        crate::init().unwrap();
+        let alloc = Alloc::new();
+        sodium_allocation_impl::<0>(&alloc);
+        sodium_allocation_impl::<7>(&alloc);
+        sodium_allocation_impl::<8>(&alloc);
+        sodium_allocation_impl::<64>(&alloc);
+        sodium_allocation_impl::<999>(&alloc);
+    }
+
+    fn sodium_allocation_impl<const N: usize>(alloc: &Alloc) {
+        crate::init().unwrap();
+        let layout = Layout::new::<[u8; N]>();
+        let mem = alloc.allocate(layout).unwrap();
+
+        // https://libsodium.gitbook.io/doc/memory_management#guarded-heap-allocations
+        // promises us that allocated memory is initialized with the magic byte 0xDB
+        assert_eq!(unsafe { mem.as_ref() }, &[0xDBu8; N]);
+
+        let mem = NonNull::new(mem.as_ptr() as *mut u8).unwrap();
+        unsafe { alloc.deallocate(mem, layout) };
+    }
+}

--- a/sodium/src/alloc/mod.rs
+++ b/sodium/src/alloc/mod.rs
@@ -1,0 +1,10 @@
+//! Access to sodium_malloc/sodium_free
+
+mod allocator;
+pub use allocator::Alloc;
+
+/// A box backed by sodium_malloc
+pub type Box<T> = allocator_api2::boxed::Box<T, Alloc>;
+
+/// A vector backed by sodium_malloc
+pub type Vec<T> = allocator_api2::vec::Vec<T, Alloc>;

--- a/sodium/src/lib.rs
+++ b/sodium/src/lib.rs
@@ -16,5 +16,6 @@ pub fn init() -> anyhow::Result<()> {
 }
 
 pub mod aead;
+pub mod alloc;
 pub mod hash;
 pub mod helpers;


### PR DESCRIPTION
This exposes the libsodium allocation API as an allocator and uses that together with allocator-api2's Box and Vec to implement the secret pool.

This brings the number of unsafe blocks needed to implement this down to two from six.