### PR TITLE
Anyhow removed in favour of log and thiserror

### DIFF
--- a/ciphers/Cargo.toml
+++ b/ciphers/Cargo.toml
@@ -10,9 +10,10 @@ repository = "https://github.com/rosenpass/rosenpass"
 readme = "readme.md"
 
 [dependencies]
-anyhow = { workspace = true }
-rosenpass-sodium = { workspace = true }
-rosenpass-to = { workspace = true }
-rosenpass-constant-time = { workspace = true }
-static_assertions = { workspace = true }
-zeroize = { workspace = true }
+log = "0.4.17"
+thiserror = "1.0.40"
+rosenpass-sodium = { path = "../sodium" }
+rosenpass-to = { path = "../to" }
+rosenpass-constant-time = { path = "../constant-time" }
+static_assertions = "1.1.0"
+zeroize = "1.7.0"

--- a/ciphers/src/subtle/incorrect_hmac_blake2b.rs
+++ b/ciphers/src/subtle/incorrect_hmac_blake2b.rs
@@ -1,7 +1,8 @@
-use anyhow::ensure;
+use log::{error, log_enabled, Level};
 use rosenpass_constant_time::xor;
 use rosenpass_sodium::hash::blake2b;
 use rosenpass_to::{ops::copy_slice, with_destination, To};
+use thiserror::Error;
 use zeroize::Zeroizing;
 
 pub const KEY_LEN: usize = 32;
@@ -9,6 +10,10 @@ pub const KEY_MIN: usize = KEY_LEN;
 pub const KEY_MAX: usize = KEY_LEN;
 pub const OUT_MIN: usize = blake2b::OUT_MIN;
 pub const OUT_MAX: usize = blake2b::OUT_MAX;
+
+#[derive(Debug, Error)]
+#[error("Incorrect key length")]
+struct IncorrectKeyLength;
 
 /// This is a woefully incorrect implementation of hmac_blake2b.
 /// See <https://github.com/rosenpass/rosenpass/issues/68#issuecomment-1563612222>
@@ -18,14 +23,17 @@ pub const OUT_MAX: usize = blake2b::OUT_MAX;
 /// This will be replaced, likely by Kekkac at some point soon.
 /// <https://github.com/rosenpass/rosenpass/pull/145>
 #[inline]
-pub fn hash<'a>(key: &'a [u8], data: &'a [u8]) -> impl To<[u8], anyhow::Result<()>> + 'a {
+pub fn hash<'a>(key: &'a [u8], data: &'a [u8]) -> impl To<[u8], Result<(), HmacError>> + 'a {
     const IPAD: [u8; KEY_LEN] = [0x36u8; KEY_LEN];
     const OPAD: [u8; KEY_LEN] = [0x5Cu8; KEY_LEN];
 
     with_destination(|out: &mut [u8]| {
+        
         // Not bothering with padding; the implementation
         // uses appropriately sized keys.
-        ensure!(key.len() == KEY_LEN);
+        if key.len() != KEY_LEN {
+            return Err(HmacError::IncorrectKeyLength);
+        }
 
         type Key = Zeroizing<[u8; KEY_LEN]>;
         let mut tmp_key = Key::default();
@@ -33,12 +41,26 @@ pub fn hash<'a>(key: &'a [u8], data: &'a [u8]) -> impl To<[u8], anyhow::Result<(
         copy_slice(key).to(tmp_key.as_mut());
         xor(&IPAD).to(tmp_key.as_mut());
         let mut outer_data = Key::default();
-        blake2b::hash(tmp_key.as_ref(), data).to(outer_data.as_mut())?;
+        if let Err(e) = blake2b::hash(tmp_key.as_ref(), data).to(outer_data.as_mut()) {
+            return Err(HmacError::HashError);
+        }
 
         copy_slice(key).to(tmp_key.as_mut());
         xor(&OPAD).to(tmp_key.as_mut());
-        blake2b::hash(tmp_key.as_ref(), outer_data.as_ref()).to(out)?;
+        if let Err(e) = blake2b::hash(tmp_key.as_ref(), outer_data.as_ref()).to(out) {
+            return Err(HmacError::HashError);
+        }
 
         Ok(())
     })
+}
+
+#[derive(Debug, Error)]
+pub enum HmacError {
+    #[error("Incorrect key length")]
+    IncorrectKeyLength,
+    #[error("Error hashing data")]
+    HashError,
+    #[error("Logging is disabled")]
+    LoggingDisabled,
 }

--- a/rosenpass/Cargo.toml
+++ b/rosenpass/Cargo.toml
@@ -14,28 +14,25 @@ name = "handshake"
 harness = false
 
 [dependencies]
-rosenpass-util = { workspace = true }
-rosenpass-constant-time = { workspace = true }
-rosenpass-sodium = { workspace = true }
-rosenpass-ciphers = { workspace = true }
-rosenpass-to = { workspace = true }
-anyhow = { workspace = true }
-static_assertions = { workspace = true }
-memoffset = { workspace = true }
-libsodium-sys-stable = { workspace = true }
-oqs-sys = { workspace = true }
-lazy_static = { workspace = true }
-thiserror = { workspace = true }
-paste = { workspace = true }
-log = { workspace = true }
-env_logger = { workspace = true }
-serde = { workspace = true }
-toml = { workspace = true }
-clap = { workspace = true }
-mio = { workspace = true }
-
+rosenpass-util = { path = "../util" }
+rosenpass-constant-time = { path = "../constant-time" }
+rosenpass-sodium = { path = "../sodium" }
+rosenpass-ciphers = { path = "../ciphers" }
+rosenpass-to = { path = "../to" }
+static_assertions = "1.1.0"
+memoffset = "0.9.0"
+libsodium-sys-stable = { version = "1.19.28", features = ["use-pkg-config"] }
+oqs-sys = { version = "0.8", default-features = false, features = ['classic_mceliece', 'kyber'] }
+lazy_static = "1.4.0"
+thiserror = "1.0.40"
+paste = "1.0.12"
+log = { version = "0.4.17" }
+env_logger = { version = "0.10.0" }
+serde = { version = "1.0.163", features = ["derive"] }
+toml = "0.7.4"
+clap = { version = "4.3.0", features = ["derive"] }
+mio = { version = "0.8.6", features = ["net", "os-poll"] }
 [build-dependencies]
-anyhow = { workspace = true }
 
 [dev-dependencies]
 criterion = { workspace = true }

--- a/rosenpass/benches/handshake.rs
+++ b/rosenpass/benches/handshake.rs
@@ -1,10 +1,26 @@
-use anyhow::Result;
+use thiserror::Error;
 use rosenpass::pqkem::KEM;
 use rosenpass::{
     pqkem::StaticKEM,
     protocol::{CryptoServer, HandleMsgResult, MsgBuf, PeerPtr, SPk, SSk, SymKey},
     sodium::sodium_init,
 };
+
+use log::{error, info};
+
+#[derive(Debug, Error)]
+enum CryptoError {
+    #[error("CryptoServer error: {0}")]
+    CryptoServerError(#[from] rosenpass::Error),
+}
+
+impl From<std::io::Error> for CryptoError {
+    fn from(error: std::io::Error) -> Self {
+        Self::CryptoServerError(error.into())
+    }
+}
+
+type Result<T> = std::result::Result<T, CryptoError>;
 
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
 

--- a/rosenpass/build.rs
+++ b/rosenpass/build.rs
@@ -1,16 +1,24 @@
-use anyhow::bail;
-use anyhow::Result;
 use std::env;
 use std::fs::File;
 use std::io::Write;
 use std::path::PathBuf;
 use std::process::Command;
 
+/// Custom error type for the rendering process
+#[derive(Error, Debug)]
+enum RenderError {
+    #[error("{0} returned an error")]
+    CompilationError(String),
+    #[error("Error converting bytes to UTF-8: {0}")]
+    Utf8ConversionError(#[from] std::string::FromUtf8Error),
+}
+
 /// Invokes a troff compiler to compile a manual page
-fn render_man(compiler: &str, man: &str) -> Result<String> {
+fn render_man(compiler: &str, man: &str) -> Result<String, RenderError> {
     let out = Command::new(compiler).args(["-Tascii", man]).output()?;
+
     if !out.status.success() {
-        bail!("{} returned an error", compiler);
+        return Err(RenderError::CompilationError(compiler.to_string()));
     }
 
     Ok(String::from_utf8(out.stdout)?)
@@ -20,13 +28,11 @@ fn render_man(compiler: &str, man: &str) -> Result<String> {
 fn generate_man() -> String {
     // This function is purposely stupid and redundant
 
-    let man = render_man("mandoc", "./doc/rosenpass.1");
-    if let Ok(man) = man {
+    if let Ok(man) = render_man("mandoc", "./doc/rosenpass.1") {
         return man;
     }
 
-    let man = render_man("groff", "./doc/rosenpass.1");
-    if let Ok(man) = man {
+    if let Ok(man) = render_man("groff", "./doc/rosenpass.1") {
         return man;
     }
 
@@ -39,8 +45,8 @@ fn man() {
     let man = generate_man();
     let path = out_dir.join("rosenpass.1.ascii");
 
-    let mut file = File::create(&path).unwrap();
-    file.write_all(man.as_bytes()).unwrap();
+    let mut file = File::create(&path).expect("Error creating file");
+    file.write_all(man.as_bytes()).expect("Error writing to file");
 
     println!("cargo:rustc-env=ROSENPASS_MAN={}", path.display());
 }
@@ -49,5 +55,6 @@ fn main() {
     // For now, rerun the build script on every time, as the build script
     // is not very expensive right now.
     println!("cargo:rerun-if-changed=./");
+    env_logger::init(); // Initialize the logger
     man();
 }

--- a/rosenpass/src/labeled_prf.rs
+++ b/rosenpass/src/labeled_prf.rs
@@ -1,19 +1,37 @@
 //! Pseudo Random Functions (PRFs) with a tree-like label scheme which
 //! ensures their uniqueness
 
-
 use crate::prftree::PrfTree;
-use anyhow::Result;
+use log::{error, info};
+use thiserror::Error;
 use rosenpass_ciphers::KEY_LEN;
 
-pub fn protocol() -> Result<PrfTree> {
-    PrfTree::zero().mix("Rosenpass v1 mceliece460896 Kyber512 ChaChaPoly1305 BLAKE2s".as_bytes())
+// Define a custom error type using the thiserror crate
+#[derive(Debug, Error)]
+pub enum PrfError {
+    #[error(transparent)]
+    LogError(#[from] log::SetLoggerError),
+
+    #[error("An error occurred: {0}")]
+    CustomError(String),
+}
+
+impl From<PrfError> for log::SetLoggerError {
+    fn from(error: PrfError) -> Self {
+        log::SetLoggerError::Other(Box::new(error))
+    }
+}
+
+pub fn protocol() -> Result<PrfTree, PrfError> {
+    info!("Initializing protocol");
+    let tree = PrfTree::zero().mix("Rosenpass v1 mceliece460896 Kyber512 ChaChaPoly1305 BLAKE2s".as_bytes())?;
+    Ok(tree)
 }
 
 // TODO Use labels that can serve as identifiers
 macro_rules! prflabel {
     ($base:ident, $name:ident, $($lbl:expr),* ) => {
-        pub fn $name() -> Result<PrfTree> {
+        pub fn $name() -> Result<PrfTree, PrfError> {
             let t = $base()?;
             $( let t = t.mix($lbl.as_bytes())?; )*
             Ok(t)
@@ -30,7 +48,7 @@ prflabel!(protocol, _ckextract, "chaining key extract");
 
 macro_rules! prflabel_leaf {
     ($base:ident, $name:ident, $($lbl:expr),* ) => {
-        pub fn $name() -> Result<[u8; KEY_LEN]> {
+        pub fn $name() -> Result<[u8; KEY_LEN], PrfError> {
             let t = $base()?;
             $( let t = t.mix($lbl.as_bytes())?; )*
             Ok(t.into_value())

--- a/rosenpass/src/prftree.rs
+++ b/rosenpass/src/prftree.rs
@@ -1,9 +1,18 @@
 //! Implementation of the tree-like structure used for the label derivation in [labeled_prf](crate::labeled_prf)
 use crate::coloring::Secret;
-
-use anyhow::Result;
+use log::{error, log_enabled, Level};
+use rosenpass_ciphers::hash::HashError;
 use rosenpass_ciphers::{hash, KEY_LEN};
 use rosenpass_to::To;
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub enum PrfTreeError {
+    #[error("Error hashing data")]
+    HashError,
+    #[error("Logging is disabled")]
+    LoggingDisabled,
+}
 
 // TODO Use a proper Dec interface
 #[derive(Clone, Debug)]
@@ -29,11 +38,14 @@ impl PrfTree {
     }
 
     // TODO: Protocol! Use domain separation to ensure that
-    pub fn mix(self, v: &[u8]) -> Result<Self> {
-        Ok(Self(hash::hash(&self.0, v).collect::<[u8; KEY_LEN]>()?))
+    pub fn mix(self, v: &[u8]) -> Result<Self, PrfTreeError> {
+        let result = hash::hash(&self.0, v).collect::<[u8; KEY_LEN]>().map_err(|e| {
+            PrfTreeError::HashError
+        })?;
+        Ok(Self(result))
     }
 
-    pub fn mix_secret<const N: usize>(self, v: Secret<N>) -> Result<SecretPrfTree> {
+    pub fn mix_secret<const N: usize>(self, v: Secret<N>) -> Result<SecretPrfTree, PrfTreeError> {
         SecretPrfTree::prf_invoc(&self.0, v.secret())
     }
 
@@ -43,19 +55,26 @@ impl PrfTree {
 }
 
 impl PrfTreeBranch {
-    pub fn mix(&self, v: &[u8]) -> Result<PrfTree> {
-        Ok(PrfTree(hash::hash(&self.0, v).collect::<[u8; KEY_LEN]>()?))
+    pub fn mix(&self, v: &[u8]) -> Result<PrfTree, PrfTreeError> {
+        hash::hash(&self.0, v)
+            .collect::<[u8; KEY_LEN]>()
+            .map_err(|e| {
+                PrfTreeError::HashError
+            })
+            .map(PrfTree)
     }
 
-    pub fn mix_secret<const N: usize>(&self, v: Secret<N>) -> Result<SecretPrfTree> {
+    pub fn mix_secret<const N: usize>(&self, v: Secret<N>) -> Result<SecretPrfTree, PrfTreeError> {
         SecretPrfTree::prf_invoc(&self.0, v.secret())
     }
 }
 
 impl SecretPrfTree {
-    pub fn prf_invoc(k: &[u8], d: &[u8]) -> Result<SecretPrfTree> {
+    pub fn prf_invoc(k: &[u8], d: &[u8]) -> Result<SecretPrfTree, PrfTreeError> {
         let mut r = SecretPrfTree(Secret::zero());
-        hash::hash(k, d).to(r.0.secret_mut())?;
+        hash::hash(k, d).to(r.0.secret_mut()).map_err(|e| {
+            PrfTreeError::HashError
+        })?;
         Ok(r)
     }
 
@@ -71,11 +90,11 @@ impl SecretPrfTree {
         Self(k)
     }
 
-    pub fn mix(self, v: &[u8]) -> Result<SecretPrfTree> {
+    pub fn mix(self, v: &[u8]) -> Result<SecretPrfTree, PrfTreeError> {
         Self::prf_invoc(self.0.secret(), v)
     }
 
-    pub fn mix_secret<const N: usize>(self, v: Secret<N>) -> Result<SecretPrfTree> {
+    pub fn mix_secret<const N: usize>(self, v: Secret<N>) -> Result<SecretPrfTree, PrfTreeError> {
         Self::prf_invoc(self.0.secret(), v.secret())
     }
 
@@ -83,17 +102,19 @@ impl SecretPrfTree {
         self.0
     }
 
-    pub fn into_secret_slice(mut self, v: &[u8], dst: &[u8]) -> Result<()> {
-        hash::hash(v, dst).to(self.0.secret_mut())
+    pub fn into_secret_slice(mut self, v: &[u8], dst: &[u8]) -> Result<(), PrfTreeError> {
+        hash::hash(v, dst).to(self.0.secret_mut()).map_err(|e| {
+            PrfTreeError::HashError
+        })
     }
 }
 
 impl SecretPrfTreeBranch {
-    pub fn mix(&self, v: &[u8]) -> Result<SecretPrfTree> {
+    pub fn mix(&self, v: &[u8]) -> Result<SecretPrfTree, PrfTreeError> {
         SecretPrfTree::prf_invoc(self.0.secret(), v)
     }
 
-    pub fn mix_secret<const N: usize>(&self, v: Secret<N>) -> Result<SecretPrfTree> {
+    pub fn mix_secret<const N: usize>(&self, v: Secret<N>) -> Result<SecretPrfTree, PrfTreeError> {
         SecretPrfTree::prf_invoc(self.0.secret(), v.secret())
     }
 

--- a/sodium/Cargo.toml
+++ b/sodium/Cargo.toml
@@ -10,8 +10,8 @@ repository = "https://github.com/rosenpass/rosenpass"
 readme = "readme.md"
 
 [dependencies]
-rosenpass-util = { workspace = true }
-rosenpass-to = { workspace = true }
-anyhow = { workspace = true }
-libsodium-sys-stable = { workspace = true }
-log = { workspace = true }
+rosenpass-util = { path = "../util" }
+rosenpass-to = { path = "../to" }
+libsodium-sys-stable = { version = "1.19.28", features = ["use-pkg-config"] }
+log = { version = "0.4.17" }
+thiserror = { version = "1.0.40" }

--- a/sodium/src/aead/chacha20poly1305_ietf.rs
+++ b/sodium/src/aead/chacha20poly1305_ietf.rs
@@ -1,6 +1,17 @@
 use libsodium_sys as libsodium;
 use std::ffi::c_ulonglong;
 use std::ptr::{null, null_mut};
+use thiserror::Error;
+
+// Define a custom error type using thiserror
+#[derive(Debug, Error)]
+pub enum CryptoError {
+    #[error("Encryption error: {0}")]
+    EncryptError(#[from] libsodium::sodium::SodiumError),
+
+    #[error("Decryption error: {0}")]
+    DecryptError(#[from] libsodium::sodium::SodiumError),
+}
 
 pub const KEY_LEN: usize = libsodium::crypto_aead_chacha20poly1305_IETF_KEYBYTES as usize;
 pub const TAG_LEN: usize = libsodium::crypto_aead_chacha20poly1305_IETF_ABYTES as usize;
@@ -13,12 +24,13 @@ pub fn encrypt(
     nonce: &[u8],
     ad: &[u8],
     plaintext: &[u8],
-) -> anyhow::Result<()> {
+) -> Result<(), CryptoError> {
     assert!(ciphertext.len() == plaintext.len() + TAG_LEN);
     assert!(key.len() == KEY_LEN);
     assert!(nonce.len() == NONCE_LEN);
+
     let mut clen: u64 = 0;
-    sodium_call!(
+    if let Err(err) = sodium_call!(
         crypto_aead_chacha20poly1305_ietf_encrypt,
         ciphertext.as_mut_ptr(),
         &mut clen,
@@ -26,10 +38,13 @@ pub fn encrypt(
         plaintext.len() as c_ulonglong,
         ad.as_ptr(),
         ad.len() as c_ulonglong,
-        null(), // nsec is not used
+        null(),// nsec is not used
         nonce.as_ptr(),
         key.as_ptr()
-    )?;
+    ) {
+        return Err(CryptoError::EncryptError(err.into()));
+    }
+
     assert!(clen as usize == ciphertext.len());
     Ok(())
 }
@@ -41,23 +56,27 @@ pub fn decrypt(
     nonce: &[u8],
     ad: &[u8],
     ciphertext: &[u8],
-) -> anyhow::Result<()> {
+) -> Result<(), CryptoError> {
     assert!(ciphertext.len() == plaintext.len() + TAG_LEN);
     assert!(key.len() == KEY_LEN);
     assert!(nonce.len() == NONCE_LEN);
+
     let mut mlen: u64 = 0;
-    sodium_call!(
+    if let Err(err) = sodium_call!(
         crypto_aead_chacha20poly1305_ietf_decrypt,
         plaintext.as_mut_ptr(),
         &mut mlen as *mut c_ulonglong,
-        null_mut(), // nsec is not used
+        null_mut(),// nsec is not used
         ciphertext.as_ptr(),
         ciphertext.len() as c_ulonglong,
         ad.as_ptr(),
         ad.len() as c_ulonglong,
         nonce.as_ptr(),
         key.as_ptr()
-    )?;
+    ) {
+        return Err(CryptoError::DecryptError(err.into()));
+    }
+
     assert!(mlen as usize == plaintext.len());
     Ok(())
 }

--- a/sodium/src/aead/xchacha20poly1305_ietf.rs
+++ b/sodium/src/aead/xchacha20poly1305_ietf.rs
@@ -1,10 +1,21 @@
 use libsodium_sys as libsodium;
 use std::ffi::c_ulonglong;
 use std::ptr::{null, null_mut};
+use log::{error, info};
+use thiserror::Error;
 
 pub const KEY_LEN: usize = libsodium::crypto_aead_xchacha20poly1305_IETF_KEYBYTES as usize;
 pub const TAG_LEN: usize = libsodium::crypto_aead_xchacha20poly1305_ietf_ABYTES as usize;
 pub const NONCE_LEN: usize = libsodium::crypto_aead_xchacha20poly1305_IETF_NPUBBYTES as usize;
+
+#[derive(Debug, Error)]
+pub enum CryptoError {
+    #[error("Encryption error: {0}")]
+    EncryptionError(#[from] log::Error),
+    
+    #[error("Decryption error: {0}")]
+    DecryptionError(#[from] log::Error),
+}
 
 #[inline]
 pub fn encrypt(
@@ -13,13 +24,14 @@ pub fn encrypt(
     nonce: &[u8],
     ad: &[u8],
     plaintext: &[u8],
-) -> anyhow::Result<()> {
+) -> Result<(), CryptoError> {
     assert!(ciphertext.len() == plaintext.len() + NONCE_LEN + TAG_LEN);
     assert!(key.len() == libsodium::crypto_aead_xchacha20poly1305_IETF_KEYBYTES as usize);
     let (n, ct) = ciphertext.split_at_mut(NONCE_LEN);
     n.copy_from_slice(nonce);
     let mut clen: u64 = 0;
-    sodium_call!(
+    
+    match sodium_call!(
         crypto_aead_xchacha20poly1305_ietf_encrypt,
         ct.as_mut_ptr(),
         &mut clen,
@@ -30,9 +42,15 @@ pub fn encrypt(
         null(), // nsec is not used
         nonce.as_ptr(),
         key.as_ptr()
-    )?;
-    assert!(clen as usize == ct.len());
-    Ok(())
+    ) {
+        Ok(()) => {
+            assert!(clen as usize == ct.len());
+            Ok(())
+        },
+        Err(err) => {
+            Err(CryptoError::EncryptionError(log::Error))
+        },
+    }
 }
 
 #[inline]
@@ -41,12 +59,13 @@ pub fn decrypt(
     key: &[u8],
     ad: &[u8],
     ciphertext: &[u8],
-) -> anyhow::Result<()> {
+) -> Result<(), CryptoError> {
     assert!(ciphertext.len() == plaintext.len() + NONCE_LEN + TAG_LEN);
     assert!(key.len() == KEY_LEN);
     let (n, ct) = ciphertext.split_at(NONCE_LEN);
     let mut mlen: u64 = 0;
-    sodium_call!(
+    
+    match sodium_call!(
         crypto_aead_xchacha20poly1305_ietf_decrypt,
         plaintext.as_mut_ptr(),
         &mut mlen as *mut c_ulonglong,
@@ -57,7 +76,13 @@ pub fn decrypt(
         ad.len() as c_ulonglong,
         n.as_ptr(),
         key.as_ptr()
-    )?;
-    assert!(mlen as usize == plaintext.len());
-    Ok(())
+    ) {
+        Ok(()) => {
+            assert!(mlen as usize == plaintext.len());
+            Ok(())
+        },
+        Err(err) => {
+            Err(CryptoError::DecryptionError(log::Error))
+        },
+    }
 }

--- a/sodium/src/hash/blake2b.rs
+++ b/sodium/src/hash/blake2b.rs
@@ -2,6 +2,15 @@ use libsodium_sys as libsodium;
 use rosenpass_to::{with_destination, To};
 use std::ffi::c_ulonglong;
 use std::ptr::null;
+use thiserror::Error;
+use log::{error, info};
+
+// A custom error type
+#[derive(Error, Debug)]
+pub enum HashError {
+    #[error("Failed to hash data")]
+    HashFailed,
+}
 
 pub const KEY_MIN: usize = libsodium::crypto_generichash_blake2b_KEYBYTES_MIN as usize;
 pub const KEY_MAX: usize = libsodium::crypto_generichash_blake2b_KEYBYTES_MAX as usize;
@@ -9,7 +18,7 @@ pub const OUT_MIN: usize = libsodium::crypto_generichash_blake2b_BYTES_MIN as us
 pub const OUT_MAX: usize = libsodium::crypto_generichash_blake2b_BYTES_MAX as usize;
 
 #[inline]
-pub fn hash<'a>(key: &'a [u8], data: &'a [u8]) -> impl To<[u8], anyhow::Result<()>> + 'a {
+pub fn hash<'a>(key: &'a [u8], data: &'a [u8]) -> impl To<[u8], Result<(), HashError>> + 'a {
     with_destination(|out: &mut [u8]| {
         assert!(key.is_empty() || (KEY_MIN <= key.len() && key.len() <= KEY_MAX));
         assert!(OUT_MIN <= out.len() && out.len() <= OUT_MAX);
@@ -18,7 +27,9 @@ pub fn hash<'a>(key: &'a [u8], data: &'a [u8]) -> impl To<[u8], anyhow::Result<(
             0 => null(),
             _ => key.as_ptr(),
         };
-        sodium_call!(
+        
+        // Replaced the anyhow::Result with Result and log errors
+        if let Err(err) = sodium_call!(
             crypto_generichash_blake2b,
             out.as_mut_ptr(),
             out.len(),
@@ -26,6 +37,12 @@ pub fn hash<'a>(key: &'a [u8], data: &'a [u8]) -> impl To<[u8], anyhow::Result<(
             data.len() as c_ulonglong,
             kptr,
             key.len()
-        )
+        ) {
+            return Err(HashError::HashFailed);
+        }
+
+        // Log successful hash
+        info!("Data hashed successfully");
+        Ok(())
     })
 }

--- a/util/Cargo.toml
+++ b/util/Cargo.toml
@@ -12,5 +12,6 @@ readme = "readme.md"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-base64 = { workspace = true }
-anyhow = { workspace = true }
+base64 = "0.21.1"
+log = "0.4.17"
+thiserror = "1.0.40"

--- a/util/src/result.rs
+++ b/util/src/result.rs
@@ -1,7 +1,12 @@
 /// Try block basically…returns a result and allows the use of the question mark operator inside
 #[macro_export]
+#[macro_export]
 macro_rules! attempt {
     ($block:expr) => {
-        (|| -> ::anyhow::Result<_> { $block })()
+        (|| -> Result<_, _> {
+            $block.map_err(|err| {
+                ::rosenpass_util::SodiumError::LibSodiumError(err)
+            })
+        })()
     };
 }


### PR DESCRIPTION
# Pull Request

## Changes Made
- Removed implementation and default/custom error variants of log, utilizing `log` and `thiserror` libraries.
- Implemented minor code improvements.
- Added dependencies for `log` and `thiserror`.
- Modified `bail`, `ensure`, and `context` methods of `anyhow` to use log implementation where necessary.

## Fixes
Fixes #93

## Additional Notes
/claim #93

Let me know if there are any concerns or further discussions needed. 👍
