### PR TITLE
fix output of authorlist to support unlimited authors

### DIFF
--- a/papers/tex/template-rosenpass.tex
+++ b/papers/tex/template-rosenpass.tex
@@ -177,7 +177,11 @@ version={4.0},
 		\titlehead{\centerline{\includegraphics[width=4cm]{RosenPass-Logo}}}
 		\title{\inserttitle}
 	}
-	\author{\csname insertauthor\endcsname}
+	\ifx\csname insertauthor\endcsname\relax
+	\author{}
+	\else
+	\author{\parbox{\linewidth}{\centering\insertauthor}}
+	\fi
 	\subject{\csname insertsubject\endcsname}
 	\date{\vspace{-1cm}}
 }


### PR DESCRIPTION
just a small adjustment in the rosenpass LaTeX template – as requested