### PR TITLE
fix: remove OSFONTDIR var from whitepaper build

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -291,7 +291,6 @@
               ];
               buildPhase = ''
                 export HOME=$(mktemp -d)
-                export OSFONTDIR="$(kpsewhich --var-value TEXMF)/fonts/{opentype/public/nunito,truetype/google/noto}"
                 latexmk -r tex/CI.rc
               '';
               installPhase = ''


### PR DESCRIPTION
Fixes #65. I checked with `pdffonts` that the whitepaper still has all fonts embedded.