### PR TITLE
Add backwards compatibility for keygen command

### DIFF
--- a/rosenpass/src/main.rs
+++ b/rosenpass/src/main.rs
@@ -5,7 +5,8 @@ use std::process::exit;
 
 /// Catches errors, prints them through the logger, then exits
 pub fn main() {
-    env_logger::init();
+    // default to displaying warning and error log messages only
+    env_logger::Builder::from_env(env_logger::Env::default().default_filter_or("warn")).init();
 
     let res = attempt!({
         rosenpass_sodium::init()?;


### PR DESCRIPTION
## Changes Made
Added deprecated keygen command, based on old usage.
```
rosenpass keygen \
  private-key mykey/pqsk \
  public-key mykey/pqpk
```
And old code:
```
-/// Generate a keypair
-pub fn cmd_keygen(mut args: ArgsWalker) -> Result<()> {
-    let mut sf: Option<String> = None;
-    let mut pf: Option<String> = None;
-
-    // Arg parsing
-    loop {
-        match args.next() {
-            Some("private-key") => args.opt(&mut sf)?,
-            Some("public-key") => args.opt(&mut pf)?,
-            Some(opt) => bail_usage!(&args, "Unknown option `{}`", opt),
-            None => break,
-        };
-    }
-
-    mandatory_opt!(&args, sf, "private-key");
-    mandatory_opt!(&args, pf, "private-key");
-
-    // Cmd
-    let (mut ssk, mut spk) = (SSk::random(), SPk::random());
-    unsafe {
-        StaticKEM::keygen(ssk.secret_mut(), spk.secret_mut())?;
-        ssk.store_secret(sf.unwrap())?;
-        spk.store_secret(pf.unwrap())?;
-    }
-
-    Ok(())
-}
```
Is this solution acceptable?
/claim #73