### PR TITLE
Fixed grammatical typo in 'cli.rs'. To resolve issue #236.

### DIFF
--- a/rosenpass/src/cli.rs
+++ b/rosenpass/src/cli.rs
@@ -240,7 +240,7 @@ impl Cli {
                         Ok(config) => {
                             eprintln!("{file:?} is valid TOML and conforms to the expected schema");
                             match config.validate() {
-                                Ok(_) => eprintln!("{file:?} is passed all logical checks"),
+                                Ok(_) => eprintln!("{file:?} has passed all logical checks"),
                                 Err(_) => eprintln!("{file:?} contains logical errors"),
                             }
                         }


### PR DESCRIPTION
Happy for the chance to do a quick grammar pr. Feedback welcome.