### PR TITLE
resolve #92: add CLI argument to specify log level filter

### DIFF
--- a/rosenpass/src/main.rs
+++ b/rosenpass/src/main.rs
@@ -1,13 +1,31 @@
+use clap::Parser;
 use log::error;
-use rosenpass::cli::Cli;
+use rosenpass::cli::CliArgs;
 use std::process::exit;
 
 /// Catches errors, prints them through the logger, then exits
 pub fn main() {
-    // default to displaying warning and error log messages only
-    env_logger::Builder::from_env(env_logger::Env::default().default_filter_or("warn")).init();
+    // parse CLI arguments
+    let args = CliArgs::parse();
 
-    match Cli::run() {
+    // init logging
+    {
+        let mut log_builder = env_logger::Builder::from_default_env(); // sets log level filter from environment (or defaults)
+        if let Some(level) = args.get_log_level() {
+            log_builder.filter_level(level); // set log level filter from CLI args if available
+        }
+        log_builder.init();
+
+        // // check the effectiveness of the log level filter with the following lines:
+        // use log::{debug, error, info, trace, warn};
+        // trace!("trace dummy");
+        // debug!("debug dummy");
+        // info!("info dummy");
+        // warn!("warn dummy");
+        // error!("error dummy");
+    }
+
+    match args.command.run() {
         Ok(_) => {}
         Err(e) => {
             error!("{e}");

--- a/rosenpass/src/main.rs
+++ b/rosenpass/src/main.rs
@@ -12,6 +12,7 @@ pub fn main() {
     {
         let mut log_builder = env_logger::Builder::from_default_env(); // sets log level filter from environment (or defaults)
         if let Some(level) = args.get_log_level() {
+            log::debug!("setting log level to {:?} (set via CLI parameter)", level);
             log_builder.filter_level(level); // set log level filter from CLI args if available
         }
         log_builder.init();


### PR DESCRIPTION
implements CLI arguments `--verbose`, `--quiet` and `--log-level LEVEL` as required by #92 

/claim #92 

arguments are mutually exclusive:
```text
cargo run --release -- -q -v keygen
[...]
    Finished `release` profile [optimized] target(s) in 0.11s
     Running `/home/user/rosenpass/target/release/rosenpass -q -v keygen`
error: the argument '--quiet' cannot be used with '--verbose'

Usage: rosenpass --quiet <COMMAND>

For more information, try '--help'.
```

Any of by Rust's [`log::LevelFilter`](https://docs.rs/log/latest/log/enum.LevelFilter.html) are supported in lowercase and uppercase.

If no log level filter is specified via the CLI, the program will behave like it did prior to this PR: it will use the `env_logger` crate to read the level from the environment or default. I did exactly #92 and did not temper with default log levels.

Note: I did not dare to touch the `rp` shell script... If frightened me after I found #245...