### PR TITLE
config: drop deprecated std::env::home_dir()

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -678,11 +678,11 @@ checksum = "d77f7ec81a6d05a3abb01ab6eb7590f6083d08449fe5a1c8b1e620283546ccb7"
 
 [[package]]
 name = "home"
-version = "0.5.5"
+version = "0.5.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5444c27eef6923071f7ebcc33e3444508466a76f7a2b93da00ed6e19f30c1ddb"
+checksum = "e3d1354bf6b7235cb4a0576c2619fd4ed18183f689b12b006a0ee7329eeff9a5"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1123,6 +1123,7 @@ dependencies = [
  "clap 4.4.10",
  "criterion",
  "env_logger",
+ "home",
  "log",
  "memoffset",
  "mio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,3 +58,4 @@ oqs-sys = { version = "0.8", default-features = false, features = ['classic_mcel
 blake2 = "0.10.6"
 chacha20poly1305 = { version = "0.10.1", default-features = false, features = [ "std", "heapless" ] }
 zerocopy = { version = "0.7.32", features = ["derive"] }
+home = "0.5.9"

--- a/rosenpass/Cargo.toml
+++ b/rosenpass/Cargo.toml
@@ -33,6 +33,7 @@ clap = { workspace = true }
 mio = { workspace = true }
 rand = { workspace = true }
 zerocopy = { workspace = true }
+home = { workspace = true }
 
 [build-dependencies]
 anyhow = { workspace = true }

--- a/rosenpass/src/config.rs
+++ b/rosenpass/src/config.rs
@@ -537,7 +537,7 @@ pub mod util {
     pub fn resolve_path_with_tilde(path: &mut PathBuf) {
         if let Some(first_segment) = path.iter().next() {
             if !path.has_root() && first_segment == "~" {
-                let home_dir = std::env::home_dir().unwrap_or_else(|| {
+                let home_dir = home::home_dir().unwrap_or_else(|| {
                     log::error!("config file contains \"~\" but can not determine home diretory");
                     std::process::exit(1);
                 });


### PR DESCRIPTION
Instead use the `home` create.