### PR TITLE
update to liboqs 0.9.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -173,11 +173,11 @@ checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
 
 [[package]]
 name = "bindgen"
-version = "0.65.1"
+version = "0.68.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfdf7b466f9a4903edc73f95d6d2bcd5baf8ae620638762244d3f60143643cc5"
+checksum = "726e4313eb6ec35d2730258ad4e15b547ee75d6afaa1361a922e78e59b7d8078"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags 2.4.1",
  "cexpr",
  "clang-sys",
  "lazy_static",
@@ -926,14 +926,15 @@ checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
 name = "oqs-sys"
-version = "0.8.0"
+version = "0.9.1+liboqs-0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fa114149fb6e5362b9cf539de9305a6a3cf1556fbfa93b5053b4f70cf3adfb9"
+checksum = "afa79adc3c10f8e01d0b134c159254e5843ec3f91c0bd868e57777beb3329e17"
 dependencies = [
  "bindgen",
  "build-deps",
  "cmake",
  "libc",
+ "pkg-config",
 ]
 
 [[package]]
@@ -953,6 +954,12 @@ name = "peeking_take_while"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
+
+[[package]]
+name = "pkg-config"
+version = "0.3.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d231b230927b5e4ad203db57bbcbee2802f6bce620b1e4a9024a07d94e2907ec"
 
 [[package]]
 name = "plotters"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,7 +54,7 @@ serde = { version = "1.0.197", features = ["derive"] }
 arbitrary = { version = "1.3.2", features = ["derive"] }
 anyhow = { version = "1.0.81", features = ["backtrace", "std"] }
 mio = { version = "0.8.11", features = ["net", "os-poll"] }
-oqs-sys = { version = "0.8", default-features = false, features = ['classic_mceliece', 'kyber']  }
+oqs-sys = { version = "0.9.1", default-features = false, features = ['classic_mceliece', 'kyber']  }
 blake2 = "0.10.6"
 chacha20poly1305 = { version = "0.10.1", default-features = false, features = [ "std", "heapless" ] }
 zerocopy = { version = "0.7.32", features = ["derive"] }


### PR DESCRIPTION
The release updated the Classic McEliece implemented and since we use it, might be a good idea to update the lib.