### PR TITLE
Change base64 to base64ct crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1813,9 +1813,9 @@ dependencies = [
 
 [[package]]
 name = "serial_test"
-version = "3.1.0"
+version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adb86f9315df5df6a70eae0cc22395a44e544a0d8897586820770a35ede74449"
+checksum = "4b4b487fe2acf240a021cf57c6b2b4903b1e78ca0ecd862a71b71d2a51fed77d"
 dependencies = [
  "futures",
  "log",
@@ -1827,9 +1827,9 @@ dependencies = [
 
 [[package]]
 name = "serial_test_derive"
-version = "3.1.0"
+version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9bb72430492e9549b0c4596725c0f82729bff861c45aa8099c0a8e67fc3b721"
+checksum = "82fe9db325bcef1fbcde82e078a5cc4efdf787e96b3b9cf45b50b529f2083d67"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -30,9 +30,9 @@ dependencies = [
 
 [[package]]
 name = "aho-corasick"
-version = "1.1.2"
+version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2969dcb958b36655471fc61f7e416fa76033bdd4bfed0678d8fee1e2d07a1f0"
+checksum = "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916"
 dependencies = [
  "memchr",
 ]
@@ -74,36 +74,36 @@ dependencies = [
 
 [[package]]
 name = "anstyle"
-version = "1.0.4"
+version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7079075b41f533b8c61d2a4d073c4676e1f8b249ff94a393b0595db304e0dd87"
+checksum = "8901269c6307e8d93993578286ac0edf7f195079ffff5ebdeea6a59ffb7e36bc"
 
 [[package]]
 name = "anstyle-parse"
-version = "0.2.2"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "317b9a89c1868f5ea6ff1d9539a69f45dffc21ce321ac1fd1160dfa48c8e2140"
+checksum = "c75ac65da39e5fe5ab759307499ddad880d724eed2f6ce5b5e8a26f4f387928c"
 dependencies = [
  "utf8parse",
 ]
 
 [[package]]
 name = "anstyle-query"
-version = "1.0.0"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ca11d4be1bab0c8bc8734a9aa7bf4ee8316d462a08c6ac5052f888fef5b494b"
+checksum = "e28923312444cdd728e4738b3f9c9cac739500909bb3d3c94b43551b16517648"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
 name = "anstyle-wincon"
-version = "3.0.1"
+version = "3.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0699d10d2f4d628a98ee7b57b289abbc98ff3bad977cb3152709d4bf2330628"
+checksum = "1cd54b81ec8d6180e24654d0b371ad22fc3dd083b6ff8ba325b72e00c87660a7"
 dependencies = [
  "anstyle",
- "windows-sys 0.48.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -146,15 +146,15 @@ dependencies = [
 
 [[package]]
 name = "autocfg"
-version = "1.1.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
+checksum = "f1fdabc7756949593fe60f30ec81974b613357de856987752631dea1e3394c80"
 
 [[package]]
 name = "backtrace"
-version = "0.3.69"
+version = "0.3.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2089b7e3f35b9dd2d0ed921ead4f6d318c27680d4a5bd167b3ee120edb105837"
+checksum = "26b05800d2e817c8b3b4b54abd461726265fa9789ae34330622f2db9ee696f9d"
 dependencies = [
  "addr2line",
  "cc",
@@ -173,11 +173,11 @@ checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
 
 [[package]]
 name = "bindgen"
-version = "0.65.1"
+version = "0.68.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfdf7b466f9a4903edc73f95d6d2bcd5baf8ae620638762244d3f60143643cc5"
+checksum = "726e4313eb6ec35d2730258ad4e15b547ee75d6afaa1361a922e78e59b7d8078"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags 2.5.0",
  "cexpr",
  "clang-sys",
  "lazy_static",
@@ -202,9 +202,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.4.1"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "327762f6e5a765692301e5bb513e0d9fef63be86bbc14528052b1cd3e6f03e07"
+checksum = "cf4b9d6a944f767f8e5e0db018570623c85f3d925ac718db4e06d0187adb21c1"
 
 [[package]]
 name = "blake2"
@@ -235,9 +235,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.14.0"
+version = "3.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f30e7476521f6f8af1a1c4c0b8cc94f0bee37d91763d0ca2665f299b6cd8aec"
+checksum = "79296716171880943b8470b5f8d03aa55eb2e645a4874bdbb28adb49162e012c"
 
 [[package]]
 name = "byteorder"
@@ -259,12 +259,13 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.0.83"
+version = "1.0.96"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1174fb0b6ec23863f8b971027804a42614e347eafb0a95bf0b12cdae21fc4d0"
+checksum = "065a29261d53ba54260972629f9ca6bffa69bac13cd1fed61420f7fa68b9f8bd"
 dependencies = [
  "jobserver",
  "libc",
+ "once_cell",
 ]
 
 [[package]]
@@ -308,9 +309,9 @@ dependencies = [
 
 [[package]]
 name = "ciborium"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "effd91f6c78e5a4ace8a5d3c0b6bfaec9e2baaef55f3efc00e45fb2e477ee926"
+checksum = "42e69ffd6f0917f5c029256a24d0161db17cea3997d185db0d35926308770f0e"
 dependencies = [
  "ciborium-io",
  "ciborium-ll",
@@ -319,15 +320,15 @@ dependencies = [
 
 [[package]]
 name = "ciborium-io"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdf919175532b369853f5d5e20b26b43112613fd6fe7aee757e35f7a44642656"
+checksum = "05afea1e0a06c9be33d539b876f1ce3692f4afea2cb41f740e7743225ed1c757"
 
 [[package]]
 name = "ciborium-ll"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "defaa24ecc093c77630e6c15e17c51f5e187bf35ee514f4e2d67baaa96dae22b"
+checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
 dependencies = [
  "ciborium-io",
  "half",
@@ -346,9 +347,9 @@ dependencies = [
 
 [[package]]
 name = "clang-sys"
-version = "1.6.1"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c688fc74432808e3eb684cae8830a86be1d66a2bd58e1f248ed0960a590baf6f"
+checksum = "67523a3b4be3ce1989d607a828d036249522dd9c1c8de7f4dd2dae43a37369d1"
 dependencies = [
  "glob",
  "libc",
@@ -484,26 +485,21 @@ checksum = "7059fff8937831a9ae6f0fe4d658ffabf58f2ca96aa9dec1c889f936f705f216"
 
 [[package]]
 name = "crossbeam-deque"
-version = "0.8.3"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce6fd6f855243022dcecf8702fef0c297d4338e226845fe067f6341ad9fa0cef"
+checksum = "613f8cc01fe9cf1a3eb3d7f488fd2fa8388403e97039e2f73692932e291a770d"
 dependencies = [
- "cfg-if",
  "crossbeam-epoch",
  "crossbeam-utils",
 ]
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.15"
+version = "0.9.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae211234986c545741a7dc064309f67ee1e5ad243d0e48335adc0484d960bcc7"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
 dependencies = [
- "autocfg",
- "cfg-if",
  "crossbeam-utils",
- "memoffset 0.9.1",
- "scopeguard",
 ]
 
 [[package]]
@@ -511,6 +507,12 @@ name = "crossbeam-utils"
 version = "0.8.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "248e3bacc7dc6baa3b21e405ee045c3047101a49145e7e9eca583ab4c2ca5345"
+
+[[package]]
+name = "crunchy"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
 
 [[package]]
 name = "crypto-common"
@@ -656,9 +658,9 @@ checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
 
 [[package]]
 name = "either"
-version = "1.9.0"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a26ae43d7bcc3b814de94796a5e736d4029efb0ee900c12e2d54c993ad1a1e07"
+checksum = "a47c1c47d2f5964e29c61246e81db715514cd532db6b5116a25ea3c03d6780a2"
 
 [[package]]
 name = "env_logger"
@@ -691,15 +693,15 @@ dependencies = [
 
 [[package]]
 name = "fastrand"
-version = "2.0.2"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "658bd65b1cf4c852a3cc96f18a8ce7b5640f6b703f905c7d74532294c2a63984"
+checksum = "9fc0510504f03c51ada170672ac806f1f105a88aa97a5281117e1ddc3368e51a"
 
 [[package]]
 name = "fiat-crypto"
-version = "0.2.7"
+version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c007b1ae3abe1cb6f85a16305acd418b7ca6343b953633fee2b76d8f108b830f"
+checksum = "38793c55593b33412e3ae40c2c9781ffaa6f438f6f8c10f24e71846fbd7ae01e"
 
 [[package]]
 name = "fnv"
@@ -824,9 +826,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.11"
+version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe9006bed769170c11f845cf00c7c1e9092aeb3f268e007c3e760ac68008070f"
+checksum = "94b22e06ecb0110981051723910cbf0b5f5e09a2062dd7663334ee79a9d1286c"
 dependencies = [
  "cfg-if",
  "libc",
@@ -835,9 +837,9 @@ dependencies = [
 
 [[package]]
 name = "gimli"
-version = "0.28.0"
+version = "0.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6fb8d784f27acf97159b40fc4db5ecd8aa23b9ad5ef69cdd136d3bc80665f0c0"
+checksum = "4271d37baee1b8c7e4b708028c57d816cf9d2434acb33a549475f78c181f6253"
 
 [[package]]
 name = "glob"
@@ -847,9 +849,13 @@ checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
 
 [[package]]
 name = "half"
-version = "1.8.2"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eabb4a44450da02c90444cf74558da904edde8fb4e9035a9a6a4e15445af0bd7"
+checksum = "6dd08c532ae367adf81c312a4580bc67f1d0fe8bc9c460520283f4c0ff277888"
+dependencies = [
+ "cfg-if",
+ "crunchy",
+]
 
 [[package]]
 name = "hash32"
@@ -868,9 +874,9 @@ checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "hashbrown"
-version = "0.14.3"
+version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "290f1a1d9242c78d09ce40a5e87e7554ee637af1351968159f4952f028f75604"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 
 [[package]]
 name = "heapless"
@@ -902,9 +908,9 @@ dependencies = [
 
 [[package]]
 name = "hermit-abi"
-version = "0.3.3"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d77f7ec81a6d05a3abb01ab6eb7590f6083d08449fe5a1c8b1e620283546ccb7"
+checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
 
 [[package]]
 name = "home"
@@ -939,12 +945,12 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.1.0"
+version = "2.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d530e1a18b1cb4c484e6e34556a0d948706958449fca0cab753d649f2bce3d1f"
+checksum = "168fb715dda47215e360912c096649d23d58bf392ac62f73919e831745e40f26"
 dependencies = [
  "equivalent",
- "hashbrown 0.14.3",
+ "hashbrown 0.14.5",
 ]
 
 [[package]]
@@ -958,13 +964,13 @@ dependencies = [
 
 [[package]]
 name = "is-terminal"
-version = "0.4.9"
+version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb0889898416213fab133e1d33a0e5858a48177452750691bde3666d0fdbaf8b"
+checksum = "f23ff5ef2b80d608d61efee834934d862cd92461afc0560dedf493e4c033738b"
 dependencies = [
- "hermit-abi 0.3.3",
- "rustix",
- "windows-sys 0.48.0",
+ "hermit-abi 0.3.9",
+ "libc",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -978,24 +984,24 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.9"
+version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af150ab688ff2122fcef229be89cb50dd66af9e01a4ff320cc137eecc9bacc38"
+checksum = "49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b"
 
 [[package]]
 name = "jobserver"
-version = "0.1.27"
+version = "0.1.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c37f63953c4c63420ed5fd3d6d398c719489b9f872b9fa683262f8edd363c7d"
+checksum = "d2b099aaa34a9751c5bf0878add70444e1ed2dd73f347be99003d4577277de6e"
 dependencies = [
  "libc",
 ]
 
 [[package]]
 name = "js-sys"
-version = "0.3.65"
+version = "0.3.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54c0c35952f67de54bb584e9fd912b3023117cbafc0a77d8f3dee1fb5f572fe8"
+checksum = "29c15563dc2726973df627357ce0c9ddddbea194836909d655df6a75d2cf296d"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -1014,9 +1020,9 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libc"
-version = "0.2.153"
+version = "0.2.154"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c198f91728a82281a64e1f4f9eeb25d82cb32a5de251c6bd1b5154d63a8e7bd"
+checksum = "ae743338b92ff9146ce83992f766a31066a91a8c84a45e0e9f21e7cf6de6d346"
 
 [[package]]
 name = "libfuzzer-sys"
@@ -1031,25 +1037,25 @@ dependencies = [
 
 [[package]]
 name = "libloading"
-version = "0.7.4"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b67380fd3b2fbe7527a606e18729d21c6f3951633d0500574c4dc22d2d638b9f"
+checksum = "0c2a198fb6b0eada2a8df47933734e6d35d350665a33a3593d7164fa52c75c19"
 dependencies = [
  "cfg-if",
- "winapi",
+ "windows-targets 0.52.5",
 ]
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.4.12"
+version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4cd1a83af159aa67994778be9070f0ae1bd732942279cabb14f86f986a21456"
+checksum = "01cda141df6706de531b6c46c3a33ecca755538219bd484262fa09410c13539c"
 
 [[package]]
 name = "lock_api"
-version = "0.4.11"
+version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c168f8615b12bc01f9c17e2eb0cc07dcae1940121185446edc3744920e8ef45"
+checksum = "07af8b9cdd281b7915f413fa73f29ebd5d55d0d3f0155584dade1ff18cea1b17"
 dependencies = [
  "autocfg",
  "scopeguard",
@@ -1063,9 +1069,9 @@ checksum = "90ed8c1e510134f979dbc4f070f87d4313098b704861a105fe34231c70a3901c"
 
 [[package]]
 name = "memchr"
-version = "2.6.4"
+version = "2.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f665ee40bc4a3c5590afb1e9677db74a508659dfd71e126420da8274909a0167"
+checksum = "6c8640c5d730cb13ebd907d8d04b52f55ac9a2eec55b440c8892f40d56c76c1d"
 
 [[package]]
 name = "memoffset"
@@ -1104,9 +1110,9 @@ checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "miniz_oxide"
-version = "0.7.1"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7810e0be55b428ada41041c41f32c9f1a42817901b4ccf45fa3d4b6561e74c7"
+checksum = "9d811f3e15f28568be3407c8e7fdb6514c1cda3cb30683f15b6a1a1dc4ea14a7"
 dependencies = [
  "adler",
 ]
@@ -1233,7 +1239,7 @@ version = "0.27.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2eb04e9c688eff1c89d72b407f168cf79bb9e867a9d3323ed6c01519eb9cc053"
 dependencies = [
- "bitflags 2.4.1",
+ "bitflags 2.5.0",
  "cfg-if",
  "libc",
 ]
@@ -1250,9 +1256,9 @@ dependencies = [
 
 [[package]]
 name = "num-traits"
-version = "0.2.17"
+version = "0.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39e3200413f237f41ab11ad6d161bc7239c84dcb631773ccd7de3dfe4b5c267c"
+checksum = "da0df0e5185db44f69b44f26786fe401b6c293d1907744beaa7fa62b2e5a517a"
 dependencies = [
  "autocfg",
 ]
@@ -1263,15 +1269,15 @@ version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
 dependencies = [
- "hermit-abi 0.3.3",
+ "hermit-abi 0.3.9",
  "libc",
 ]
 
 [[package]]
 name = "object"
-version = "0.32.1"
+version = "0.32.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9cf5f9dd3933bd50a9e1f149ec995f39ae2c496d31fd772c1fd45ebc27e902b0"
+checksum = "a6a622008b6e321afc04970976f62ee297fdbaa6f95318ca343e3eebb9648441"
 dependencies = [
  "memchr",
 ]
@@ -1290,20 +1296,21 @@ checksum = "0ab1bc2a289d34bd04a330323ac98a1b4bc82c9d9fcb1e66b63caa84da26b575"
 
 [[package]]
 name = "opaque-debug"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
+checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
 name = "oqs-sys"
-version = "0.8.0"
+version = "0.9.1+liboqs-0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fa114149fb6e5362b9cf539de9305a6a3cf1556fbfa93b5053b4f70cf3adfb9"
+checksum = "afa79adc3c10f8e01d0b134c159254e5843ec3f91c0bd868e57777beb3329e17"
 dependencies = [
  "bindgen",
  "build-deps",
  "cmake",
  "libc",
+ "pkg-config",
 ]
 
 [[package]]
@@ -1314,9 +1321,9 @@ checksum = "e2355d85b9a3786f481747ced0e0ff2ba35213a1f9bd406ed906554d7af805a1"
 
 [[package]]
 name = "parking_lot"
-version = "0.12.1"
+version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3742b2c103b9f06bc9fff0a37ff4912935851bee6d36f3c02bcc755bcfec228f"
+checksum = "7e4af0ca4f6caed20e900d564c242b8e5d4903fdacf31d3daf527b66fe6f42fb"
 dependencies = [
  "lock_api",
  "parking_lot_core",
@@ -1324,15 +1331,15 @@ dependencies = [
 
 [[package]]
 name = "parking_lot_core"
-version = "0.9.9"
+version = "0.9.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c42a9226546d68acdd9c0a280d17ce19bfe27a46bf68784e4066115788d008e"
+checksum = "1e401f977ab385c9e4e3ab30627d6f26d00e2c73eef317493c4ec6d468726cf8"
 dependencies = [
  "cfg-if",
  "libc",
  "redox_syscall",
  "smallvec",
- "windows-targets 0.48.5",
+ "windows-targets 0.52.5",
 ]
 
 [[package]]
@@ -1358,6 +1365,12 @@ name = "pin-utils"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
+name = "pkg-config"
+version = "0.3.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d231b230927b5e4ad203db57bbcbee2802f6bce620b1e4a9024a07d94e2907ec"
 
 [[package]]
 name = "platforms"
@@ -1412,9 +1425,9 @@ checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
 
 [[package]]
 name = "prettyplease"
-version = "0.2.15"
+version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae005bd773ab59b4725093fd7df83fd7892f7d8eafb48dbd7de6e024e4215f9d"
+checksum = "5ac2cf0f2e4f42b49f5ffd07dae8d746508ef7526c13940e5f524012ae6c6550"
 dependencies = [
  "proc-macro2",
  "syn",
@@ -1479,9 +1492,9 @@ dependencies = [
 
 [[package]]
 name = "rayon"
-version = "1.8.0"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c27db03db7734835b3f53954b534c91069375ce6ccaa2e065441e07d9b6cdb1"
+checksum = "b418a60154510ca1a002a752ca9714984e21e4241e804d32555251faf8b78ffa"
 dependencies = [
  "either",
  "rayon-core",
@@ -1489,9 +1502,9 @@ dependencies = [
 
 [[package]]
 name = "rayon-core"
-version = "1.12.0"
+version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ce3fb6ad83f861aac485e76e1985cd109d9a3713802152be56c3b1f0e0658ed"
+checksum = "1465873a3dfdaa8ae7cb14b4383657caab0b3e8a0aa9ae8e04b044854c8dfce2"
 dependencies = [
  "crossbeam-deque",
  "crossbeam-utils",
@@ -1499,18 +1512,18 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.4.1"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4722d768eff46b75989dd134e5c353f0d6296e5aaa3132e776cbdb56be7731aa"
+checksum = "469052894dcb553421e483e4209ee581a45100d31b4018de03e5a7ad86374a7e"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags 2.5.0",
 ]
 
 [[package]]
 name = "regex"
-version = "1.10.2"
+version = "1.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "380b951a9c5e80ddfd6136919eef32310721aa4aacd4889a8d39124b026ab343"
+checksum = "c117dbdfde9c8308975b6a18d71f3f385c89461f7b3fb054288ecf2a2058ba4c"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1520,9 +1533,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.3"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f804c7828047e88b2d32e2d7fe5a105da8ee3264f01902f796c8e067dc2483f"
+checksum = "86b83b8b9847f9bf95ef68afb0b8e6cdb80f498442f5179a29fad448fcc1eaea"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1531,9 +1544,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c08c74e62047bb2de4ff487b251e4a92e24f48745648451635cec7d591162d9f"
+checksum = "adad44e29e4c806119491a7f06f03de4d1af22c3a680dd47f1e6e179439d1f56"
 
 [[package]]
 name = "rosenpass"
@@ -1626,11 +1639,13 @@ dependencies = [
  "allocator-api2",
  "allocator-api2-tests",
  "anyhow",
+ "base64ct",
  "log",
  "memsec",
  "rand",
  "rosenpass-to",
  "rosenpass-util",
+ "tempfile",
  "zeroize",
 ]
 
@@ -1719,11 +1734,11 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.38.32"
+version = "0.38.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65e04861e65f21776e67888bfbea442b3642beaa0138fdb1dd7a84a52dffdb89"
+checksum = "70dc5ec042f7a43c4a73241207cecc9873a06d45debb38b329f8541d85c2730f"
 dependencies = [
- "bitflags 2.4.1",
+ "bitflags 2.5.0",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -1732,9 +1747,9 @@ dependencies = [
 
 [[package]]
 name = "ryu"
-version = "1.0.15"
+version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ad4cc8da4ef723ed60bced201181d83791ad433213d8c24efffda1eec85d741"
+checksum = "e86697c916019a8588c99b5fac3cead74ec0b4b819707a682fd4d23fa0ce1ba1"
 
 [[package]]
 name = "same-file"
@@ -1768,24 +1783,24 @@ checksum = "b84345e4c9bd703274a082fb80caaa99b7612be48dfaa1dd9266577ec412309d"
 
 [[package]]
 name = "semver"
-version = "1.0.21"
+version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b97ed7a9823b74f99c7742f5336af7be5ecd3eeafcb1507d1fa93347b1d589b0"
+checksum = "92d43fe69e652f3df9bdc2b85b2854a0825b86e4fb76bc44d945137d053639ca"
 
 [[package]]
 name = "serde"
-version = "1.0.199"
+version = "1.0.200"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c9f6e76df036c77cd94996771fb40db98187f096dd0b9af39c6c6e452ba966a"
+checksum = "ddc6f9cc94d67c0e21aaf7eda3a010fd3af78ebf6e096aa6e2e13c79749cce4f"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.199"
+version = "1.0.200"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11bd257a6541e141e42ca6d24ae26f7714887b47e89aa739099104c7e4d3b7fc"
+checksum = "856f046b9400cee3c8c94ed572ecdb752444c24528c035cd35882aad6f492bcb"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1794,9 +1809,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.108"
+version = "1.0.116"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d1c7e3eac408d115102c4c24ad393e0821bb3a5df4d506a80f85f7a742a526b"
+checksum = "3e17db7126d17feb94eb3fad46bf1a96b034e8aacbc2e775fe81505f8b0b2813"
 dependencies = [
  "itoa",
  "ryu",
@@ -1805,9 +1820,9 @@ dependencies = [
 
 [[package]]
 name = "serde_spanned"
-version = "0.6.4"
+version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12022b835073e5b11e90a14f86838ceb1c8fb0325b72416845c487ac0fa95e80"
+checksum = "eb3622f419d1296904700073ea6cc23ad690adbd66f13ea683df73298736f0c1"
 dependencies = [
  "serde",
 ]
@@ -1839,9 +1854,9 @@ dependencies = [
 
 [[package]]
 name = "shlex"
-version = "1.2.0"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7cee0529a6d40f580e7a5e6c495c8fbfe21b7b52795ed4bb5e62cdf92bc6380"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "slab"
@@ -1860,9 +1875,9 @@ checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
 
 [[package]]
 name = "socket2"
-version = "0.5.6"
+version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05ffd9c0a93b7543e062e759284fcf5f5e3b098501104bfbdde4d404db792871"
+checksum = "ce305eb0b4296696835b71df73eb912e0f1ffd2556a501fcede6e0c50349191c"
 dependencies = [
  "libc",
  "windows-sys 0.52.0",
@@ -1945,9 +1960,9 @@ dependencies = [
 
 [[package]]
 name = "termcolor"
-version = "1.4.0"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff1bc3d3f05aff0403e8ac0d92ced918ec05b666a43f83297ccef5bea8a3d449"
+checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
 dependencies = [
  "winapi-util",
 ]
@@ -1960,9 +1975,9 @@ checksum = "8e7a7de15468c6e65dd7db81cf3822c1ec94c71b2a3c1a976ea8e4696c91115c"
 
 [[package]]
 name = "textwrap"
-version = "0.16.0"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "222a222a5bfe1bba4a77b45ec488a741b3cb8872e5e499451fd7d0129c9c7c3d"
+checksum = "23d434d3f8967a09480fb04132ebe0a3e088c173e6d0ee7897abbdf4eab0f8b9"
 
 [[package]]
 name = "thiserror"
@@ -2049,7 +2064,7 @@ version = "0.19.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b5bb770da30e5cbfde35a2d7b9b8a2c4b8ef89548a7a6aeab5c9a576e3e7421"
 dependencies = [
- "indexmap 2.1.0",
+ "indexmap 2.2.6",
  "serde",
  "serde_spanned",
  "toml_datetime",
@@ -2092,9 +2107,9 @@ checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
 name = "walkdir"
-version = "2.4.0"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d71d857dc86794ca4c280d616f7da00d2dbfd8cd788846559a6813e6aa4b54ee"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
 dependencies = [
  "same-file",
  "winapi-util",
@@ -2108,9 +2123,9 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.88"
+version = "0.2.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7daec296f25a1bae309c0cd5c29c4b260e510e6d813c286b19eaadf409d40fce"
+checksum = "4be2531df63900aeb2bca0daaaddec08491ee64ceecbee5076636a3b026795a8"
 dependencies = [
  "cfg-if",
  "wasm-bindgen-macro",
@@ -2118,9 +2133,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.88"
+version = "0.2.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e397f4664c0e4e428e8313a469aaa58310d302159845980fd23b0f22a847f217"
+checksum = "614d787b966d3989fa7bb98a654e369c762374fd3213d212cfc0251257e747da"
 dependencies = [
  "bumpalo",
  "log",
@@ -2133,9 +2148,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.88"
+version = "0.2.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5961017b3b08ad5f3fe39f1e79877f8ee7c23c5e5fd5eb80de95abc41f1f16b2"
+checksum = "a1f8823de937b71b9460c0c34e25f3da88250760bec0ebac694b49997550d726"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -2143,9 +2158,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.88"
+version = "0.2.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5353b8dab669f5e10f5bd76df26a9360c748f054f862ff5f3f8aae0c7fb3907"
+checksum = "e94f17b526d0a461a191c78ea52bbce64071ed5c04c9ffe424dcb38f74171bb7"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2156,15 +2171,15 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.88"
+version = "0.2.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d046c5d029ba91a1ed14da14dca44b68bf2f124cfbaf741c54151fdb3e0750b"
+checksum = "af190c94f2773fdb3729c55b007a722abb5384da03bc0986df4c289bf5567e96"
 
 [[package]]
 name = "web-sys"
-version = "0.3.65"
+version = "0.3.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5db499c5f66323272151db0e666cd34f78617522fb0c1604d31a27c50c206a85"
+checksum = "77afa9a11836342370f4817622a2f0f418b134426d91a82dfb48f532d2ec13ef"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -2200,11 +2215,11 @@ checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
 
 [[package]]
 name = "winapi-util"
-version = "0.1.6"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f29e6f9198ba0d26b4c9f07dbe6f9ed633e1f3d5b8b414090084349e46a52596"
+checksum = "4d4cc384e1e73b93bafa6fb4f1df8c41695c8a91cf9c4c64358067d15a7b6c6b"
 dependencies = [
- "winapi",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2237,7 +2252,7 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets 0.52.0",
+ "windows-targets 0.52.5",
 ]
 
 [[package]]
@@ -2272,17 +2287,18 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
-version = "0.52.0"
+version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a18201040b24831fbb9e4eb208f8892e1f50a37feb53cc7ff887feb8f50e7cd"
+checksum = "6f0713a46559409d202e70e28227288446bf7841d3211583a4b53e3f6d96e7eb"
 dependencies = [
- "windows_aarch64_gnullvm 0.52.0",
- "windows_aarch64_msvc 0.52.0",
- "windows_i686_gnu 0.52.0",
- "windows_i686_msvc 0.52.0",
- "windows_x86_64_gnu 0.52.0",
- "windows_x86_64_gnullvm 0.52.0",
- "windows_x86_64_msvc 0.52.0",
+ "windows_aarch64_gnullvm 0.52.5",
+ "windows_aarch64_msvc 0.52.5",
+ "windows_i686_gnu 0.52.5",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc 0.52.5",
+ "windows_x86_64_gnu 0.52.5",
+ "windows_x86_64_gnullvm 0.52.5",
+ "windows_x86_64_msvc 0.52.5",
 ]
 
 [[package]]
@@ -2299,9 +2315,9 @@ checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.52.0"
+version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb7764e35d4db8a7921e09562a0304bf2f93e0a51bfccee0bd0bb0b666b015ea"
+checksum = "7088eed71e8b8dda258ecc8bac5fb1153c5cffaf2578fc8ff5d61e23578d3263"
 
 [[package]]
 name = "windows_aarch64_msvc"
@@ -2317,9 +2333,9 @@ checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.52.0"
+version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbaa0368d4f1d2aaefc55b6fcfee13f41544ddf36801e793edbbfd7d7df075ef"
+checksum = "9985fd1504e250c615ca5f281c3f7a6da76213ebd5ccc9561496568a2752afb6"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -2335,9 +2351,15 @@ checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.52.0"
+version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a28637cb1fa3560a16915793afb20081aba2c92ee8af57b4d5f28e4b3e7df313"
+checksum = "88ba073cf16d5372720ec942a8ccbf61626074c6d4dd2e745299726ce8b89670"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87f4261229030a858f36b459e748ae97545d6f1ec60e5e0d6a3d32e0dc232ee9"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -2353,9 +2375,9 @@ checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.52.0"
+version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffe5e8e31046ce6230cc7215707b816e339ff4d4d67c65dffa206fd0f7aa7b9a"
+checksum = "db3c2bf3d13d5b658be73463284eaf12830ac9a26a90c717b7f771dfe97487bf"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -2371,9 +2393,9 @@ checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.52.0"
+version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d6fa32db2bc4a2f5abeacf2b69f7992cd09dca97498da74a151a3132c26befd"
+checksum = "4e4246f76bdeff09eb48875a0fd3e2af6aada79d409d33011886d3e1581517d9"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -2389,9 +2411,9 @@ checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.52.0"
+version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a657e1e9d3f514745a572a6846d3c7aa7dbe1658c056ed9c3344c4109a6949e"
+checksum = "852298e482cd67c356ddd9570386e2862b5673c85bd5f88df9ab6802b334c596"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -2407,15 +2429,15 @@ checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.52.0"
+version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dff9641d1cd4be8d1a070daf9e3773c5f67e78b4d9d42263020c057706765c04"
+checksum = "bec47e5bfd1bff0eeaf6d8b485cc1074891a197ab4225d504cb7a1ab88b02bf0"
 
 [[package]]
 name = "winnow"
-version = "0.5.19"
+version = "0.5.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "829846f3e3db426d4cee4510841b71a8e58aa2a76b1132579487ae430ccd9c7b"
+checksum = "f593a95398737aeed53e489c785df13f3618e41dbcd6718c6addbf1395aa6876"
 dependencies = [
  "memchr",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -166,10 +166,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "base64"
-version = "0.21.7"
+name = "base64ct"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
+checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
 
 [[package]]
 name = "bindgen"
@@ -1646,9 +1646,10 @@ name = "rosenpass-util"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "base64",
+ "base64ct",
  "static_assertions",
  "typenum",
+ "zeroize",
 ]
 
 [[package]]
@@ -1656,7 +1657,7 @@ name = "rp"
 version = "0.2.1"
 dependencies = [
  "anyhow",
- "base64",
+ "base64ct",
  "ctrlc-async",
  "futures",
  "futures-util",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,5 +61,5 @@ blake2 = "0.10.6"
 chacha20poly1305 = { version = "0.10.1", default-features = false, features = [ "std", "heapless" ] }
 zerocopy = { version = "0.7.32", features = ["derive"] }
 home = "0.5.9"
-serial_test = "3.1.0"
+serial_test = "3.1.1"
 derive_builder = "0.20.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,7 @@ test_bin = "0.4.0"
 libfuzzer-sys = "0.4"
 stacker = "0.1.15"
 doc-comment = "0.3.3"
-base64 = "0.21.7"
+base64ct = {version = "1.6.0", default-features=false}
 zeroize = "1.7.0"
 memoffset = "0.9.1"
 thiserror = "1.0.59"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,10 +32,6 @@ rosenpass-ciphers = { path = "ciphers" }
 rosenpass-to = { path = "to" }
 rosenpass-secret-memory = { path = "secret-memory" }
 rosenpass-oqs = { path = "oqs" }
-criterion = "0.4.0"
-test_bin = "0.4.0"
-libfuzzer-sys = "0.4"
-stacker = "0.1.15"
 doc-comment = "0.3.3"
 base64ct = {version = "1.6.0", default-features=false}
 zeroize = "1.7.0"
@@ -46,20 +42,27 @@ env_logger = "0.10.2"
 toml = "0.7.8"
 static_assertions = "1.1.0"
 allocator-api2 = "0.2.14"
-allocator-api2-tests = "0.2.15"
 memsec = "0.6.3"
 rand = "0.8.5"
 typenum = "1.17.0"
 log = { version = "0.4.21" }
 clap = { version = "4.5.4", features = ["derive"] }
-serde = { version = "1.0.199", features = ["derive"] }
+serde = { version = "1.0.200", features = ["derive"] }
 arbitrary = { version = "1.3.2", features = ["derive"] }
 anyhow = { version = "1.0.82", features = ["backtrace", "std"] }
 mio = { version = "0.8.11", features = ["net", "os-poll"] }
-oqs-sys = { version = "0.8", default-features = false, features = ['classic_mceliece', 'kyber']  }
+oqs-sys = { version = "0.9.1", default-features = false, features = ['classic_mceliece', 'kyber']  }
 blake2 = "0.10.6"
 chacha20poly1305 = { version = "0.10.1", default-features = false, features = [ "std", "heapless" ] }
 zerocopy = { version = "0.7.32", features = ["derive"] }
 home = "0.5.9"
-serial_test = "3.1.1"
 derive_builder = "0.20.0"
+
+#Dev dependencies
+serial_test = "3.1.1"
+tempfile="3"
+stacker = "0.1.15"
+libfuzzer-sys = "0.4"
+test_bin = "0.4.0"
+criterion = "0.4.0"
+allocator-api2-tests = "0.2.15"

--- a/rosenpass/src/app_server.rs
+++ b/rosenpass/src/app_server.rs
@@ -32,8 +32,8 @@ use crate::{
 use rosenpass_util::attempt;
 use rosenpass_util::b64::B64Display;
 
-const MAX_B64_KEY_SIZE: usize = 1000;
-const MAX_B64_PEER_ID_SIZE: usize = 1000;
+const MAX_B64_KEY_SIZE: usize = 32 * 5 / 3;
+const MAX_B64_PEER_ID_SIZE: usize = 32 * 5 / 3;
 
 const IPV4_ANY_ADDR: Ipv4Addr = Ipv4Addr::new(0, 0, 0, 0);
 const IPV6_ANY_ADDR: Ipv6Addr = Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 0);
@@ -794,7 +794,10 @@ impl AppServer {
                     }
                 }
             };
-            key.store_b64_writer::<MAX_B64_KEY_SIZE, _>(child.stdin.take().unwrap());
+            if let Err(e) = key.store_b64_writer::<MAX_B64_KEY_SIZE, _>(child.stdin.take().unwrap())
+            {
+                error!("could not write psk to wg: {:?}", e);
+            }
 
             thread::spawn(move || {
                 let status = child.wait();

--- a/rosenpass/src/cli.rs
+++ b/rosenpass/src/cli.rs
@@ -300,6 +300,7 @@ impl CliCommand {
         config: config::Rosenpass,
         test_helpers: Option<AppServerTest>,
     ) -> anyhow::Result<()> {
+        const MAX_PSK_SIZE: usize = 1000;
         // load own keys
         let sk = SSk::load(&config.secret_key)?;
         let pk = SPk::load(&config.public_key)?;
@@ -316,7 +317,10 @@ impl CliCommand {
         for cfg_peer in config.peers {
             srv.add_peer(
                 // psk, pk, outfile, outwg, tx_addr
-                cfg_peer.pre_shared_key.map(SymKey::load_b64).transpose()?,
+                cfg_peer
+                    .pre_shared_key
+                    .map(SymKey::load_b64::<MAX_PSK_SIZE, _>)
+                    .transpose()?,
                 SPk::load(&cfg_peer.public_key)?,
                 cfg_peer.key_out,
                 cfg_peer.wg.map(|cfg| app_server::WireguardOut {

--- a/rp/Cargo.toml
+++ b/rp/Cargo.toml
@@ -34,5 +34,5 @@ netlink-packet-generic = "0.3"
 netlink-packet-wireguard = "0.2"
 
 [dev-dependencies]
-tempfile = "3"
-stacker = "0.1.15"
+tempfile = {workspace = true}
+stacker = {workspace = true}

--- a/rp/Cargo.toml
+++ b/rp/Cargo.toml
@@ -11,7 +11,7 @@ repository = "https://github.com/rosenpass/rosenpass"
 
 [dependencies]
 anyhow = { workspace = true }
-base64 = { workspace = true }
+base64ct = { workspace = true }
 x25519-dalek = { version = "2", features = ["static_secrets"] }
 zeroize = { workspace = true }
 

--- a/rp/src/exchange.rs
+++ b/rp/src/exchange.rs
@@ -2,6 +2,7 @@ use std::{net::SocketAddr, path::PathBuf};
 
 use anyhow::Result;
 
+use crate::key::WG_B64_LEN;
 #[derive(Default)]
 pub struct ExchangePeer {
     pub public_keys_dir: PathBuf,
@@ -160,7 +161,7 @@ pub async fn exchange(options: ExchangeOptions) -> Result<()> {
 
     let wgsk_path = options.private_keys_dir.join("wgsk");
 
-    let wgsk = Secret::<WG_KEY_LEN>::load_b64(wgsk_path)?;
+    let wgsk = Secret::<WG_KEY_LEN>::load_b64::<WG_B64_LEN, _>(wgsk_path)?;
 
     let mut attr: Vec<WgDeviceAttrs> = Vec::with_capacity(2);
     attr.push(WgDeviceAttrs::PrivateKey(*wgsk.secret()));
@@ -221,7 +222,7 @@ pub async fn exchange(options: ExchangeOptions) -> Result<()> {
 
         srv.add_peer(
             if psk.exists() {
-                Some(SymKey::load_b64(psk))
+                Some(SymKey::load_b64::<WG_B64_LEN, _>(psk))
             } else {
                 None
             }

--- a/rp/src/key.rs
+++ b/rp/src/key.rs
@@ -1,18 +1,19 @@
 use std::{
-    fs::{self, DirBuilder, OpenOptions},
-    io::Write,
-    os::unix::fs::{DirBuilderExt, OpenOptionsExt, PermissionsExt},
+    fs::{self, DirBuilder},
+    os::unix::fs::{DirBuilderExt, PermissionsExt},
     path::Path,
 };
 
 use anyhow::{anyhow, Result};
-use base64::Engine;
+use rosenpass_util::file::{LoadValueB64, StoreValueB64};
 use zeroize::Zeroize;
 
 use rosenpass::protocol::{SPk, SSk};
 use rosenpass_cipher_traits::Kem;
 use rosenpass_ciphers::kem::StaticKem;
-use rosenpass_secret_memory::{file::StoreSecret as _, Secret};
+use rosenpass_secret_memory::{file::StoreSecret as _, Public, Secret};
+
+pub const WG_B64_LEN: usize = 44;
 
 #[cfg(not(target_family = "unix"))]
 pub fn genkey(_: &Path) -> Result<()> {
@@ -44,18 +45,7 @@ pub fn genkey(private_keys_dir: &Path) -> Result<()> {
 
     if !wgsk_path.exists() {
         let wgsk: Secret<32> = Secret::random();
-
-        let mut wgsk_file = OpenOptions::new()
-            .write(true)
-            .create(true)
-            .mode(0o600)
-            .open(wgsk_path)?;
-
-        wgsk_file.write_all(
-            base64::engine::general_purpose::STANDARD
-                .encode(wgsk.secret())
-                .as_bytes(),
-        )?;
+        wgsk.store_b64::<WG_B64_LEN, _>(wgsk_path)?;
     } else {
         eprintln!(
             "WireGuard secret key already exists at {:#?}: not regenerating",
@@ -91,20 +81,15 @@ pub fn pubkey(private_keys_dir: &Path, public_keys_dir: &Path) -> Result<()> {
     let private_pqpk = private_keys_dir.join("pqpk");
     let public_pqpk = public_keys_dir.join("pqpk");
 
-    let wgsk = Secret::from_slice(
-        &base64::engine::general_purpose::STANDARD.decode(fs::read_to_string(private_wgsk)?)?,
-    );
-    let mut wgpk: x25519_dalek::PublicKey = {
+    let wgsk = Secret::load_b64::<WG_B64_LEN, _>(private_wgsk)?;
+    let mut wgpk: Public<32> = {
         let mut secret = x25519_dalek::StaticSecret::from(*wgsk.secret());
         let public = x25519_dalek::PublicKey::from(&secret);
         secret.zeroize();
-        public
+        Public::from_slice(public.as_bytes())
     };
 
-    fs::write(
-        public_wgpk,
-        base64::engine::general_purpose::STANDARD.encode(wgpk.as_bytes()),
-    )?;
+    wgpk.store_b64::<WG_B64_LEN, _>(public_wgpk)?;
     wgpk.zeroize();
 
     fs::copy(private_pqpk, public_pqpk)?;
@@ -116,12 +101,13 @@ pub fn pubkey(private_keys_dir: &Path, public_keys_dir: &Path) -> Result<()> {
 mod tests {
     use std::fs;
 
-    use base64::Engine;
     use rosenpass::protocol::{SPk, SSk};
+    use rosenpass_secret_memory::Secret;
     use rosenpass_util::file::LoadValue;
+    use rosenpass_util::file::LoadValueB64;
     use tempfile::tempdir;
 
-    use crate::key::{genkey, pubkey};
+    use crate::key::{genkey, pubkey, WG_B64_LEN};
 
     #[test]
     fn it_works() {
@@ -137,9 +123,9 @@ mod tests {
         assert!(private_keys_dir.path().is_dir());
         assert!(SPk::load(private_keys_dir.path().join("pqpk")).is_ok());
         assert!(SSk::load(private_keys_dir.path().join("pqsk")).is_ok());
-        assert!(base64::engine::general_purpose::STANDARD
-            .decode(&fs::read_to_string(private_keys_dir.path().join("wgsk")).unwrap())
-            .is_ok());
+        assert!(
+            Secret::<32>::load_b64::<WG_B64_LEN, _>(private_keys_dir.path().join("wgsk")).is_ok()
+        );
 
         let public_keys_dir = tempdir().unwrap();
         fs::remove_dir(public_keys_dir.path()).unwrap();
@@ -152,9 +138,9 @@ mod tests {
         assert!(public_keys_dir.path().exists());
         assert!(public_keys_dir.path().is_dir());
         assert!(SPk::load(public_keys_dir.path().join("pqpk")).is_ok());
-        assert!(base64::engine::general_purpose::STANDARD
-            .decode(&fs::read_to_string(public_keys_dir.path().join("wgpk")).unwrap())
-            .is_ok());
+        assert!(
+            Secret::<32>::load_b64::<WG_B64_LEN, _>(public_keys_dir.path().join("wgpk")).is_ok()
+        );
 
         let pk_1 = fs::read(private_keys_dir.path().join("pqpk")).unwrap();
         let pk_2 = fs::read(public_keys_dir.path().join("pqpk")).unwrap();

--- a/rp/src/key.rs
+++ b/rp/src/key.rs
@@ -13,7 +13,7 @@ use rosenpass_cipher_traits::Kem;
 use rosenpass_ciphers::kem::StaticKem;
 use rosenpass_secret_memory::{file::StoreSecret as _, Public, Secret};
 
-pub const WG_B64_LEN: usize = 44;
+pub const WG_B64_LEN: usize = 32 * 5 / 3;
 
 #[cfg(not(target_family = "unix"))]
 pub fn genkey(_: &Path) -> Result<()> {

--- a/secret-memory/Cargo.toml
+++ b/secret-memory/Cargo.toml
@@ -21,3 +21,5 @@ log = { workspace = true }
 
 [dev-dependencies]
 allocator-api2-tests = { workspace = true }
+tempfile = {workspace = true}
+base64ct = {workspace = true}

--- a/secret-memory/src/public.rs
+++ b/secret-memory/src/public.rs
@@ -5,7 +5,7 @@ use rosenpass_to::{ops::copy_slice, To};
 use rosenpass_util::b64::{b64_decode, b64_encode};
 use rosenpass_util::file::{
     fopen_r, fopen_w, LoadValue, LoadValueB64, ReadExactToEnd, ReadSliceToEnd, StoreValue,
-    StoreValueB64, Visibility,
+    StoreValueB64, StoreValueB64Writer, Visibility,
 };
 use rosenpass_util::functional::mutating;
 use std::borrow::{Borrow, BorrowMut};
@@ -128,11 +128,11 @@ impl<const N: usize> LoadValueB64 for Public<N> {
         let mut v = Public::zero();
         let p = path.as_ref();
 
-        fopen_r(p)?
+        let len = fopen_r(p)?
             .read_slice_to_end(&mut f)
             .with_context(|| format!("Could not load file {p:?}"))?;
 
-        b64_decode(&f, &mut v.value)
+        b64_decode(&f[0..len], &mut v.value)
             .with_context(|| format!("Could not decode base64 file {p:?}"))?;
 
         Ok(v)
@@ -151,5 +151,129 @@ impl<const N: usize> StoreValueB64 for Public<N> {
             .write_all(encoded_str.as_bytes())
             .with_context(|| format!("Could not write file {p:?}"))?;
         Ok(())
+    }
+}
+
+impl<const N: usize> StoreValueB64Writer for Public<N> {
+    type Error = anyhow::Error;
+
+    fn store_b64_writer<const F: usize, W: std::io::Write>(
+        &self,
+        mut writer: W,
+    ) -> Result<(), Self::Error> {
+        let mut f = [0u8; F];
+        let encoded_str = b64_encode(&self.value, &mut f)
+            .with_context(|| format!("Could not encode secret to base64"))?;
+
+        writer
+            .write_all(encoded_str.as_bytes())
+            .with_context(|| format!("Could not write base64 to writer"))?;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+
+    #[cfg(test)]
+    mod tests {
+        use crate::Public;
+        use rosenpass_util::{
+            b64::b64_encode,
+            file::{
+                fopen_w, LoadValue, LoadValueB64, StoreValue, StoreValueB64, StoreValueB64Writer,
+                Visibility,
+            },
+        };
+        use std::{fs, os::unix::fs::PermissionsExt};
+        use tempfile::tempdir;
+
+        /// test loading a public from an example file, and then storing it again in a different file
+        #[test]
+        fn test_public_load_store() {
+            const N: usize = 100;
+
+            // Generate original random bytes
+            let original_bytes: [u8; N] = [rand::random(); N];
+
+            // Create a temporary directory
+            let temp_dir = tempdir().unwrap();
+
+            // Store the original public to an example file in the temporary directory
+            let example_file = temp_dir.path().join("example_file");
+            std::fs::write(example_file.clone(), &original_bytes).unwrap();
+
+            // Load the public from the example file
+
+            let loaded_public = Public::load(&example_file).unwrap();
+
+            // Check that the loaded public matches the original bytes
+            assert_eq!(&loaded_public.value, &original_bytes);
+
+            // Store the loaded public to a different file in the temporary directory
+            let new_file = temp_dir.path().join("new_file");
+            loaded_public.store(&new_file).unwrap();
+
+            // Read the contents of the new file
+            let new_file_contents = fs::read(&new_file).unwrap();
+
+            // Read the contents of the original file
+            let original_file_contents = fs::read(&example_file).unwrap();
+
+            // Check that the contents of the new file match the original file
+            assert_eq!(new_file_contents, original_file_contents);
+        }
+
+        /// test loading a base64 encoded public from an example file, and then storing it again in a different file
+        #[test]
+        fn test_public_load_store_base64() {
+            const N: usize = 100;
+            // Generate original random bytes
+            let original_bytes: [u8; N] = [rand::random(); N];
+            // Create a temporary directory
+            let temp_dir = tempdir().unwrap();
+            let example_file = temp_dir.path().join("example_file");
+            let mut encoded_public = [0u8; N * 2];
+            let encoded_public = b64_encode(&original_bytes, &mut encoded_public).unwrap();
+            std::fs::write(&example_file, encoded_public).unwrap();
+
+            // Load the public from the example file
+            let loaded_public = Public::load_b64::<{ N * 2 }, _>(&example_file).unwrap();
+            // Check that the loaded public matches the original bytes
+            assert_eq!(&loaded_public.value, &original_bytes);
+
+            // Store the loaded public to a different file in the temporary directory
+            let new_file = temp_dir.path().join("new_file");
+            loaded_public.store_b64::<{ N * 2 }, _>(&new_file).unwrap();
+
+            // Read the contents of the new file
+            let new_file_contents = fs::read(&new_file).unwrap();
+            // Read the contents of the original file
+            let original_file_contents = fs::read(&example_file).unwrap();
+            // Check that the contents of the new file match the original file
+            assert_eq!(new_file_contents, original_file_contents);
+
+            //Check new file permissions are public
+            let metadata = fs::metadata(&new_file).unwrap();
+            assert_eq!(metadata.permissions().mode() & 0o000777, 0o644);
+
+            // Store the loaded public to a different file in the temporary directory for a second time
+            let new_file = temp_dir.path().join("new_file_writer");
+            let new_file_writer = fopen_w(new_file.clone(), Visibility::Public).unwrap();
+            loaded_public
+                .store_b64_writer::<{ N * 2 }, _>(&new_file_writer)
+                .unwrap();
+
+            // Read the contents of the new file
+            let new_file_contents = fs::read(&new_file).unwrap();
+            // Read the contents of the original file
+            let original_file_contents = fs::read(&example_file).unwrap();
+            // Check that the contents of the new file match the original file
+            assert_eq!(new_file_contents, original_file_contents);
+
+            //Check new file permissions are public
+            let metadata = fs::metadata(&new_file).unwrap();
+            assert_eq!(metadata.permissions().mode() & 0o000777, 0o644);
+        }
     }
 }

--- a/util/Cargo.toml
+++ b/util/Cargo.toml
@@ -12,7 +12,8 @@ readme = "readme.md"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-base64 = { workspace = true }
+base64ct = { workspace = true }
 anyhow = { workspace = true }
 typenum = { workspace = true }
 static_assertions = { workspace = true }
+zeroize = {workspace = true}

--- a/util/src/b64.rs
+++ b/util/src/b64.rs
@@ -1,20 +1,54 @@
-use base64::{
-    display::Base64Display as B64Display, read::DecoderReader as B64Reader,
-    write::EncoderWriter as B64Writer,
+use base64ct::{
+    Base64,
+    Decoder as B64Reader,
+    Encoder as B64Writer,
 };
-use std::io::{Read, Write};
+use zeroize::Zeroize;
 
-use base64::engine::general_purpose::GeneralPurpose as Base64Engine;
-const B64ENGINE: Base64Engine = base64::engine::general_purpose::STANDARD;
+use std::fmt::Display;
 
-pub fn fmt_b64<'a>(payload: &'a [u8]) -> B64Display<'a, 'static, Base64Engine> {
-    B64Display::<'a, 'static>::new(payload, &B64ENGINE)
+pub struct B64DisplayHelper<'a, const F: usize>(&'a [u8]);
+
+impl<const F: usize> Display for B64DisplayHelper<'_, F> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let mut bytes = [0u8; F];
+        let string = b64_encode(&self.0, &mut bytes).map_err(|_| std::fmt::Error)?;
+        let result = f.write_str(string);
+        bytes.zeroize();
+        result
+    }
 }
 
-pub fn b64_writer<W: Write>(w: W) -> B64Writer<'static, Base64Engine, W> {
-    B64Writer::new(w, &B64ENGINE)
+pub trait B64Display {
+    fn fmt_b64<'o, const F: usize>(&'o self) -> B64DisplayHelper<'o, F>;
 }
 
-pub fn b64_reader<R: Read>(r: R) -> B64Reader<'static, Base64Engine, R> {
-    B64Reader::new(r, &B64ENGINE)
+impl B64Display for [u8] {
+    fn fmt_b64<'o, const F: usize>(&'o self) -> B64DisplayHelper<'o, F> {
+        B64DisplayHelper(self)
+    }
+}
+
+impl<T: AsRef<[u8]>> B64Display for T {
+    fn fmt_b64<'o, const F: usize>(&'o self) -> B64DisplayHelper<'o, F> {
+        B64DisplayHelper(self.as_ref())
+    }
+}
+
+pub fn b64_decode(input: &[u8], output: &mut [u8]) -> anyhow::Result<()> {
+    let mut reader = B64Reader::<Base64>::new(input).map_err(|e| anyhow::anyhow!(e))?;
+    reader.decode(output).map_err(|e| anyhow::anyhow!(e))?;
+    if reader.is_finished() {
+        Ok(())
+    } else {
+        Err(anyhow::anyhow!(
+            "Input not decoded completely (buffer size too small?)"
+        ))
+    }
+}
+
+pub fn b64_encode<'o>(input: &[u8], output: &'o mut [u8]) -> anyhow::Result<&'o str> {
+    let mut writer = B64Writer::<Base64>::new(output).map_err(|e| anyhow::anyhow!(e))?;
+    writer.encode(input).map_err(|e| anyhow::anyhow!(e))?;
+    writer.finish().map_err(|e| anyhow::anyhow!(e))
 }

--- a/util/src/b64.rs
+++ b/util/src/b64.rs
@@ -33,7 +33,13 @@ impl<T: AsRef<[u8]>> B64Display for T {
 
 pub fn b64_decode(input: &[u8], output: &mut [u8]) -> anyhow::Result<()> {
     let mut reader = B64Reader::<Base64>::new(input).map_err(|e| anyhow::anyhow!(e))?;
-    reader.decode(output).map_err(|e| anyhow::anyhow!(e))?;
+    match reader.decode(output) {
+        Ok(_) => (),
+        Err(base64ct::Error::InvalidLength) => (),
+        Err(e) => {
+            return Err(anyhow::anyhow!(e));
+        }
+    }
     if reader.is_finished() {
         Ok(())
     } else {
@@ -47,4 +53,78 @@ pub fn b64_encode<'o>(input: &[u8], output: &'o mut [u8]) -> anyhow::Result<&'o 
     let mut writer = B64Writer::<Base64>::new(output).map_err(|e| anyhow::anyhow!(e))?;
     writer.encode(input).map_err(|e| anyhow::anyhow!(e))?;
     writer.finish().map_err(|e| anyhow::anyhow!(e))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_b64_encode() {
+        let input = b"Hello, World!";
+        let mut output = [0u8; 20];
+        let result = b64_encode(input, &mut output);
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap(), "SGVsbG8sIFdvcmxkIQ==");
+    }
+
+    #[test]
+    fn test_b64_encode_small_buffer() {
+        let input = b"Hello, World!";
+        let mut output = [0u8; 10]; // Small output buffer
+        let result = b64_encode(input, &mut output);
+        assert!(result.is_err());
+        assert_eq!(result.unwrap_err().to_string(), "invalid Base64 length");
+    }
+
+    #[test]
+    fn test_b64_encode_empty_buffer() {
+        let input = b"";
+        let mut output = [0u8; 16];
+        let result = b64_encode(input, &mut output);
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap(), "");
+    }
+
+    #[test]
+    fn test_b64_decode() {
+        let input = b"SGVsbG8sIFdvcmxkIQ==";
+        let mut output = [0u8; 1000];
+        b64_decode(input, &mut output).unwrap();
+        assert_eq!(&output[..13], b"Hello, World!");
+    }
+
+    #[test]
+    fn test_b64_decode_small_buffer() {
+        let input = b"SGVsbG8sIFdvcmxkIQ==";
+        let mut output = [0u8; 10]; // Small output buffer
+        let result = b64_decode(input, &mut output);
+        assert!(result.is_err());
+        assert_eq!(
+            result.unwrap_err().to_string(),
+            "Input not decoded completely (buffer size too small?)"
+        );
+    }
+
+    #[test]
+    fn test_b64_decode_empty_buffer() {
+        let input = b"";
+        let mut output = [0u8; 16];
+        let result = b64_decode(input, &mut output);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_fmt_b64() {
+        let input = b"Hello, World!";
+        let result = input.fmt_b64::<20>().to_string();
+        assert_eq!(result, "SGVsbG8sIFdvcmxkIQ==");
+    }
+
+    #[test]
+    fn test_fmt_b64_empty_input() {
+        let input = b"";
+        let result = input.fmt_b64::<16>().to_string();
+        assert_eq!(result, "");
+    }
 }

--- a/util/src/b64.rs
+++ b/util/src/b64.rs
@@ -1,8 +1,4 @@
-use base64ct::{
-    Base64,
-    Decoder as B64Reader,
-    Encoder as B64Writer,
-};
+use base64ct::{Base64, Decoder as B64Reader, Encoder as B64Writer};
 use zeroize::Zeroize;
 
 use std::fmt::Display;

--- a/util/src/file.rs
+++ b/util/src/file.rs
@@ -30,6 +30,30 @@ pub fn fopen_r<P: AsRef<Path>>(path: P) -> std::io::Result<File> {
         .open(path)
 }
 
+pub trait ReadSliceToEnd {
+    type Error;
+
+    fn read_slice_to_end(&mut self, buf: &mut [u8]) -> Result<usize, Self::Error>;
+}
+
+impl<R: Read> ReadSliceToEnd for R {
+    type Error = anyhow::Error;
+
+    fn read_slice_to_end(&mut self, buf: &mut [u8]) -> anyhow::Result<usize> {
+        let mut dummy = [0u8; 8];
+        let mut read = 0;
+        while read < buf.len() {
+            let bytes_read = self.read(&mut buf[read..])?;
+            if bytes_read == 0 {
+                break;
+            }
+            read += bytes_read;
+        }
+        ensure!(self.read(&mut dummy)? == 0, "File too long!");
+        Ok(read)
+    }
+}
+
 pub trait ReadExactToEnd {
     type Error;
 
@@ -58,13 +82,36 @@ pub trait LoadValue {
 pub trait LoadValueB64 {
     type Error;
 
-    fn load_b64<P: AsRef<Path>>(path: P) -> Result<Self, Self::Error>
+    fn load_b64<const F: usize, P: AsRef<Path>>(path: P) -> Result<Self, Self::Error>
     where
         Self: Sized;
+}
+
+pub trait StoreValueB64 {
+    type Error;
+
+    fn store_b64<const F: usize, P: AsRef<Path>>(&self, path: P) -> Result<(), Self::Error>
+    where
+        Self: Sized;
+}
+
+pub trait StoreValueB64Writer {
+    type Error;
+
+    fn store_b64_writer<const F: usize, W: std::io::Write>(
+        &self,
+        writer: W,
+    ) -> Result<(), Self::Error>;
 }
 
 pub trait StoreValue {
     type Error;
 
     fn store<P: AsRef<Path>>(&self, path: P) -> Result<(), Self::Error>;
+}
+
+pub trait DisplayValueB64 {
+    type Error;
+
+    fn display_b64<'o>(&self, output: &'o mut [u8]) -> Result<&'o str, Self::Error>;
 }


### PR DESCRIPTION
Investigating #261 , I found `base64`'s `Encoder` and `Decoder` implements the `Read` and `Write` traits. However, they use their own built in buffer, which can store unprotected copies of secrets.

The [`base64ct` crate](https://docs.rs/base64ct/latest/base64ct/) is built  and used for cryptographic applications, and has no-std support (stack only) and minimal buffering AFAICT. This allows us to use `Secret` and avoid intermediate buffers that are on the heap or copies stored elsewhere in crates structs.

