### PR TITLE
feat(rosenpass): Add wireguard-broker interface in AppServer

### DIFF
--- a/.github/workflows/dependent-issues.yml
+++ b/.github/workflows/dependent-issues.yml
@@ -25,6 +25,10 @@ on:
 
 jobs:
   check:
+    permissions:
+      issues: write
+      pull-requests: write
+      statuses: write
     runs-on: ubuntu-latest
     steps:
       - uses: z0al/dependent-issues@v1

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -109,9 +109,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.83"
+version = "1.0.85"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25bdb32cbbdce2b519a9cd7df3a678443100e265d5e25ca763b7572a5104f5f3"
+checksum = "27a4bd113ab6da4cd0f521068a6e2ee1065eab54107266a11835d02c8ec86a37"
 dependencies = [
  "backtrace",
 ]
@@ -428,6 +428,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "cobs"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67ba02a97a2bd10f4b59b25c7973101c79642302776489e030cd13cdab09ed15"
+
+[[package]]
 name = "colorchoice"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -730,6 +736,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a47c1c47d2f5964e29c61246e81db715514cd532db6b5116a25ea3c03d6780a2"
 
 [[package]]
+name = "embedded-io"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef1a6892d9eef45c8fa6b9e0086428a2cca8491aca8f787c534a3d6d0bcb3ced"
+
+[[package]]
 name = "env_logger"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -954,6 +966,7 @@ dependencies = [
  "atomic-polyfill",
  "hash32",
  "rustc_version",
+ "serde",
  "spin",
  "stable_deref_trait",
 ]
@@ -1516,6 +1529,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "postcard"
+version = "1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a55c51ee6c0db07e68448e336cf8ea4131a620edefebf9893e759b2d793420f8"
+dependencies = [
+ "cobs",
+ "embedded-io",
+ "heapless",
+ "serde",
+]
+
+[[package]]
 name = "ppv-lite86"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1667,6 +1692,7 @@ dependencies = [
  "rosenpass-secret-memory",
  "rosenpass-to",
  "rosenpass-util",
+ "rosenpass-wireguard-broker",
  "serde",
  "serial_test",
  "stacker",
@@ -1772,10 +1798,13 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "clap 4.5.4",
+ "derive_builder 0.20.0",
  "env_logger",
  "log",
  "mio",
+ "postcard",
  "rand",
+ "rosenpass-secret-memory",
  "rosenpass-to",
  "rosenpass-util",
  "thiserror",
@@ -1802,6 +1831,7 @@ dependencies = [
  "rosenpass-ciphers",
  "rosenpass-secret-memory",
  "rosenpass-util",
+ "rosenpass-wireguard-broker",
  "rtnetlink",
  "stacker",
  "tempfile",
@@ -2118,18 +2148,18 @@ checksum = "23d434d3f8967a09480fb04132ebe0a3e088c173e6d0ee7897abbdf4eab0f8b9"
 
 [[package]]
 name = "thiserror"
-version = "1.0.60"
+version = "1.0.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "579e9083ca58dd9dcf91a9923bb9054071b9ebbd800b342194c9feb0ee89fc18"
+checksum = "c546c80d6be4bc6a00c0f01730c08df82eaa7a7a61f11d656526506112cc1709"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.60"
+version = "1.0.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2470041c06ec3ac1ab38d0356a6119054dedaea53e12fbefc0de730a1c08524"
+checksum = "46c3384250002a6d5af4d114f2845d37b57521033f30d5c3f46c4d70e1197533"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1906,18 +1906,18 @@ checksum = "92d43fe69e652f3df9bdc2b85b2854a0825b86e4fb76bc44d945137d053639ca"
 
 [[package]]
 name = "serde"
-version = "1.0.201"
+version = "1.0.202"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "780f1cebed1629e4753a1a38a3c72d30b97ec044f0aef68cb26650a3c5cf363c"
+checksum = "226b61a0d411b2ba5ff6d7f73a476ac4f8bb900373459cd00fab8512828ba395"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.201"
+version = "1.0.202"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5e405930b9796f1c00bee880d03fc7e0bb4b9a11afc776885ffe84320da2865"
+checksum = "6048858004bcff69094cd972ed40a32500f153bd3be9f716b2eed2e8217c4838"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,11 +34,12 @@ rosenpass-ciphers = { path = "ciphers" }
 rosenpass-to = { path = "to" }
 rosenpass-secret-memory = { path = "secret-memory" }
 rosenpass-oqs = { path = "oqs" }
+rosenpass-wireguard-broker = { path = "wireguard-broker" }
 doc-comment = "0.3.3"
 base64ct = {version = "1.6.0", default-features=false}
 zeroize = "1.7.0"
 memoffset = "0.9.1"
-thiserror = "1.0.60"
+thiserror = "1.0.61"
 paste = "1.0.15"
 env_logger = "0.10.2"
 toml = "0.7.8"
@@ -51,7 +52,7 @@ log = { version = "0.4.21" }
 clap = { version = "4.5.4", features = ["derive"] }
 serde = { version = "1.0.202", features = ["derive"] }
 arbitrary = { version = "1.3.2", features = ["derive"] }
-anyhow = { version = "1.0.83", features = ["backtrace", "std"] }
+anyhow = { version = "1.0.85", features = ["backtrace", "std"] }
 mio = { version = "0.8.11", features = ["net", "os-poll"] }
 oqs-sys = { version = "0.9.1", default-features = false, features = ['classic_mceliece', 'kyber']  }
 blake2 = "0.10.6"
@@ -60,6 +61,7 @@ zerocopy = { version = "0.7.34", features = ["derive"] }
 home = "0.5.9"
 derive_builder = "0.20.0"
 tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }
+postcard= {version = "1.0.8", features = ["alloc"]}
 
 #Dev dependencies
 serial_test = "3.1.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,7 +49,7 @@ rand = "0.8.5"
 typenum = "1.17.0"
 log = { version = "0.4.21" }
 clap = { version = "4.5.4", features = ["derive"] }
-serde = { version = "1.0.201", features = ["derive"] }
+serde = { version = "1.0.202", features = ["derive"] }
 arbitrary = { version = "1.3.2", features = ["derive"] }
 anyhow = { version = "1.0.83", features = ["backtrace", "std"] }
 mio = { version = "0.8.11", features = ["net", "os-poll"] }

--- a/rosenpass/Cargo.toml
+++ b/rosenpass/Cargo.toml
@@ -39,6 +39,7 @@ rand = { workspace = true }
 zerocopy = { workspace = true }
 home = { workspace = true }
 derive_builder = {workspace = true}
+rosenpass-wireguard-broker = {workspace = true}
 
 [build-dependencies]
 anyhow = { workspace = true }
@@ -48,3 +49,6 @@ criterion = { workspace = true }
 test_bin = { workspace = true }
 stacker = { workspace = true }
 serial_test = {workspace = true}
+
+[features]
+enable_broker_api = ["rosenpass-wireguard-broker/enable_broker_api"]

--- a/rosenpass/src/config.rs
+++ b/rosenpass/src/config.rs
@@ -135,7 +135,7 @@ impl Rosenpass {
         }
 
         // add path to "self"
-        config.config_file_path = p.as_ref().to_owned();
+        p.as_ref().clone_into(&mut config.config_file_path);
 
         // return
         Ok(config)

--- a/rosenpass/src/protocol.rs
+++ b/rosenpass/src/protocol.rs
@@ -2295,7 +2295,7 @@ mod test {
                         .secret(),
                 )
                 .unwrap()
-                .mix(&ip_addr_port_a.encode())
+                .mix(ip_addr_port_a.encode())
                 .unwrap()
                 .into_value()[..16]
                 .to_vec();

--- a/rp/Cargo.toml
+++ b/rp/Cargo.toml
@@ -20,6 +20,7 @@ rosenpass-ciphers = { workspace = true }
 rosenpass-cipher-traits = { workspace = true }
 rosenpass-secret-memory = { workspace = true }
 rosenpass-util = { workspace = true }
+rosenpass-wireguard-broker = {workspace = true}
 
 tokio = {workspace = true}
 

--- a/rp/src/cli.rs
+++ b/rp/src/cli.rs
@@ -267,7 +267,7 @@ mod tests {
 
     #[inline]
     fn parse(arr: &[&str]) -> Result<Cli, String> {
-        Cli::parse(arr.into_iter().map(|x| x.to_string()).peekable())
+        Cli::parse(arr.iter().map(|x| x.to_string()).peekable())
     }
 
     #[inline]
@@ -300,7 +300,7 @@ mod tests {
         assert!(cli.is_ok());
         let cli = cli.unwrap();
 
-        assert_eq!(cli.verbose, false);
+        assert!(!cli.verbose);
         assert!(matches!(cli.command, Some(Command::GenKey { .. })));
 
         match cli.command {
@@ -324,7 +324,7 @@ mod tests {
         assert!(cli.is_ok());
         let cli = cli.unwrap();
 
-        assert_eq!(cli.verbose, false);
+        assert!(!cli.verbose);
         assert!(matches!(cli.command, Some(Command::PubKey { .. })));
 
         match cli.command {
@@ -365,7 +365,7 @@ mod tests {
         assert!(cli.is_ok());
         let cli = cli.unwrap();
 
-        assert_eq!(cli.verbose, false);
+        assert!(!cli.verbose);
         assert!(matches!(cli.command, Some(Command::Exchange(_))));
 
         match cli.command {
@@ -391,7 +391,7 @@ mod tests {
         assert!(cli.is_ok());
         let cli = cli.unwrap();
 
-        assert_eq!(cli.verbose, false);
+        assert!(!cli.verbose);
         assert!(matches!(cli.command, Some(Command::Exchange(_))));
 
         match cli.command {
@@ -431,7 +431,7 @@ mod tests {
         assert!(cli.is_ok());
         let cli = cli.unwrap();
 
-        assert_eq!(cli.verbose, false);
+        assert!(!cli.verbose);
         assert!(matches!(cli.command, Some(Command::Exchange(_))));
 
         match cli.command {

--- a/secret-memory/src/public.rs
+++ b/secret-memory/src/public.rs
@@ -162,8 +162,8 @@ impl<const N: usize> StoreValueB64Writer for Public<N> {
         mut writer: W,
     ) -> Result<(), Self::Error> {
         let mut f = [0u8; F];
-        let encoded_str = b64_encode(&self.value, &mut f)
-            .with_context(|| "Could not encode secret to base64")?;
+        let encoded_str =
+            b64_encode(&self.value, &mut f).with_context(|| "Could not encode secret to base64")?;
 
         writer
             .write_all(encoded_str.as_bytes())

--- a/secret-memory/src/public.rs
+++ b/secret-memory/src/public.rs
@@ -163,11 +163,11 @@ impl<const N: usize> StoreValueB64Writer for Public<N> {
     ) -> Result<(), Self::Error> {
         let mut f = [0u8; F];
         let encoded_str = b64_encode(&self.value, &mut f)
-            .with_context(|| format!("Could not encode secret to base64"))?;
+            .with_context(|| "Could not encode secret to base64")?;
 
         writer
             .write_all(encoded_str.as_bytes())
-            .with_context(|| format!("Could not write base64 to writer"))?;
+            .with_context(|| "Could not write base64 to writer")?;
         Ok(())
     }
 }

--- a/secret-memory/src/secret.rs
+++ b/secret-memory/src/secret.rs
@@ -295,11 +295,11 @@ impl<const N: usize> StoreValueB64Writer for Secret<N> {
     fn store_b64_writer<const F: usize, W: Write>(&self, mut writer: W) -> anyhow::Result<()> {
         let mut f: Secret<F> = Secret::random();
         let encoded_str = b64_encode(self.secret(), f.secret_mut())
-            .with_context(|| format!("Could not encode secret to base64"))?;
+            .with_context(|| "Could not encode secret to base64")?;
 
         writer
             .write_all(encoded_str.as_bytes())
-            .with_context(|| format!("Could not write base64 to writer"))?;
+            .with_context(|| "Could not write base64 to writer")?;
         f.zeroize();
         Ok(())
     }

--- a/util/src/b64.rs
+++ b/util/src/b64.rs
@@ -8,7 +8,7 @@ pub struct B64DisplayHelper<'a, const F: usize>(&'a [u8]);
 impl<const F: usize> Display for B64DisplayHelper<'_, F> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut bytes = [0u8; F];
-        let string = b64_encode(&self.0, &mut bytes).map_err(|_| std::fmt::Error)?;
+        let string = b64_encode(self.0, &mut bytes).map_err(|_| std::fmt::Error)?;
         let result = f.write_str(string);
         bytes.zeroize();
         result
@@ -16,17 +16,17 @@ impl<const F: usize> Display for B64DisplayHelper<'_, F> {
 }
 
 pub trait B64Display {
-    fn fmt_b64<'o, const F: usize>(&'o self) -> B64DisplayHelper<'o, F>;
+    fn fmt_b64<const F: usize>(&self) -> B64DisplayHelper<F>;
 }
 
 impl B64Display for [u8] {
-    fn fmt_b64<'o, const F: usize>(&'o self) -> B64DisplayHelper<'o, F> {
+    fn fmt_b64<const F: usize>(&self) -> B64DisplayHelper<F> {
         B64DisplayHelper(self)
     }
 }
 
 impl<T: AsRef<[u8]>> B64Display for T {
-    fn fmt_b64<'o, const F: usize>(&'o self) -> B64DisplayHelper<'o, F> {
+    fn fmt_b64<const F: usize>(&self) -> B64DisplayHelper<F> {
         B64DisplayHelper(self.as_ref())
     }
 }

--- a/wireguard-broker/Cargo.toml
+++ b/wireguard-broker/Cargo.toml
@@ -12,6 +12,7 @@ readme = "readme.md"
 [dependencies]
 thiserror = { workspace = true }
 zerocopy = { workspace = true }
+rosenpass-secret-memory = {workspace = true}
 
 # Privileged only
 wireguard-uapi = { workspace = true }
@@ -23,6 +24,8 @@ anyhow = { workspace = true }
 clap = { workspace = true }
 env_logger = { workspace = true }
 log = { workspace = true }
+derive_builder = {workspace = true}
+postcard = {workspace = true}
 
 # Mio broker client
 mio = { workspace = true }
@@ -32,18 +35,18 @@ rosenpass-util = { workspace = true }
 rand = {workspace = true}
 
 [features]
-enable_broker=[]
+enable_broker_api=[]
 
 [[bin]]
 name = "rosenpass-wireguard-broker-privileged"
 path = "src/bin/priviledged.rs"
 test = false
 doc = false
-required-features=["enable_broker"]
+required-features=["enable_broker_api"]
 
 [[bin]]
 name = "rosenpass-wireguard-broker-socket-handler"
 test = false
 path = "src/bin/socket_handler.rs"
 doc = false
-required-features=["enable_broker"]
+required-features=["enable_broker_api"]

--- a/wireguard-broker/src/api/config.rs
+++ b/wireguard-broker/src/api/config.rs
@@ -1,0 +1,43 @@
+use crate::{SerializedBrokerConfig, WG_KEY_LEN, WG_PEER_LEN};
+use derive_builder::Builder;
+use rosenpass_secret_memory::{Public, Secret};
+
+#[derive(Builder)]
+#[builder(pattern = "mutable")]
+//TODO: Use generics for iface, add additional params
+pub struct NetworkBrokerConfig<'a> {
+    pub iface: &'a str,
+    pub peer_id: &'a Public<WG_PEER_LEN>,
+    pub psk: &'a Secret<WG_KEY_LEN>,
+}
+
+impl<'a> Into<SerializedBrokerConfig<'a>> for NetworkBrokerConfig<'a> {
+    fn into(self) -> SerializedBrokerConfig<'a> {
+        SerializedBrokerConfig {
+            interface: self.iface.as_bytes(),
+            peer_id: self.peer_id,
+            psk: self.psk,
+            additional_params: &[],
+        }
+    }
+}
+
+#[derive(thiserror::Error, Debug, Clone, Eq, PartialEq)]
+pub enum NetworkBrokerConfigErr {
+    #[error("Interface")]
+    Interface,
+}
+
+impl<'a> TryFrom<SerializedBrokerConfig<'a>> for NetworkBrokerConfig<'a> {
+    type Error = NetworkBrokerConfigErr;
+
+    fn try_from(value: SerializedBrokerConfig<'a>) -> Result<Self, Self::Error> {
+        let iface =
+            std::str::from_utf8(value.interface).map_err(|_| NetworkBrokerConfigErr::Interface)?;
+        Ok(Self {
+            iface,
+            peer_id: value.peer_id,
+            psk: value.psk,
+        })
+    }
+}

--- a/wireguard-broker/src/api/mod.rs
+++ b/wireguard-broker/src/api/mod.rs
@@ -1,4 +1,4 @@
 pub mod client;
-pub mod mio_client;
+pub mod config;
 pub mod msgs;
 pub mod server;

--- a/wireguard-broker/src/bin/priviledged.rs
+++ b/wireguard-broker/src/bin/priviledged.rs
@@ -3,7 +3,7 @@ use std::result::Result;
 
 use rosenpass_wireguard_broker::api::msgs;
 use rosenpass_wireguard_broker::api::server::BrokerServer;
-use rosenpass_wireguard_broker::netlink as wg;
+use rosenpass_wireguard_broker::brokers::netlink as wg;
 
 #[derive(thiserror::Error, Debug)]
 pub enum BrokerAppError {

--- a/wireguard-broker/src/brokers/mod.rs
+++ b/wireguard-broker/src/brokers/mod.rs
@@ -1,0 +1,6 @@
+#[cfg(feature = "enable_broker_api")]
+pub mod mio_client;
+#[cfg(feature = "enable_broker_api")]
+pub mod netlink;
+
+pub mod native_unix;

--- a/wireguard-broker/src/brokers/native_unix.rs
+++ b/wireguard-broker/src/brokers/native_unix.rs
@@ -1,0 +1,177 @@
+use std::fmt::Debug;
+use std::process::{Command, Stdio};
+use std::thread;
+
+use derive_builder::Builder;
+use log::{debug, error};
+use postcard::{from_bytes, to_allocvec};
+use rosenpass_secret_memory::{Public, Secret};
+use rosenpass_util::b64::b64_decode;
+use rosenpass_util::{b64::B64Display, file::StoreValueB64Writer};
+
+use crate::{SerializedBrokerConfig, WireGuardBroker, WireguardBrokerCfg, WireguardBrokerMio};
+use crate::{WG_KEY_LEN, WG_PEER_LEN};
+
+const MAX_B64_KEY_SIZE: usize = WG_KEY_LEN * 5 / 3;
+const MAX_B64_PEER_ID_SIZE: usize = WG_PEER_LEN * 5 / 3;
+
+#[derive(Debug)]
+pub struct NativeUnixBroker {}
+
+impl Default for NativeUnixBroker {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl NativeUnixBroker {
+    pub fn new() -> Self {
+        Self {}
+    }
+}
+
+impl WireGuardBroker for NativeUnixBroker {
+    type Error = anyhow::Error;
+
+    fn set_psk(&mut self, config: SerializedBrokerConfig<'_>) -> Result<(), Self::Error> {
+        let config: NativeUnixBrokerConfig = config.try_into()?;
+
+        let peer_id = format!("{}", config.peer_id.fmt_b64::<MAX_B64_PEER_ID_SIZE>());
+
+        let mut child = match Command::new("wg")
+            .arg("set")
+            .arg(config.interface)
+            .arg("peer")
+            .arg(peer_id)
+            .arg("preshared-key")
+            .arg("/dev/stdin")
+            .stdin(Stdio::piped())
+            .args(config.extra_params)
+            .spawn()
+        {
+            Ok(x) => x,
+            Err(e) => {
+                if e.kind() == std::io::ErrorKind::NotFound {
+                    anyhow::bail!("Could not find wg command");
+                } else {
+                    return Err(anyhow::Error::new(e));
+                }
+            }
+        };
+        if let Err(e) = config
+            .psk
+            .store_b64_writer::<MAX_B64_KEY_SIZE, _>(child.stdin.take().unwrap())
+        {
+            error!("could not write psk to wg: {:?}", e);
+        }
+
+        thread::spawn(move || {
+            let status = child.wait();
+
+            if let Ok(status) = status {
+                if status.success() {
+                    debug!("successfully passed psk to wg")
+                } else {
+                    error!("could not pass psk to wg {:?}", status)
+                }
+            } else {
+                error!("wait failed: {:?}", status)
+            }
+        });
+        Ok(())
+    }
+}
+
+impl WireguardBrokerMio for NativeUnixBroker {
+    type MioError = anyhow::Error;
+
+    fn register(
+        &mut self,
+        _registry: &mio::Registry,
+        _token: mio::Token,
+    ) -> Result<(), Self::MioError> {
+        Ok(())
+    }
+
+    fn process_poll(&mut self) -> Result<(), Self::MioError> {
+        Ok(())
+    }
+
+    fn unregister(&mut self, _registry: &mio::Registry) -> Result<(), Self::MioError> {
+        Ok(())
+    }
+}
+
+#[derive(Debug, Builder)]
+#[builder(pattern = "mutable")]
+pub struct NativeUnixBrokerConfigBase {
+    pub interface: String,
+    pub peer_id: Public<WG_PEER_LEN>,
+    #[builder(private)]
+    pub extra_params: Vec<u8>,
+}
+
+impl NativeUnixBrokerConfigBaseBuilder {
+    pub fn peer_id_b64(
+        &mut self,
+        peer_id: &str,
+    ) -> Result<&mut Self, NativeUnixBrokerConfigBaseBuilderError> {
+        let mut peer_id_b64 = Public::<WG_PEER_LEN>::zero();
+        b64_decode(peer_id.as_bytes(), &mut peer_id_b64.value).map_err(|_e| {
+            NativeUnixBrokerConfigBaseBuilderError::ValidationError(
+                "Failed to parse peer id b64".to_string(),
+            )
+        })?;
+        Ok(self.peer_id(peer_id_b64))
+    }
+
+    pub fn extra_params_ser(
+        &mut self,
+        extra_params: &Vec<String>,
+    ) -> Result<&mut Self, NativeUnixBrokerConfigBuilderError> {
+        let params = to_allocvec(extra_params).map_err(|_e| {
+            NativeUnixBrokerConfigBuilderError::ValidationError(
+                "Failed to parse extra params".to_string(),
+            )
+        })?;
+        Ok(self.extra_params(params))
+    }
+}
+
+impl WireguardBrokerCfg for NativeUnixBrokerConfigBase {
+    fn create_config<'a>(&'a self, psk: &'a Secret<WG_KEY_LEN>) -> SerializedBrokerConfig<'a> {
+        SerializedBrokerConfig {
+            interface: self.interface.as_bytes(),
+            peer_id: &self.peer_id,
+            psk,
+            additional_params: &self.extra_params,
+        }
+    }
+}
+
+#[derive(Debug, Builder)]
+#[builder(pattern = "mutable")]
+pub struct NativeUnixBrokerConfig<'a> {
+    pub interface: &'a str,
+    pub peer_id: &'a Public<WG_PEER_LEN>,
+    pub psk: &'a Secret<WG_KEY_LEN>,
+    pub extra_params: Vec<String>,
+}
+
+impl<'a> TryFrom<SerializedBrokerConfig<'a>> for NativeUnixBrokerConfig<'a> {
+    type Error = anyhow::Error;
+
+    fn try_from(value: SerializedBrokerConfig<'a>) -> Result<Self, Self::Error> {
+        let iface = std::str::from_utf8(value.interface)
+            .map_err(|_| anyhow::Error::msg("Interface UTF8 decoding error"))?;
+
+        let extra_params: Vec<String> =
+            from_bytes(value.additional_params).map_err(anyhow::Error::new)?;
+        Ok(Self {
+            interface: iface,
+            peer_id: value.peer_id,
+            psk: value.psk,
+            extra_params,
+        })
+    }
+}

--- a/wireguard-broker/src/lib.rs
+++ b/wireguard-broker/src/lib.rs
@@ -1,19 +1,40 @@
-#[cfg(feature = "enable_broker")]
-use std::result::Result;
+use rosenpass_secret_memory::{Public, Secret};
+use std::{fmt::Debug, result::Result};
 
-#[cfg(feature = "enable_broker")]
-pub trait WireGuardBroker {
+pub const WG_KEY_LEN: usize = 32;
+pub const WG_PEER_LEN: usize = 32;
+pub trait WireGuardBroker: Debug {
     type Error;
-
-    fn set_psk(
-        &mut self,
-        interface: &str,
-        peer_id: [u8; 32],
-        psk: [u8; 32],
-    ) -> Result<(), Self::Error>;
+    fn set_psk(&mut self, config: SerializedBrokerConfig<'_>) -> Result<(), Self::Error>;
 }
 
-#[cfg(feature = "enable_broker")]
+pub trait WireguardBrokerCfg: Debug {
+    fn create_config<'a>(&'a self, psk: &'a Secret<WG_KEY_LEN>) -> SerializedBrokerConfig<'a>;
+}
+
+#[derive(Debug)]
+pub struct SerializedBrokerConfig<'a> {
+    pub interface: &'a [u8],
+    pub peer_id: &'a Public<WG_PEER_LEN>,
+    pub psk: &'a Secret<WG_KEY_LEN>,
+    pub additional_params: &'a [u8],
+}
+
+pub trait WireguardBrokerMio: WireGuardBroker {
+    type MioError;
+    /// Register interested events for mio::Registry
+    fn register(
+        &mut self,
+        registry: &mio::Registry,
+        token: mio::Token,
+    ) -> Result<(), Self::MioError>;
+    /// Run after a mio::poll operation
+    fn process_poll(&mut self) -> Result<(), Self::MioError>;
+
+    fn unregister(&mut self, registry: &mio::Registry) -> Result<(), Self::MioError>;
+}
+
+#[cfg(feature = "enable_broker_api")]
 pub mod api;
-#[cfg(feature = "enable_broker")]
-pub mod netlink;
+
+pub mod brokers;


### PR DESCRIPTION
Dynamically dispatch WireguardBrokerMio trait in AppServer. Also allows for mio event registration and poll processing, similar to dev/broker-architecture branch

Tested basic setup of connections between two devices