### PR TITLE
chore: Add write permissions in dependent-issues workflow

### DIFF
--- a/.github/workflows/dependent-issues.yml
+++ b/.github/workflows/dependent-issues.yml
@@ -25,6 +25,10 @@ on:
 
 jobs:
   check:
+    permissions:
+      issues: write
+      pull-requests: write
+      statuses: write
     runs-on: ubuntu-latest
     steps:
       - uses: z0al/dependent-issues@v1


### PR DESCRIPTION
Dependent issues needs permissions to access issues, PRs, etc.