### PR TITLE
Warn only if neither peer nor outfile is defined

### DIFF
--- a/rosenpass/src/app_server.rs
+++ b/rosenpass/src/app_server.rs
@@ -213,7 +213,7 @@ impl AppPeerPtr {
             let config = broker.peer_cfg.create_config(psk);
             let broker = server.brokers.store.get_mut(&broker.ptr().0).unwrap();
             broker.set_psk(config)?;
-        } else {
+        } else if server.peers[self.0].outfile.is_none() {
             log::warn!("No broker peer found for peer {}", self.0);
         }
         Ok(())


### PR DESCRIPTION
Right now a warning message is logged if no Wireguard peer is defined. This is misleading in cases where the outfile is used instead.