### PR TITLE
chore: Remove libsodium references in nix flake, ci

### DIFF
--- a/.github/workflows/qc.yaml
+++ b/.github/workflows/qc.yaml
@@ -46,8 +46,6 @@ jobs:
             ~/.cargo/git/db/
             target/
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-      - name: Install libsodium
-        run: sudo apt-get install -y libsodium-dev
         # liboqs requires quite a lot of stack memory, thus we adjust
         # the default stack size picked for new threads (which is used
         # by `cargo test`) to be _big enough_. Setting it to 8 MiB
@@ -87,8 +85,6 @@ jobs:
             target/
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
       - run: rustup component add clippy
-      - name: Install libsodium
-        run: sudo apt-get install -y libsodium-dev
       - uses: actions-rs/clippy-check@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -108,8 +104,6 @@ jobs:
             target/
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
       - run: rustup component add clippy
-      - name: Install libsodium
-        run: sudo apt-get install -y libsodium-dev
       # `--no-deps` used as a workaround for a rust compiler bug. See:
       # - https://github.com/rosenpass/rosenpass/issues/62
       # - https://github.com/rust-lang/rust/issues/108378
@@ -128,8 +122,6 @@ jobs:
             ~/.cargo/git/db/
             target/
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-      - name: Install libsodium
-        run: sudo apt-get install -y libsodium-dev
         # liboqs requires quite a lot of stack memory, thus we adjust
         # the default stack size picked for new threads (which is used
         # by `cargo test`) to be _big enough_. Setting it to 8 MiB
@@ -171,8 +163,6 @@ jobs:
             ~/.cargo/git/db/
             target/
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-      - name: Install libsodium
-        run: sudo apt-get install -y libsodium-dev
       - name: Install nightly toolchain
         run: |
           rustup toolchain install nightly

--- a/cipher-traits/readme.md
+++ b/cipher-traits/readme.md
@@ -1,4 +1,4 @@
-# Rosenpass internal libsodium bindings
+# Rosenpass internal cryptographic traits
 
 Rosenpass internal library providing traits for cryptographic primitives.
 

--- a/flake.nix
+++ b/flake.nix
@@ -120,11 +120,10 @@
                     p.stdenv.cc
                     cmake # for oqs build in the oqs-sys crate
                     mandoc # for the built-in manual
-                    pkg-config # let libsodium-sys-stable find libsodium
                     removeReferencesTo
                     rustPlatform.bindgenHook # for C-bindings in the crypto libs
                   ];
-                  buildInputs = with p; [ bash libsodium ];
+                  buildInputs = with p; [ bash ];
 
                   override = x: {
                     preBuild =
@@ -226,11 +225,10 @@
                     p.stdenv.cc
                     cmake # for oqs build in the oqs-sys crate
                     mandoc # for the built-in manual
-                    pkg-config # let libsodium-sys-stable find libsodium
                     removeReferencesTo
                     rustPlatform.bindgenHook # for C-bindings in the crypto libs
                   ];
-                  buildInputs = with p; [ bash libsodium ];
+                  buildInputs = with p; [ bash ];
 
                   override = x: {
                     preBuild =

--- a/readme.md
+++ b/readme.md
@@ -25,7 +25,7 @@ Follow [quick start instructions](https://rosenpass.eu/#start) to get a VPN up a
 
 ## Software architecture
 
-The [rosenpass tool](./src/) is written in Rust and uses liboqs[^liboqs] and libsodium[^libsodium]. The tool establishes a symmetric key and provides it to WireGuard. Since it supplies WireGuard with key through the PSK feature using Rosenpass+WireGuard is cryptographically no less secure than using WireGuard on its own ("hybrid security"). Rosenpass refreshes the symmetric key every two minutes.
+The [rosenpass tool](./src/) is written in Rust and uses liboqs[^liboqs]. The tool establishes a symmetric key and provides it to WireGuard. Since it supplies WireGuard with key through the PSK feature using Rosenpass+WireGuard is cryptographically no less secure than using WireGuard on its own ("hybrid security"). Rosenpass refreshes the symmetric key every two minutes.
 
 As with any application a small risk of critical security issues (such as buffer overflows, remote code execution) exists; the Rosenpass application is written in the Rust programming language which is much less prone to such issues. Rosenpass can also write keys to files instead of supplying them to WireGuard With a bit of scripting the stand alone mode of the implementation can be used to run the application in a Container, VM or on another host. This mode can also be used to integrate tools other than WireGuard with Rosenpass.
 
@@ -59,7 +59,6 @@ The code uses a variety of optimizations to speed up analysis such as using secr
 A wrapper script provides instant feedback about which queries execute as expected in color: A red cross if a query fails and a green check if it succeeds.
 
 [^liboqs]: https://openquantumsafe.org/liboqs/
-[^libsodium]: https://doc.libsodium.org/
 [^wg]: https://www.wireguard.com/
 [^pqwg]: https://eprint.iacr.org/2020/379
 [^pqwg-statedis]: Unless supplied with a pre-shared-key, but this defeats the purpose of a key exchange protocol


### PR DESCRIPTION
Fixes #328 