### PR TITLE
drop unused import of WG_B64_LEN

### DIFF
--- a/rp/src/exchange.rs
+++ b/rp/src/exchange.rs
@@ -2,7 +2,9 @@ use std::{net::SocketAddr, path::PathBuf};
 
 use anyhow::Result;
 
+#[cfg(any(target_os = "linux", target_os = "freebsd"))]
 use crate::key::WG_B64_LEN;
+
 #[derive(Default)]
 pub struct ExchangePeer {
     pub public_keys_dir: PathBuf,


### PR DESCRIPTION
This causes warnings