### PR TITLE
Add `rosenpass-user` and `broker-user` parameters to `rp`

### DIFF
--- a/rp/src/exchange.rs
+++ b/rp/src/exchange.rs
@@ -18,6 +18,8 @@ pub struct ExchangeOptions {
     pub dev: Option<String>,
     pub listen: Option<SocketAddr>,
     pub peers: Vec<ExchangePeer>,
+    pub rosenpass_user: Option<String>,
+    pub broker_user: Option<String>,
 }
 
 #[cfg(not(any(target_os = "linux", target_os = "freebsd")))]


### PR DESCRIPTION
This PR implements the requested features in #214 and #215, adding optional `rosenpass-user` and `broker-user` parameters to `rp`.

From #214:

> The rp script should accept rosenpass-user and broker-user parameters. broker-user defaults to rosenpass-user.
> The script should use capsh ([see arch wiki](https://wiki.archlinux.org/title/capabilities#Running_a_program_with_temporary_capabilities))
> to enable the broker to start with enough privileges to configure WireGuard.

From #215:

> When rosenpass-user is not given, the parameter should default to the SUDO_USER environment variable.