### PR TITLE
Fix Kyber encapsulation fuzz test shared key length to make test pass

### DIFF
--- a/fuzz/fuzz_targets/kyber_encaps.rs
+++ b/fuzz/fuzz_targets/kyber_encaps.rs
@@ -14,7 +14,7 @@ pub struct Input {
 
 fuzz_target!(|input: Input| {
     let mut ciphertext = [0u8; EphemeralKem::CT_LEN];
-    let mut shared_secret = [0u8; EphemeralKem::SK_LEN];
+    let mut shared_secret = [0u8; EphemeralKem::SHK_LEN];
 
     EphemeralKem::encaps(&mut shared_secret, &mut ciphertext, &input.pk).unwrap();
 });


### PR DESCRIPTION
This PR fixes the length of `shared_secret`, changing it from `SK_LEN` to `SHK_LEN` so that the fuzz test now passes unconditionally.

This is one of the two current CI failures on `main`. The other (a test failure during one of the Nix builds) I haven't been able to reproduce, and think is likely due to a caching issue; in particular, that test was previously failing on main but was fixed by the prior PR merge.