### PR TITLE
ci: add `concurrency` option to skip in progress

### DIFF
--- a/.github/workflows/nix.yaml
+++ b/.github/workflows/nix.yaml
@@ -6,6 +6,11 @@ on:
   push:
     branches:
       - main
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   i686-linux---default:
     name: Build i686-linux.default

--- a/.github/workflows/qc.yaml
+++ b/.github/workflows/qc.yaml
@@ -4,6 +4,10 @@ on:
   push:
     branches: [main]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   checks: write
   contents: read

--- a/.github/workflows/regressions.yml
+++ b/.github/workflows/regressions.yml
@@ -1,4 +1,4 @@
-name: QC
+name: Regressions
 on:
   pull_request:
   push:

--- a/.github/workflows/regressions.yml
+++ b/.github/workflows/regressions.yml
@@ -4,6 +4,10 @@ on:
   push:
     branches: [main]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   checks: write
   contents: read


### PR DESCRIPTION
Instead of running outdated CI jobs, skip them automatically.