### PR TITLE
chore(rosenpass): Set version to 0.3.0-dev

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1801,7 +1801,7 @@ checksum = "adad44e29e4c806119491a7f06f03de4d1af22c3a680dd47f1e6e179439d1f56"
 
 [[package]]
 name = "rosenpass"
-version = "0.2.1"
+version = "0.3.0-dev"
 dependencies = [
  "anyhow",
  "clap 4.5.20",

--- a/rosenpass/Cargo.toml
+++ b/rosenpass/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rosenpass"
-version = "0.2.1"
+version = "0.3.0-dev"
 authors = ["Karolin Varner <karo@cupdev.net>", "wucke13 <wucke13@gmail.com>"]
 edition = "2021"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
The latest release left the `main` branch on 0.2.1