### PR TITLE
RFC feat(rosenpass): git describe based version

### DIFF
--- a/rosenpass/build.rs
+++ b/rosenpass/build.rs
@@ -47,6 +47,11 @@ fn man() {
 fn main() {
     // For now, rerun the build script on every time, as the build script
     // is not very expensive right now.
+
+    let output = Command::new("git").args(&["describe"]).output().unwrap();
+    let mut git_tag = String::from_utf8(output.stdout).unwrap();
+    git_tag.remove(0); // remove the leading 'v'
+    println!("cargo:rustc-env=GIT_TAG={}", git_tag);
     println!("cargo:rerun-if-changed=./");
     man();
 }

--- a/rosenpass/src/cli.rs
+++ b/rosenpass/src/cli.rs
@@ -41,7 +41,7 @@ pub enum BrokerInterface {
 
 /// struct holding all CLI arguments for `clap` crate to parse
 #[derive(Parser, Debug)]
-#[command(author, version, about, long_about)]
+#[command(author, version = env!("GIT_TAG"), about, long_about)]
 pub struct CliArgs {
     /// lowest log level to show – log messages at higher levels will be omitted
     #[arg(long = "log-level", value_name = "LOG_LEVEL", group = "log-level")]


### PR DESCRIPTION
Use `git describe` to automatically generate the version, instead of using "just" cargo. The advantage is to have a dynamic version showing the exact git hash and commits since latest release.