### PR TITLE
Introduce "High Quality" Systemd unit files for `rosenpass` and `rp`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2003,9 +2003,11 @@ dependencies = [
  "rosenpass-util",
  "rosenpass-wireguard-broker",
  "rtnetlink",
+ "serde",
  "stacker",
  "tempfile",
  "tokio",
+ "toml",
  "x25519-dalek",
  "zeroize",
 ]

--- a/flake.nix
+++ b/flake.nix
@@ -136,6 +136,7 @@
 
           checks = {
             systemd-rosenpass = pkgs.testers.runNixOSTest ./tests/systemd/rosenpass.nix;
+            systemd-rp = pkgs.testers.runNixOSTest ./tests/systemd/rp.nix;
 
             cargo-fmt = pkgs.runCommand "check-cargo-fmt"
               { inherit (self.devShells.${system}.default) nativeBuildInputs buildInputs; } ''

--- a/flake.nix
+++ b/flake.nix
@@ -135,6 +135,8 @@
 
 
           checks = {
+            systemd-rosenpass = pkgs.testers.runNixOSTest ./tests/systemd/rosenpass.nix;
+
             cargo-fmt = pkgs.runCommand "check-cargo-fmt"
               { inherit (self.devShells.${system}.default) nativeBuildInputs buildInputs; } ''
               cargo fmt --manifest-path=${./.}/Cargo.toml --check --all && touch $out

--- a/pkgs/release-package.nix
+++ b/pkgs/release-package.nix
@@ -20,7 +20,7 @@ in
 runCommandNoCC "lace-result" { } ''
   mkdir {bin,$out}
   tar -cvf $out/rosenpass-${stdenvNoCC.hostPlatform.system}-${version}.tar \
-    -C ${package} bin/rosenpass \
+    -C ${package} bin/rosenpass lib/systemd \
     -C ${rp} bin/rp
   cp ${oci-image} \
     $out/rosenpass-oci-image-${stdenvNoCC.hostPlatform.system}-${version}.tar.gz

--- a/pkgs/rosenpass.nix
+++ b/pkgs/rosenpass.nix
@@ -74,6 +74,7 @@ rustPlatform.buildRustPackage {
   postInstall = ''
     mkdir -p $out/lib/systemd/system
     install systemd/rosenpass@.service $out/lib/systemd/system
+    install systemd/rp@.service $out/lib/systemd/system
     install systemd/rosenpass.target $out/lib/systemd/system
   '';
 

--- a/pkgs/rosenpass.nix
+++ b/pkgs/rosenpass.nix
@@ -12,6 +12,8 @@ let
     extensions = [
       "lock"
       "rs"
+      "service"
+      "target"
       "toml"
     ];
     # Files to explicitly include
@@ -68,6 +70,12 @@ rustPlatform.buildRustPackage {
   buildInputs = [ bash ];
 
   hardeningDisable = lib.optional isStatic "fortify";
+
+  postInstall = ''
+    mkdir -p $out/lib/systemd/system
+    install systemd/rosenpass@.service $out/lib/systemd/system
+    install systemd/rosenpass.target $out/lib/systemd/system
+  '';
 
   meta = {
     inherit (cargoToml.package) description homepage;

--- a/rp/Cargo.toml
+++ b/rp/Cargo.toml
@@ -12,6 +12,8 @@ repository = "https://github.com/rosenpass/rosenpass"
 [dependencies]
 anyhow = { workspace = true }
 base64ct = { workspace = true }
+serde = { workspace = true }
+toml = { workspace = true }
 x25519-dalek = { version = "2", features = ["static_secrets"] }
 zeroize = { workspace = true }
 

--- a/rp/Cargo.toml
+++ b/rp/Cargo.toml
@@ -26,10 +26,11 @@ rosenpass-wireguard-broker = { workspace = true }
 
 tokio = { workspace = true }
 
-[target.'cfg(any(target_os = "linux", target_os = "freebsd"))'.dependencies]
-ctrlc-async = "3.2"
 futures = "0.3"
 futures-util = "0.3"
+
+[target.'cfg(any(target_os = "linux", target_os = "freebsd"))'.dependencies]
+ctrlc-async = "3.2"
 genetlink = "0.2"
 rtnetlink = "0.14"
 netlink-packet-core = "0.7"

--- a/rp/src/cli.rs
+++ b/rp/src/cli.rs
@@ -32,7 +32,7 @@ fn fatal<T>(note: &str, command: Option<CommandType>) -> Result<T, String> {
         Some(command) => match command {
             CommandType::GenKey => Err(format!("{}\nUsage: rp genkey PRIVATE_KEYS_DIR", note)),
             CommandType::PubKey => Err(format!("{}\nUsage: rp pubkey PRIVATE_KEYS_DIR PUBLIC_KEYS_DIR", note)),
-            CommandType::Exchange => Err(format!("{}\nUsage: rp exchange PRIVATE_KEYS_DIR [dev <device>] [listen <ip>:<port>] [peer PUBLIC_KEYS_DIR [endpoint <ip>:<port>] [persistent-keepalive <interval>] [allowed-ips <ip1>/<cidr1>[,<ip2>/<cidr2>]...]]...", note)),
+            CommandType::Exchange => Err(format!("{}\nUsage: rp exchange PRIVATE_KEYS_DIR [dev <device>] [ip <ip1>/<cidr1>] [listen <ip>:<port>] [peer PUBLIC_KEYS_DIR [endpoint <ip>:<port>] [persistent-keepalive <interval>] [allowed-ips <ip1>/<cidr1>[,<ip2>/<cidr2>]...]]...", note)),
         },
         None => Err(format!("{}\nUsage: rp [verbose] genkey|pubkey|exchange [ARGS]...", note)),
     }
@@ -142,6 +142,13 @@ impl ExchangeOptions {
                         options.dev = Some(device);
                     } else {
                         return fatal("dev option requires parameter", Some(CommandType::Exchange));
+                    }
+                }
+                "ip" => {
+                    if let Some(ip) = args.next() {
+                        options.ip = Some(ip);
+                    } else {
+                        return fatal("ip option requires parameter", Some(CommandType::Exchange));
                     }
                 }
                 "listen" => {

--- a/rp/src/exchange.rs
+++ b/rp/src/exchange.rs
@@ -1,5 +1,6 @@
 use anyhow::Error;
 use futures::lock::Mutex;
+use serde::Deserialize;
 use std::future::Future;
 use std::ops::DerefMut;
 use std::pin::Pin;
@@ -11,7 +12,7 @@ use anyhow::Result;
 #[cfg(any(target_os = "linux", target_os = "freebsd"))]
 use crate::key::WG_B64_LEN;
 
-#[derive(Default)]
+#[derive(Default, Deserialize)]
 pub struct ExchangePeer {
     pub public_keys_dir: PathBuf,
     pub endpoint: Option<SocketAddr>,
@@ -19,7 +20,7 @@ pub struct ExchangePeer {
     pub allowed_ips: Option<String>,
 }
 
-#[derive(Default)]
+#[derive(Default, Deserialize)]
 pub struct ExchangeOptions {
     pub verbose: bool,
     pub private_keys_dir: PathBuf,

--- a/rp/src/main.rs
+++ b/rp/src/main.rs
@@ -1,4 +1,4 @@
-use std::process::exit;
+use std::{fs, process::exit};
 
 use cli::{Cli, Command};
 use exchange::exchange;
@@ -34,6 +34,13 @@ async fn main() {
         } => pubkey(&private_keys_dir, &public_keys_dir),
         Command::Exchange(mut options) => {
             options.verbose = cli.verbose;
+            exchange(options).await
+        }
+        Command::ExchangeConfig { config_file } => {
+            let s: String = fs::read_to_string(config_file).expect("cannot read config");
+            let mut options: exchange::ExchangeOptions =
+                toml::from_str::<exchange::ExchangeOptions>(&s).expect("cannot parse config");
+            options.verbose = options.verbose || cli.verbose;
             exchange(options).await
         }
         Command::Help => {

--- a/systemd/rosenpass.target
+++ b/systemd/rosenpass.target
@@ -1,0 +1,2 @@
+[Unit]
+Description=Rosenpass target

--- a/systemd/rosenpass@.service
+++ b/systemd/rosenpass@.service
@@ -1,0 +1,47 @@
+[Unit]
+Description=Rosenpass key exchange for %I
+Documentation=man:rosenpass(1)
+Documentation=https://rosenpass.eu/docs
+
+After=network-online.target nss-lookup.target sys-devices-virtual-net-%i.device
+Wants=network-online.target nss-lookup.target
+BindsTo=sys-devices-virtual-net-%i.device
+PartOf=rosenpass.target
+
+[Service]
+ExecStart=rosenpass exchange-config /etc/rosenpass/%i.toml
+LoadCredential=pqsk:/etc/rosenpass/%i/pqsk
+
+AmbientCapabilities=CAP_NET_ADMIN
+CapabilityBoundingSet=~CAP_AUDIT_CONTROL CAP_AUDIT_READ CAP_AUDIT_WRITE CAP_BLOCK_SUSPEND CAP_BPF CAP_CHOWN CAP_FSETID CAP_SETFCAP CAP_DAC_OVERRIDE CAP_DAC_READ_SEARCH CAP_FOWNER CAP_IPC_OWNER CAP_IPC_LOCK CAP_KILL CAP_LEASE CAP_LINUX_IMMUTABLE CAP_MAC_ADMIN CAP_MAC_OVERRIDE CAP_MKNOD CAP_NET_BIND_SERVICE CAP_NET_BROADCAST CAP_NET_RAW CAP_SETUID CAP_SETGID CAP_SETPCAP CAP_SYS_ADMIN CAP_SYS_BOOT CAP_SYS_CHROOT CAP_SYSLOG CAP_SYS_MODULE CAP_SYS_NICE CAP_SYS_RESOURCE CAP_SYS_PACCT CAP_SYS_PTRACE CAP_SYS_RAWIO CAP_SYS_TIME CAP_SYS_TTY_CONFIG CAP_WAKE_ALARM
+DynamicUser=true
+LockPersonality=true
+MemoryDenyWriteExecute=true
+PrivateDevices=true
+ProcSubset=pid
+ProtectClock=true
+ProtectControlGroups=true
+ProtectHome=true
+ProtectHostname=true
+ProtectKernelLogs=true
+ProtectKernelModules=true
+ProtectKernelTunables=true
+ProtectProc=noaccess
+RestrictAddressFamilies=AF_NETLINK AF_INET AF_INET6
+RestrictNamespaces=true
+RestrictRealtime=true
+SystemCallArchitectures=native
+SystemCallFilter=~@clock
+SystemCallFilter=~@cpu-emulation
+SystemCallFilter=~@debug
+SystemCallFilter=~@module
+SystemCallFilter=~@mount
+SystemCallFilter=~@obsolete
+SystemCallFilter=~@privileged
+SystemCallFilter=~@raw-io
+SystemCallFilter=~@reboot
+SystemCallFilter=~@swap
+UMask=0077
+
+[Install]
+WantedBy=multi-user.target

--- a/systemd/rp@.service
+++ b/systemd/rp@.service
@@ -1,0 +1,48 @@
+[Unit]
+Description=Rosenpass key exchange for %I
+Documentation=man:rosenpass(1)
+Documentation=https://rosenpass.eu/docs
+
+After=network-online.target nss-lookup.target
+Wants=network-online.target nss-lookup.target
+PartOf=rosenpass.target
+
+[Service]
+ExecStart=rp exchange-config /etc/rosenpass/%i.toml
+LoadCredential=pqpk:/etc/rosenpass/%i/pqpk
+LoadCredential=pqsk:/etc/rosenpass/%i/pqsk
+LoadCredential=wgsk:/etc/rosenpass/%i/wgsk
+
+AmbientCapabilities=CAP_NET_ADMIN
+CapabilityBoundingSet=~CAP_AUDIT_CONTROL CAP_AUDIT_READ CAP_AUDIT_WRITE CAP_BLOCK_SUSPEND CAP_BPF CAP_CHOWN CAP_FSETID CAP_SETFCAP CAP_DAC_OVERRIDE CAP_DAC_READ_SEARCH CAP_FOWNER CAP_IPC_OWNER CAP_IPC_LOCK CAP_KILL CAP_LEASE CAP_LINUX_IMMUTABLE CAP_MAC_ADMIN CAP_MAC_OVERRIDE CAP_MKNOD CAP_NET_BIND_SERVICE CAP_NET_BROADCAST CAP_NET_RAW CAP_SETUID CAP_SETGID CAP_SETPCAP CAP_SYS_ADMIN CAP_SYS_BOOT CAP_SYS_CHROOT CAP_SYSLOG CAP_SYS_MODULE CAP_SYS_NICE CAP_SYS_RESOURCE CAP_SYS_PACCT CAP_SYS_PTRACE CAP_SYS_RAWIO CAP_SYS_TIME CAP_SYS_TTY_CONFIG CAP_WAKE_ALARM
+DynamicUser=true
+LockPersonality=true
+MemoryDenyWriteExecute=true
+PrivateDevices=true
+ProcSubset=pid
+ProtectClock=true
+ProtectControlGroups=true
+ProtectHome=true
+ProtectHostname=true
+ProtectKernelLogs=true
+ProtectKernelModules=true
+ProtectKernelTunables=true
+ProtectProc=noaccess
+RestrictAddressFamilies=AF_NETLINK AF_INET AF_INET6
+RestrictNamespaces=true
+RestrictRealtime=true
+SystemCallArchitectures=native
+SystemCallFilter=~@clock
+SystemCallFilter=~@cpu-emulation
+SystemCallFilter=~@debug
+SystemCallFilter=~@module
+SystemCallFilter=~@mount
+SystemCallFilter=~@obsolete
+SystemCallFilter=~@privileged
+SystemCallFilter=~@raw-io
+SystemCallFilter=~@reboot
+SystemCallFilter=~@swap
+UMask=0077
+
+[Install]
+WantedBy=multi-user.target

--- a/tests/systemd/rosenpass.nix
+++ b/tests/systemd/rosenpass.nix
@@ -1,0 +1,183 @@
+# This test is largely inspired from:
+# https://github.com/NixOS/nixpkgs/blob/master/nixos/tests/rosenpass.nix
+# https://github.com/NixOS/nixpkgs/blob/master/nixos/tests/wireguard/basic.nix
+{ pkgs, ... }:
+
+let
+  server = {
+    ip4 = "192.168.0.1";
+    ip6 = "fd00::1";
+    wg = {
+      ip4 = "10.23.42.1";
+      ip6 = "fc00::1";
+      public = "mQufmDFeQQuU/fIaB2hHgluhjjm1ypK4hJr1cW3WqAw=";
+      secret = "4N5Y1dldqrpsbaEiY8O0XBUGUFf8vkvtBtm8AoOX7Eo=";
+      listen = 10000;
+    };
+  };
+
+  client = {
+    ip4 = "192.168.0.2";
+    ip6 = "fd00::2";
+    wg = {
+      ip4 = "10.23.42.2";
+      ip6 = "fc00::2";
+      public = "Mb3GOlT7oS+F3JntVKiaD7SpHxLxNdtEmWz/9FMnRFU=";
+      secret = "uC5dfGMv7Oxf5UDfdPkj6rZiRZT2dRWp5x8IQxrNcUE=";
+    };
+  };
+
+  server_config = {
+    listen = [ "0.0.0.0:9999" ];
+    public_key = "/etc/rosenpass/rp0/pqpk";
+    secret_key = "/run/credentials/rosenpass@rp0.service/pqsk";
+    verbosity = "Verbose";
+    peers = [{
+      device = "rp0";
+      peer = client.wg.public;
+      public_key = "/etc/rosenpass/rp0/peers/client/pqpk";
+    }];
+  };
+  client_config = {
+    listen = [ ];
+    public_key = "/etc/rosenpass/rp0/pqpk";
+    secret_key = "/run/credentials/rosenpass@rp0.service/pqsk";
+    verbosity = "Verbose";
+    peers = [{
+      device = "rp0";
+      peer = server.wg.public;
+      public_key = "/etc/rosenpass/rp0/peers/server/pqpk";
+      endpoint = "${server.ip4}:9999";
+    }];
+  };
+
+  config = pkgs.runCommand "config" { } ''
+    mkdir -pv $out
+    cp -v ${(pkgs.formats.toml {}).generate "rp0.toml" server_config} $out/server
+    cp -v ${(pkgs.formats.toml {}).generate "rp0.toml" client_config} $out/client
+  '';
+in
+{
+  name = "rosenpass unit";
+
+  nodes =
+    let
+      shared = peer: { config, modulesPath, pkgs, ... }: {
+        # Need to work around a problem in recent systemd changes.
+        # It won't be necessary in other distros (for which the systemd file was designed), this is NixOS specific
+        # https://github.com/NixOS/nixpkgs/issues/258371#issuecomment-1925672767
+        # This can potentially be removed in future nixpkgs updates
+        systemd.packages = [
+          (pkgs.runCommand "rosenpass" { } ''
+            mkdir -p $out/lib/systemd/system
+            < ${pkgs.rosenpass}/lib/systemd/system/rosenpass.target > $out/lib/systemd/system/rosenpass.target
+            < ${pkgs.rosenpass}/lib/systemd/system/rosenpass@.service \
+            sed 's@^\(\[Service]\)$@\1\nEnvironment=PATH=${pkgs.wireguard-tools}/bin@' |
+            sed 's@^ExecStartPre=envsubst @ExecStartPre='"${pkgs.envsubst}"'/bin/envsubst @' |
+            sed 's@^ExecStart=rosenpass @ExecStart='"${pkgs.rosenpass}"'/bin/rosenpass @' > $out/lib/systemd/system/rosenpass@.service
+          '')
+        ];
+        networking.wireguard = {
+          enable = true;
+          interfaces.rp0 = {
+            ips = [ "${peer.wg.ip4}/32" "${peer.wg.ip6}/128" ];
+            privateKeyFile = "/etc/wireguard/wgsk";
+          };
+        };
+        environment.etc."wireguard/wgsk".text = peer.wg.secret;
+        networking.interfaces.eth1 = {
+          ipv4.addresses = [{
+            address = peer.ip4;
+            prefixLength = 24;
+          }];
+          ipv6.addresses = [{
+            address = peer.ip6;
+            prefixLength = 64;
+          }];
+        };
+      };
+    in
+    {
+      server = {
+        imports = [ (shared server) ];
+        networking.firewall.allowedUDPPorts = [ 9999 server.wg.listen ];
+        networking.wireguard.interfaces.rp0 = {
+          listenPort = server.wg.listen;
+          peers = [
+            {
+              allowedIPs = [ client.wg.ip4 client.wg.ip6 ];
+              publicKey = client.wg.public;
+            }
+          ];
+        };
+      };
+      client = {
+        imports = [ (shared client) ];
+        networking.wireguard.interfaces.rp0 = {
+          peers = [
+            {
+              allowedIPs = [ "10.23.42.0/24" "fc00::/64" ];
+              publicKey = server.wg.public;
+              endpoint = "${server.ip4}:${toString server.wg.listen}";
+            }
+          ];
+        };
+      };
+    };
+  testScript = { ... }: ''
+    from os import system
+    rosenpass = "${pkgs.rosenpass}/bin/rosenpass"
+
+    start_all()
+
+    for machine in [server, client]:
+      machine.wait_for_unit("multi-user.target")
+      machine.wait_for_unit("network-online.target")
+
+    with subtest("Key, Config, and Service Setup"):
+      for name, machine, remote in [("server", server, client), ("client", client, server)]:
+        # generate all the keys
+        system(f"{rosenpass} gen-keys --public-key {name}-pqpk --secret-key {name}-pqsk")
+
+        # copy private keys to our side
+        machine.copy_from_host(f"{name}-pqsk", "/etc/rosenpass/rp0/pqsk")
+        machine.copy_from_host(f"{name}-pqpk", "/etc/rosenpass/rp0/pqpk")
+
+        # copy public keys to other side
+        remote.copy_from_host(f"{name}-pqpk", f"/etc/rosenpass/rp0/peers/{name}/pqpk")
+
+        machine.copy_from_host(f"${config}/{name}", "/etc/rosenpass/rp0.toml")
+
+      for machine in [server, client]:
+        machine.wait_for_unit("wireguard-rp0.service")
+
+    with subtest("wg network test"):
+      client.succeed("wg show all preshared-keys | grep none", timeout=5);
+      client.succeed("ping -c5 ${server.wg.ip4}")
+      server.succeed("ping -c5 ${client.wg.ip6}")
+
+    with subtest("Set up rosenpass"):
+      for machine in [server, client]:
+        machine.succeed("systemctl start rosenpass@rp0.service")
+
+      for machine in [server, client]:
+        machine.wait_for_unit("rosenpass@rp0.service")
+
+
+    with subtest("compare preshared keys"):
+      client.wait_until_succeeds("wg show all preshared-keys | grep --invert-match none", timeout=5);
+      server.wait_until_succeeds("wg show all preshared-keys | grep --invert-match none", timeout=5);
+
+      def get_psk(m):
+        psk = m.succeed("wg show rp0 preshared-keys | awk '{print $2}'")
+        psk = psk.strip()
+        assert len(psk.split()) == 1, "Only one PSK"
+        return psk
+
+      assert get_psk(client) == get_psk(server), "preshared keys need to match"
+
+    with subtest("rosenpass network test"):
+      client.succeed("ping -c5 ${server.wg.ip4}")
+      server.succeed("ping -c5 ${client.wg.ip6}")
+  '';
+}

--- a/tests/systemd/rp.nix
+++ b/tests/systemd/rp.nix
@@ -1,0 +1,139 @@
+{ pkgs, ... }:
+
+let
+  server = {
+    ip4 = "192.168.0.1";
+    ip6 = "fd00::1";
+    wg = {
+      ip6 = "fc00::1";
+      listen = 10000;
+    };
+  };
+
+  client = {
+    ip4 = "192.168.0.2";
+    ip6 = "fd00::2";
+    wg = {
+      ip6 = "fc00::2";
+    };
+  };
+
+  server_config = {
+    listen = "${server.ip4}:9999";
+    private_keys_dir = "/run/credentials/rp@test-rp-device0.service";
+    verbose = true;
+    dev = "test-rp-device0";
+    ip = "fc00::1/64";
+    peers = [{
+      public_keys_dir = "/etc/rosenpass/test-rp-device0/peers/client";
+      allowed_ips = "fc00::2";
+    }];
+  };
+  client_config = {
+    private_keys_dir = "/run/credentials/rp@test-rp-device0.service";
+    verbose = true;
+    dev = "test-rp-device0";
+    ip = "fc00::2/128";
+    peers = [{
+      public_keys_dir = "/etc/rosenpass/test-rp-device0/peers/server";
+      endpoint = "${server.ip4}:9999";
+      allowed_ips = "fc00::/64";
+    }];
+  };
+
+  config = pkgs.runCommand "config" { } ''
+    mkdir -pv $out
+    cp -v ${(pkgs.formats.toml {}).generate "test-rp-device0.toml" server_config} $out/server
+    cp -v ${(pkgs.formats.toml {}).generate "test-rp-device0.toml" client_config} $out/client
+  '';
+in
+{
+  name = "rp systemd unit";
+
+  nodes =
+    let
+      shared = peer: { config, modulesPath, pkgs, ... }: {
+        # Need to work around a problem in recent systemd changes.
+        # It won't be necessary in other distros (for which the systemd file was designed), this is NixOS specific
+        # https://github.com/NixOS/nixpkgs/issues/258371#issuecomment-1925672767
+        # This can potentially be removed in future nixpkgs updates
+        systemd.packages = [
+          (pkgs.runCommand "rp@.service" { } ''
+            mkdir -p $out/lib/systemd/system
+            < ${pkgs.rosenpass}/lib/systemd/system/rosenpass.target > $out/lib/systemd/system/rosenpass.target
+            < ${pkgs.rosenpass}/lib/systemd/system/rp@.service \
+            sed 's@^\(\[Service]\)$@\1\nEnvironment=PATH=${pkgs.iproute2}/bin:${pkgs.wireguard-tools}/bin@' |
+            sed 's@^ExecStartPre=envsubst @ExecStartPre='"${pkgs.envsubst}"'/bin/envsubst @' |
+            sed 's@^ExecStart=rp @ExecStart='"${pkgs.rosenpass}"'/bin/rp @' > $out/lib/systemd/system/rp@.service
+          '')
+        ];
+        environment.systemPackages = [ pkgs.wireguard-tools ];
+        networking.interfaces.eth1 = {
+          ipv4.addresses = [{
+            address = peer.ip4;
+            prefixLength = 24;
+          }];
+          ipv6.addresses = [{
+            address = peer.ip6;
+            prefixLength = 64;
+          }];
+        };
+      };
+    in
+    {
+      server = {
+        imports = [ (shared server) ];
+        networking.firewall.allowedUDPPorts = [ 9999 server.wg.listen ];
+      };
+      client = {
+        imports = [ (shared client) ];
+      };
+    };
+  testScript = { ... }: ''
+    from os import system
+    rp = "${pkgs.rosenpass}/bin/rp"
+
+    start_all()
+
+    for machine in [server, client]:
+      machine.wait_for_unit("multi-user.target")
+      machine.wait_for_unit("network-online.target")
+
+    with subtest("Key, Config, and Service Setup"):
+      for name, machine, remote in [("server", server, client), ("client", client, server)]:
+        # create all the keys
+        system(f"{rp} genkey {name}-sk")
+        system(f"{rp} pubkey {name}-sk {name}-pk")
+
+        # copy secret keys to our side
+        for file in ["pqpk", "pqsk", "wgsk"]:
+          machine.copy_from_host(f"{name}-sk/{file}", f"/etc/rosenpass/test-rp-device0/{file}")
+        # copy public keys to other side
+        for file in ["pqpk", "wgpk"]:
+          remote.copy_from_host(f"{name}-pk/{file}", f"/etc/rosenpass/test-rp-device0/peers/{name}/{file}")
+
+        machine.copy_from_host(f"${config}/{name}", "/etc/rosenpass/test-rp-device0.toml")
+
+      for machine in [server, client]:
+        machine.succeed("systemctl start rp@test-rp-device0.service")
+
+      for machine in [server, client]:
+        machine.wait_for_unit("rp@test-rp-device0.service")
+
+    with subtest("compare preshared keys"):
+      client.wait_until_succeeds("wg show all preshared-keys | grep --invert-match none", timeout=5);
+      server.wait_until_succeeds("wg show all preshared-keys | grep --invert-match none", timeout=5);
+
+      def get_psk(m):
+        psk = m.succeed("wg show test-rp-device0 preshared-keys | awk '{print $2}'")
+        psk = psk.strip()
+        assert len(psk.split()) == 1, "Only one PSK"
+        return psk
+
+      assert get_psk(client) == get_psk(server), "preshared keys need to match"
+
+    with subtest("network test"):
+      client.succeed("ping -c5 ${server.wg.ip6}")
+      server.succeed("ping -c5 ${client.wg.ip6}")
+  '';
+}


### PR DESCRIPTION
This PR introduces systemd unit files to simplify running `rosenpass` and`rp` with minimal setup. The workflow after these changes is like this:

1. Create configuration files, private/public keys on both server and client, and distribute them accordingly
2. Start the service using `systemctl start rp@<config-name>.service` (or respectively `rosenpass@<config-name>.service`)
3. Enjoy a post-quantum-secure encrypted connection

I tested this manually on an Ubuntu machine. The automated tests use NixOS, see next section.

## Changes Introduced

To achieve the above, the following changes have been made:

- Rosenpass Unit File: 
  - Added a systemd unit file for `rosenpass`
  - Implemented a NixOS integration test for verification

- `rp` App: Patched the `rp` application to support configuration files

- `rp` Unit File:
  - Added a systemd unit file for `rp`
  - Added a NixOS integration test for verification

## Considerations and Notes

While working on this, a few challenges and limitations were encountered:

- Rust Code Quality: The Rust code may not be best practice and could be improved. Feedback on how to refine it is appreciated.
- `rosenpass` Client Config Parsing: The `listen` field is currently required in the client configuration, which feels wrong. However, i feel addressing this would be feature-creep in this PR.
- `rp` IP Parameter Limitation: The `ip` parameter for `rp exchange` could theoretically support multiple IPs, but this functionality was not implemented in this iteration, as it already supports the standard scenarios.

The need to extend the `rp` code was not anticipated during the initial planning of this work package. However, the current implementation is functional for simple use cases and should provide a solid foundation for further enhancements if needed.

I hope this implementation aligns with your goals and expectations. Feedback and suggestions for improvement are welcome!
