### PR TITLE
Add docstring examples and unit tests for the LengthPrefixEncoder module

### DIFF
--- a/util/src/length_prefix_encoding/encoder.rs
+++ b/util/src/length_prefix_encoding/encoder.rs
@@ -1,3 +1,12 @@
+//! Utilities for encoding length-prefixed messages that can be transmitted via I/O streams.
+//!
+//! Messages are prefixed with an unsigned 64-bit little-endian length header, followed by the
+//! message payload. Each [`LengthPrefixEncoder`] maintains internal buffers and additional state for as-yet
+//! incomplete messages.
+//!
+//! It also performs sanity checks and handles typical error conditions that may be encountered
+//! when writing structured data to an output sink (such as stdout or an active socket connection).
+
 use std::{
     borrow::{Borrow, BorrowMut},
     cmp::min,

--- a/util/src/length_prefix_encoding/mod.rs
+++ b/util/src/length_prefix_encoding/mod.rs
@@ -1,4 +1,2 @@
-/// Module that handles decoding functionality
 pub mod decoder;
-/// Module that handles encoding functionality
 pub mod encoder;


### PR DESCRIPTION
~~Warning: Needs (a lot of) refinement. Placeholders abound.~~

---

Status: Should be ready for review/merge, pending further comments.