### PR TITLE
chore(coverage): Fix missing coverage from API integration tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1850,6 +1850,7 @@ dependencies = [
  "rustix",
  "serde",
  "serial_test",
+ "signal-hook",
  "stacker",
  "static_assertions",
  "tempfile",
@@ -2177,6 +2178,16 @@ name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
+name = "signal-hook"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8621587d4798caf8eb44879d42e56b9a93ea5dcd315a6487c357130095b62801"
+dependencies = [
+ "libc",
+ "signal-hook-registry",
+]
 
 [[package]]
 name = "signal-hook-registry"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -74,6 +74,7 @@ hex = { version = "0.4.3" }
 heck = { version = "0.5.0" }
 libc = { version = "0.2" }
 uds = { git = "https://github.com/rosenpass/uds" }
+signal-hook = "0.3.17"
 
 #Dev dependencies
 serial_test = "3.2.0"
@@ -89,4 +90,4 @@ procspawn = { version = "1.0.1", features = ["test-support"] }
 #Broker dependencies (might need cleanup or changes)
 wireguard-uapi = { version = "3.0.0", features = ["xplatform"] }
 command-fds = "0.2.3"
-rustix = { version = "0.38.41", features = ["net", "fs"] }
+rustix = { version = "0.38.41", features = ["net", "fs", "process"] }

--- a/rosenpass/Cargo.toml
+++ b/rosenpass/Cargo.toml
@@ -62,6 +62,7 @@ heck = { workspace = true, optional = true }
 command-fds = { workspace = true, optional = true }
 rustix = { workspace = true, optional = true }
 uds = { workspace = true, optional = true, features = ["mio_1xx"] }
+signal-hook = { workspace = true, optional = true }
 
 [build-dependencies]
 anyhow = { workspace = true }
@@ -87,5 +88,6 @@ experiment_api = [
     "rosenpass-util/experiment_file_descriptor_passing",
     "rosenpass-wireguard-broker/experiment_api",
 ]
+internal_signal_handling_for_coverage_reports = ["signal-hook"]
 internal_testing = []
 internal_bin_gen_ipc_msg_types = ["hex", "heck"]

--- a/rosenpass/tests/api-integration-tests-api-setup.rs
+++ b/rosenpass/tests/api-integration-tests-api-setup.rs
@@ -33,8 +33,10 @@ struct KillChild(std::process::Child);
 
 impl Drop for KillChild {
     fn drop(&mut self) {
-        self.0.kill().discard_result();
-        self.0.wait().discard_result()
+        use rustix::process::{kill_process, Pid, Signal::Term};
+        let pid = Pid::from_child(&self.0);
+        rustix::process::kill_process(pid, Term).discard_result();
+        self.0.wait().discard_result();
     }
 }
 
@@ -153,7 +155,6 @@ fn api_integration_api_setup() -> anyhow::Result<()> {
                 peer_b.config_file_path.to_str().context("")?,
             ])
             .stdin(Stdio::null())
-            .stderr(Stdio::null())
             .stdout(Stdio::piped())
             .spawn()?,
     );


### PR DESCRIPTION
Three changes:
1. We neglected to forward stderr from Rosenpass subprocess two in the API setup integration test (driveby fix)
2. Added rudimentary signal handling for program termination to rosenpass, specifically for the coverage reporting
3. Apparently std::process::Child::kill() sends SIGKILL and not SIGTERM, so our nice new signal handler was never used. Switched to a rustix based child reaper.

(2) and (3) where necessary because llvm-cov does not produce coverage when a subprocess terminates due to a default signal handler.