### PR TITLE
chore(tests): start using unused test output

### DIFF
--- a/rosenpass/tests/integration_test.rs
+++ b/rosenpass/tests/integration_test.rs
@@ -160,6 +160,9 @@ fn check_example_config() {
         .output()
         .expect("EXAMPLE_CONFIG not valid");
 
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert_eq!(stderr, "");
+
     fs::copy(
         tmp_dir.path().join("rp-public-key"),
         tmp_dir.path().join("rp-peer-public-key"),


### PR DESCRIPTION
Resolve a warning of unused `output` variable.

Fixes: 0745019 docs(cli): Create commented config file