### PR TITLE
Avoid unnecessarily copying the doctest binaries

### DIFF
--- a/coverage_report.sh
+++ b/coverage_report.sh
@@ -23,7 +23,7 @@ main() {
 
   exc cargo llvm-cov --all-features --workspace --doctests --branch
 
-  exc cp -rv target/llvm-cov-target/doctestbins target/llvm-cov-target/debug/deps/doctestbins
+  exc mv -v target/llvm-cov-target/doctestbins target/llvm-cov-target/debug/deps/
   exc rm -rf "${OUTPUT_DIR}"
   exc mkdir -p "${OUTPUT_DIR}"
   exc grcov target/llvm-cov-target/ --llvm  -s . --branch \


### PR DESCRIPTION
The doctest binaries can take up ~3GB for a debug build. There's no reason to waste that much disk space and copying them is slower than moving, too. They're only used by `grcov` right now, so they needn't be preserved.

---

Before:

```sh
> du -sh target
8.6G    target
```

```sh
> du -h target | sort -h | tail -n 6
3.0G    target/llvm-cov-target/debug/deps/doctestbins
3.0G    target/llvm-cov-target/doctestbins
4.6G    target/llvm-cov-target/debug/deps
5.2G    target/llvm-cov-target/debug
8.5G    target/llvm-cov-target
8.6G    target
```

After:

```sh
> du -sh target
5.6G    target
```

```sh
> du -h target | sort -h | tail -n 6
265M    target/llvm-cov-target/debug/build
3.0G    target/llvm-cov-target/debug/deps/doctestbins
4.6G    target/llvm-cov-target/debug/deps
5.2G    target/llvm-cov-target/debug
5.5G    target/llvm-cov-target
5.6G    target
```