### PR TITLE
Add a missing cleanup step to the coverage script

### DIFF
--- a/coverage_report.sh
+++ b/coverage_report.sh
@@ -23,6 +23,7 @@ main() {
 
   exc cargo llvm-cov --all-features --workspace --doctests --branch
 
+  exc rm -rf target/llvm-cov-target/debug/deps/doctestbins
   exc mv -v target/llvm-cov-target/doctestbins target/llvm-cov-target/debug/deps/
   exc rm -rf "${OUTPUT_DIR}"
   exc mkdir -p "${OUTPUT_DIR}"


### PR DESCRIPTION
Looks like `cargo llvm-cov` doesn't clean up the entire `target/llvm-cov-target` directory tree, which means running the coverage script more than once fails as `mv` refuses to overwrite the leftover doctest binaries from a previous run.