### PR TITLE
feat(ciphers+fuzz): Add experimental feature to use a keyed version of SHAKE256 instead of Blake2b.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1191,6 +1191,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "keccak"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecc2af9a1119c51f12a14607e783cb977bde58bc069ff0c3da1095e635d70654"
+dependencies = [
+ "cpufeatures",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1884,6 +1893,7 @@ dependencies = [
  "rosenpass-secret-memory",
  "rosenpass-to",
  "rosenpass-util",
+ "sha3",
  "static_assertions",
  "zeroize",
 ]
@@ -2176,6 +2186,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.87",
+]
+
+[[package]]
+name = "sha3"
+version = "0.10.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75872d278a8f37ef87fa0ddbda7802605cb18344497949862c0d4dcb291eba60"
+dependencies = [
+ "digest",
+ "keccak",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -75,6 +75,7 @@ heck = { version = "0.5.0" }
 libc = { version = "0.2" }
 uds = { git = "https://github.com/rosenpass/uds" }
 signal-hook = "0.3.17"
+sha3 = "0.10"
 
 #Dev dependencies
 serial_test = "3.2.0"

--- a/ciphers/Cargo.toml
+++ b/ciphers/Cargo.toml
@@ -11,6 +11,7 @@ readme = "readme.md"
 
 [features]
 experiment_libcrux = ["dep:libcrux"]
+experiment_sha3 = ["dep:sha3"]
 
 [dependencies]
 anyhow = { workspace = true }
@@ -24,3 +25,4 @@ zeroize = { workspace = true }
 chacha20poly1305 = { workspace = true }
 blake2 = { workspace = true }
 libcrux = { workspace = true, optional = true }
+sha3 = {workspace = true, optional = true}

--- a/ciphers/src/lib.rs
+++ b/ciphers/src/lib.rs
@@ -14,9 +14,12 @@ const_assert!(KEY_LEN == hash_domain::KEY_LEN);
 /// to the cryptographic protocol should use the facilities in [hash_domain], (though
 /// hash domain uses this module internally)
 pub mod keyed_hash {
+    #[cfg(not(feature = "experiment_sha3"))]
     pub use crate::subtle::incorrect_hmac_blake2b::{
         hash, KEY_LEN, KEY_MAX, KEY_MIN, OUT_MAX, OUT_MIN,
     };
+    #[cfg(feature = "experiment_sha3")]
+    pub use crate::subtle::keyed_shake256::{hash, KEY_LEN, KEY_MAX, KEY_MIN, OUT_MAX, OUT_MIN};
 }
 
 /// Authenticated encryption with associated data

--- a/ciphers/src/subtle/keyed_shake256.rs
+++ b/ciphers/src/subtle/keyed_shake256.rs
@@ -1,0 +1,65 @@
+use anyhow::ensure;
+use rosenpass_to::ops::copy_slice;
+use rosenpass_to::{with_destination, To};
+use sha3::digest::{ExtendableOutput, Update, XofReader};
+use sha3::Shake256;
+use zeroize::Zeroizing;
+
+/// The key length, 32 bytes or 256 bits.
+pub const KEY_LEN: usize = 32;
+/// The output length, 32 bytes or 256 bits.
+pub const OUT_LEN: usize = 32;
+/// The minimal key length, identical to [KEY_LEN].
+pub const KEY_MIN: usize = KEY_LEN;
+/// The maximal key length, identical to [KEY_LEN].
+pub const KEY_MAX: usize = KEY_LEN;
+/// The minimal output length.
+pub const OUT_MIN: usize = OUT_LEN;
+/// The maximal output length.
+pub const OUT_MAX: usize = OUT_LEN;
+
+/// Provides a keyed hash function based on SHAKE256. To work for the protocol, the output length
+/// and key length are fixed to 32 bytes (also see [KEY_LEN] and [OUT_LEN]).
+///
+/// Note that the SHAKE256 is designed for 64 bytes output length, which we truncate to 32 bytes
+/// to work well with the overall protocol. Referring to Table 4 of FIPS 202, this offers the
+/// same collision resistance as SHAKE128, but 256 bits of preimage resistance. We therefore
+/// prefer a truncated SHAKE256 over SHAKE128.
+///
+/// #Examples
+/// ```rust
+/// # use rosenpass_ciphers::subtle::keyed_shake256::hash;
+/// use rosenpass_to::To;
+/// let key: [u8; 32] = [0; 32];
+/// let data: [u8; 32] = [255; 32];
+/// // buffer for the hash output
+/// let mut hash_data: [u8; 32] = [0u8; 32];
+///
+/// assert!(hash(&key, &data).to(&mut hash_data).is_ok(), "Hashing has to return OK result");
+/// # let expected_hash: &[u8] = &[166, 35, 212, 217, 225, 226, 193, 131, 163, 196, 223, 79, 56,
+/// 193, 107, 23, 45, 213, 14, 86, 198, 177, 49, 182, 233, 217, 157, 39, 188, 240, 140, 163];
+/// # assert_eq!(hash_data, expected_hash);
+/// ```
+pub fn hash<'a>(key: &'a [u8], data: &'a [u8]) -> impl To<[u8], anyhow::Result<()>> + 'a {
+    with_destination(|out: &mut [u8]| {
+        // Since SHAKE256 is a XOF, we fix the output length manually to what is required for the
+        // protocol.
+        ensure!(out.len() == OUT_LEN);
+        let mut out: [u8; OUT_LEN] = out.try_into().unwrap();
+        // Not bothering with padding; the implementation
+        // uses appropriately sized keys.
+        ensure!(key.len() == KEY_LEN);
+        let mut shake256 = Shake256::default();
+        shake256.update(key);
+        shake256.update(data);
+
+        // Following the NIST recommendations in Section A.2 of the FIPS 202 standard,
+        // (pages 24/25, i.e., 32/33 in the PDF) we append the length of the input to the end of
+        // the input. This prevents that if the same input is used with two different output lengths,
+        // the shorter output is a prefix of the longer output. See the Section A.2 of the FIPS 202
+        // standard for more details.
+        shake256.update(&((OUT_LEN as u8).to_le_bytes()));
+        shake256.finalize_xof().read(&mut out);
+        Ok(())
+    })
+}

--- a/ciphers/src/subtle/mod.rs
+++ b/ciphers/src/subtle/mod.rs
@@ -4,10 +4,14 @@
 /// - [chacha20poly1305_ietf_libcrux]: The Chacha20Poly1305 AEAD as implemented in [libcrux](https://github.com/cryspen/libcrux) (only used when the feature `experiment_libcrux` is enabled).
 /// - [incorrect_hmac_blake2b]: An (incorrect) hmac based on [blake2b].
 /// - [xchacha20poly1305_ietf] The Chacha20Poly1305 AEAD as implemented in [RustCrypto](https://crates.io/crates/chacha20poly1305)
+#[cfg(not(feature = "experiment_sha3"))]
 pub mod blake2b;
 #[cfg(not(feature = "experiment_libcrux"))]
 pub mod chacha20poly1305_ietf;
 #[cfg(feature = "experiment_libcrux")]
 pub mod chacha20poly1305_ietf_libcrux;
+#[cfg(not(feature = "experiment_sha3"))]
 pub mod incorrect_hmac_blake2b;
+#[cfg(feature = "experiment_sha3")]
+pub mod keyed_shake256;
 pub mod xchacha20poly1305_ietf;

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2021"
 
 [features]
 experiment_libcrux = ["rosenpass-ciphers/experiment_libcrux"]
+experiment_sha3 = ["rosenpass-ciphers/experiment_sha3"]
 
 [package.metadata]
 cargo-fuzz = true

--- a/fuzz/fuzz_targets/blake2b.rs
+++ b/fuzz/fuzz_targets/blake2b.rs
@@ -3,16 +3,16 @@ extern crate arbitrary;
 extern crate rosenpass;
 
 use libfuzzer_sys::fuzz_target;
-
+#[cfg(not(feature = "experiment_sha3"))]
 use rosenpass_ciphers::subtle::blake2b;
 use rosenpass_to::To;
-
+#[cfg(not(feature = "experiment_sha3"))]
 #[derive(arbitrary::Arbitrary, Debug)]
 pub struct Blake2b {
     pub key: [u8; 32],
     pub data: Box<[u8]>,
 }
-
+#[cfg(not(feature = "experiment_sha3"))]
 fuzz_target!(|input: Blake2b| {
     let mut out = [0u8; 32];
 


### PR DESCRIPTION
This PR adds support for using a keyed version of SHAKE256, truncated to 32 bytes, instead of the incorrect HMAC with Blake2b as the PRF for key derivation for rosenpass.

This feature is a compile time flag as of now, namely the flag "experiment_sha3".

Since there is also fuzzing for Blake2b, this PR also disables this fuzzing if the feature "experiment_sha3" is disabled.

