### PR TITLE
ci(supply-chain+dependabot): Automatically create exemptions for cargo-crev for dependa-bot PRs

### DIFF
--- a/.github/workflows/cargo-crev-exemptions-dependabot.yml
+++ b/.github/workflows/cargo-crev-exemptions-dependabot.yml
@@ -1,0 +1,58 @@
+name: Dependabot Vet Exemptions
+on:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - "Cargo.toml"
+      - "Cargo.lock"
+
+jobs:
+  dependabot-cargo-crev-exceptions:
+    if: github.actor == 'dependabot[bot]' # Run only for Dependabot PRs
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.head_ref }}
+          token: ${{ secrets.GITHUB_TOKEN }} # Ensure push access
+
+      - uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+          key: cargo-vet-cache
+
+      - name: Install stable toolchain # Since we are running/compiling cargo-vet, we should rely on the stable toolchain.
+        run: |
+          rustup toolchain install stable
+          rustup default stable
+
+      - uses: actions/cache@v4
+        with:
+          path: ${{ runner.tool_cache }}/cargo-vet
+          key: cargo-vet-bin
+
+      - name: Add the tool cache directory to the search path
+        run: echo "${{ runner.tool_cache }}/cargo-vet/bin" >> $GITHUB_PATH
+
+      - name: Ensure that the tool cache is populated with the cargo-vet binary
+        run: cargo install --root ${{ runner.tool_cache }}/cargo-vet cargo-vet
+
+      - name: Regenerate vet exemptions
+        run: cargo vet regenerate exemptions
+
+      - name: Check for changes
+        run: git diff --exit-code || echo "Changes detected, committing..."
+
+      - name: Commit and push changes
+        if: success()
+        run: |
+          git config --global user.name "github-actions[bot]"
+          git config --global user.email "github-actions@github.com"
+          git add supply-chain./*
+          git commit -m "Regenerate cargo vet exemptions"
+          git push origin ${{ github.head_ref }}


### PR DESCRIPTION
This PR adds a new CI workflow that only triggers for PRs by dependabot. When triggered, it regenerates the exemptions for cargo-crev so that the cargo-crev does not fail for dependabot PR and these can be merged.

Since the CI job only triggers for dependabot, this has to be tested on the main branch.