### PR TITLE
ci(cargo-crev): Fix regeneration of cargo-crev-exemptions

### DIFF
--- a/.github/workflows/cargo-crev-exemptions-dependabot.yml
+++ b/.github/workflows/cargo-crev-exemptions-dependabot.yml
@@ -53,6 +53,6 @@ jobs:
         run: |
           git config --global user.name "github-actions[bot]"
           git config --global user.email "github-actions@github.com"
-          git add supply-chain./*
+          git add supply-chain/*
           git commit -m "Regenerate cargo vet exemptions"
           git push origin ${{ github.head_ref }}


### PR DESCRIPTION
This PR fixes a typo that makes the regeneration of the cargo-crev exemtpions for dependabot-PRs fail.