### PR TITLE
chore: Ignore rust advisory RUSTSEC-2023-0089

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -27,6 +27,7 @@ feature-depth = 1
 ignore = [
     "RUSTSEC-2024-0370",
     "RUSTSEC-2024-0436",
+    "RUSTSEC-2023-0089",
 ]
 # If this is true, then cargo deny will use the git executable to fetch advisory database.
 # If this is false, then it uses a built-in git library.


### PR DESCRIPTION
error[unmaintained]: atomic-polyfill is unmaintained
   ┌─ /github/workspace/Cargo.lock:15:1
   │
15 │ atomic-polyfill 1.0.3 registry+https://github.com/rust-lang/crates.io-index
   │ ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ unmaintained advisory detected
   │
   ├ ID: RUSTSEC-2023-0089
   ├ Advisory: https://rustsec.org/advisories/RUSTSEC-2023-0089
   ├ The author has archived the GitHub repository and mentions deprecation in
     project's
     [README](https://github.com/embassy-rs/atomic-polyfill/blob/48e55c166684f37af0b00fbee5a0809b1a2bae8e/README.md).

     ## Possible alternatives

      * [portable-atomic](https://crates.io/crates/portable-atomic) ├ Announcement: https://github.com/embassy-rs/atomic-polyfill/commit/48e55c166684f37af0b00fbee5a0809b1a2bae8e ├ Solution: No safe upgrade is available! ├ atomic-polyfill v1.0.3 └── heapless v0.7.17 ├── aead v0.5.2
         │   └── chacha20poly1305 v0.10.1
         │       └── rosenpass-ciphers v0.1.0
         │           ├── rosenpass v0.3.0-dev
         │           │   ├── rosenpass-fuzzing v0.0.1
         │           │   └── rp v0.2.1
         │           ├── rosenpass-fuzzing v0.0.1 (*)
         │           └── rp v0.2.1 (*)
         └── postcard v1.1.1
             └── rosenpass-wireguard-broker v0.1.0
                 ├── rosenpass v0.3.0-dev (*)
                 └── rp v0.2.1 (*)