### PR TITLE
fix: make CI workflows run after pushing excemptions for cargo-vet

### DIFF
--- a/.github/workflows/dependent-issues.yml
+++ b/.github/workflows/dependent-issues.yml
@@ -17,6 +17,10 @@ on:
       # this action is required to pass before merging. Otherwise, it
       # can be removed.
       - synchronize
+  workflow_run:
+    workflows: [Regenerate cargo-vet exemptions for dependabot-PRs]
+    types:
+      - completed
 
   # Schedule a daily check. Useful if you reference cross-repository
   # issues or pull requests. Otherwise, it can be removed.
@@ -25,6 +29,8 @@ on:
 
 jobs:
   check:
+    # Only run this for dependabot PRs if it's triggered by the workflow to regenerate cargo-vet exemptions
+    if: ${{ github.actor != 'dependabot[bot]' || github.event_name == 'workflow_run' }}
     permissions:
       issues: write
       pull-requests: write

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -14,6 +14,15 @@ on:
       - ".github/workflows/docker.yaml"
     branches:
       - "main"
+  workflow_run:
+    workflows: [Regenerate cargo-vet exemptions for dependabot-PRs]
+    types:
+      - completed
+    paths:
+      - "docker/Dockerfile"
+      - ".github/workflows/docker.yaml"
+    branches:
+      - "main"
 
 permissions:
   contents: read
@@ -24,6 +33,8 @@ jobs:
   # 1. BUILD & TEST
   # --------------------------------
   build-and-test-rp:
+    # Only run this for dependabot PRs if it's triggered by the workflow to regenerate cargo-vet exemptions
+    if: ${{ github.actor != 'dependabot[bot]' || github.event_name == 'workflow_run' }}
     strategy:
       matrix:
         arch: [amd64, arm64]
@@ -118,8 +129,8 @@ jobs:
   docker-image-rp:
     needs:
       - build-and-test-rp
-    # Skip if this is not a PR. Then we want to push this image.
-    if: ${{ github.event_name != 'pull_request' }}
+    # Only run this job if it s triggered by by a push to the main branch or a version tag.
+    if: ${{ github.event_name != 'pull_request' && github.event_name != 'workflow_run' }}
     # Use a matrix to build for both AMD64 and ARM64
     strategy:
       matrix:
@@ -183,8 +194,8 @@ jobs:
   docker-image-rosenpass:
     needs:
       - build-and-test-rp
-    # Skip if this is not a PR. Then we want to push this image.
-    if: ${{ github.event_name != 'pull_request' }}
+    # Only run this job if it s triggered by by a push to the main branch or a version tag.
+    if: ${{ github.event_name != 'pull_request' && github.event_name != 'workflow_run' }}
     # Use a matrix to build for both AMD64 and ARM64
     strategy:
       matrix:
@@ -249,7 +260,7 @@ jobs:
     needs:
       - docker-image-rosenpass
       - docker-image-rp
-    if: ${{ github.event_name != 'pull_request' }}
+    if: ${{ github.event_name != 'pull_request' && github.event_name != 'workflow_run' }}
     strategy:
       matrix:
         target: [rp, rosenpass]

--- a/.github/workflows/nix-mac.yaml
+++ b/.github/workflows/nix-mac.yaml
@@ -13,6 +13,8 @@ concurrency:
 
 jobs:
   aarch64-darwin---default:
+    # Only run this for dependabot PRs if it's triggered by the workflow to regenerate cargo-vet exemptions or explicitly called
+    if: ${{ github.actor != 'dependabot[bot]' || github.event_name == 'workflow_run' || github.event_name == 'workflow_call'}}
     name: Build aarch64-darwin.default
     runs-on:
       - warp-macos-13-arm64-6x
@@ -30,6 +32,8 @@ jobs:
       - name: Build
         run: nix build .#packages.aarch64-darwin.default --print-build-logs
   aarch64-darwin---release-package:
+    # Only run this for dependabot PRs if it's triggered by the workflow to regenerate cargo-vet exemptions or explicitly called
+    if: ${{ github.actor != 'dependabot[bot]' || github.event_name == 'workflow_run' || github.event_name == 'workflow_call'}}
     name: Build aarch64-darwin.release-package
     runs-on:
       - warp-macos-13-arm64-6x
@@ -49,6 +53,8 @@ jobs:
       - name: Build
         run: nix build .#packages.aarch64-darwin.release-package --print-build-logs
   aarch64-darwin---rosenpass:
+    # Only run this for dependabot PRs if it's triggered by the workflow to regenerate cargo-vet exemptions or explicitly called
+    if: ${{ github.actor != 'dependabot[bot]' || github.event_name == 'workflow_run' || github.event_name == 'workflow_call'}}
     name: Build aarch64-darwin.rosenpass
     runs-on:
       - warp-macos-13-arm64-6x
@@ -65,6 +71,8 @@ jobs:
       - name: Build
         run: nix build .#packages.aarch64-darwin.rosenpass --print-build-logs
   aarch64-darwin---rp:
+    # Only run this for dependabot PRs if it's triggered by the workflow to regenerate cargo-vet exemptions or explicitly called
+    if: ${{ github.actor != 'dependabot[bot]' || github.event_name == 'workflow_run' || github.event_name == 'workflow_call'}}
     name: Build aarch64-darwin.rp
     runs-on:
       - warp-macos-13-arm64-6x
@@ -81,6 +89,8 @@ jobs:
       - name: Build
         run: nix build .#packages.aarch64-darwin.rp --print-build-logs
   aarch64-darwin---rosenpass-oci-image:
+    # Only run this for dependabot PRs if it's triggered by the workflow to regenerate cargo-vet exemptions or explicitly called
+    if: ${{ github.actor != 'dependabot[bot]' || github.event_name == 'workflow_run' || github.event_name == 'workflow_call'}}
     name: Build aarch64-darwin.rosenpass-oci-image
     runs-on:
       - warp-macos-13-arm64-6x
@@ -98,6 +108,8 @@ jobs:
       - name: Build
         run: nix build .#packages.aarch64-darwin.rosenpass-oci-image --print-build-logs
   aarch64-darwin---check:
+    # Only run this for dependabot PRs if it's triggered by the workflow to regenerate cargo-vet exemptions or explicitly called
+    if: ${{ github.actor != 'dependabot[bot]' || github.event_name == 'workflow_run' || github.event_name == 'workflow_call'}}
     name: Run Nix checks on aarch64-darwin
     runs-on:
       - warp-macos-13-arm64-6x

--- a/.github/workflows/nix.yaml
+++ b/.github/workflows/nix.yaml
@@ -6,6 +6,10 @@ on:
   push:
     branches:
       - main
+  workflow_run:
+    workflows: [Regenerate cargo-vet exemptions for dependabot-PRs]
+    types:
+      - completed
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -13,6 +17,8 @@ concurrency:
 
 jobs:
   i686-linux---default:
+    # Only run this for dependabot PRs if it's triggered by the workflow to regenerate cargo-vet exemptions
+    if: ${{ github.actor != 'dependabot[bot]' || github.event_name == 'workflow_run' }}
     name: Build i686-linux.default
     runs-on:
       - ubicloud-standard-2-ubuntu-2204
@@ -30,6 +36,8 @@ jobs:
       - name: Build
         run: nix build .#packages.i686-linux.default --print-build-logs
   i686-linux---rosenpass:
+    # Only run this for dependabot PRs if it's triggered by the workflow to regenerate cargo-vet exemptions
+    if: ${{ github.actor != 'dependabot[bot]' || github.event_name == 'workflow_run' }}
     name: Build i686-linux.rosenpass
     runs-on:
       - ubicloud-standard-2-ubuntu-2204
@@ -46,6 +54,8 @@ jobs:
       - name: Build
         run: nix build .#packages.i686-linux.rosenpass --print-build-logs
   i686-linux---rosenpass-oci-image:
+    # Only run this for dependabot PRs if it's triggered by the workflow to regenerate cargo-vet exemptions
+    if: ${{ github.actor != 'dependabot[bot]' || github.event_name == 'workflow_run' }}
     name: Build i686-linux.rosenpass-oci-image
     runs-on:
       - ubicloud-standard-2-ubuntu-2204
@@ -63,6 +73,8 @@ jobs:
       - name: Build
         run: nix build .#packages.i686-linux.rosenpass-oci-image --print-build-logs
   i686-linux---check:
+    # Only run this for dependabot PRs if it's triggered by the workflow to regenerate cargo-vet exemptions
+    if: ${{ github.actor != 'dependabot[bot]' || github.event_name == 'workflow_run' }}
     name: Run Nix checks on i686-linux
     runs-on:
       - ubicloud-standard-2-ubuntu-2204
@@ -78,6 +90,8 @@ jobs:
       - name: Check
         run: nix flake check . --print-build-logs
   x86_64-linux---default:
+    # Only run this for dependabot PRs if it's triggered by the workflow to regenerate cargo-vet exemptions
+    if: ${{ github.actor != 'dependabot[bot]' || github.event_name == 'workflow_run' }}
     name: Build x86_64-linux.default
     runs-on:
       - ubicloud-standard-2-ubuntu-2204
@@ -95,6 +109,8 @@ jobs:
       - name: Build
         run: nix build .#packages.x86_64-linux.default --print-build-logs
   x86_64-linux---proof-proverif:
+    # Only run this for dependabot PRs if it's triggered by the workflow to regenerate cargo-vet exemptions
+    if: ${{ github.actor != 'dependabot[bot]' || github.event_name == 'workflow_run' }}
     name: Build x86_64-linux.proof-proverif
     runs-on:
       - ubicloud-standard-2-ubuntu-2204
@@ -112,6 +128,8 @@ jobs:
       - name: Build
         run: nix build .#packages.x86_64-linux.proof-proverif --print-build-logs
   x86_64-linux---proverif-patched:
+    # Only run this for dependabot PRs if it's triggered by the workflow to regenerate cargo-vet exemptions
+    if: ${{ github.actor != 'dependabot[bot]' || github.event_name == 'workflow_run' }}
     name: Build x86_64-linux.proverif-patched
     runs-on:
       - ubicloud-standard-2-ubuntu-2204
@@ -128,6 +146,8 @@ jobs:
       - name: Build
         run: nix build .#packages.x86_64-linux.proverif-patched --print-build-logs
   x86_64-linux---release-package:
+    # Only run this for dependabot PRs if it's triggered by the workflow to regenerate cargo-vet exemptions
+    if: ${{ github.actor != 'dependabot[bot]' || github.event_name == 'workflow_run' }}
     name: Build x86_64-linux.release-package
     runs-on:
       - ubicloud-standard-2-ubuntu-2204
@@ -171,6 +191,8 @@ jobs:
   #     - name: Build
   #       run: nix build .#packages.aarch64-linux.release-package --print-build-logs
   x86_64-linux---rosenpass:
+    # Only run this for dependabot PRs if it's triggered by the workflow to regenerate cargo-vet exemptions
+    if: ${{ github.actor != 'dependabot[bot]' || github.event_name == 'workflow_run' }}
     name: Build x86_64-linux.rosenpass
     runs-on:
       - ubicloud-standard-2-ubuntu-2204
@@ -187,6 +209,8 @@ jobs:
       - name: Build
         run: nix build .#packages.x86_64-linux.rosenpass --print-build-logs
   aarch64-linux---rosenpass:
+    # Only run this for dependabot PRs if it's triggered by the workflow to regenerate cargo-vet exemptions
+    if: ${{ github.actor != 'dependabot[bot]' || github.event_name == 'workflow_run' }}
     name: Build aarch64-linux.rosenpass
     runs-on:
       - ubicloud-standard-2-arm-ubuntu-2204
@@ -208,6 +232,8 @@ jobs:
       - name: Build
         run: nix build .#packages.aarch64-linux.rosenpass --print-build-logs
   aarch64-linux---rp:
+    # Only run this for dependabot PRs if it's triggered by the workflow to regenerate cargo-vet exemptions
+    if: ${{ github.actor != 'dependabot[bot]' || github.event_name == 'workflow_run' }}
     name: Build aarch64-linux.rp
     runs-on:
       - ubicloud-standard-2-arm-ubuntu-2204
@@ -229,6 +255,8 @@ jobs:
       - name: Build
         run: nix build .#packages.aarch64-linux.rp --print-build-logs
   x86_64-linux---rosenpass-oci-image:
+    # Only run this for dependabot PRs if it's triggered by the workflow to regenerate cargo-vet exemptions
+    if: ${{ github.actor != 'dependabot[bot]' || github.event_name == 'workflow_run' }}
     name: Build x86_64-linux.rosenpass-oci-image
     runs-on:
       - ubicloud-standard-2-ubuntu-2204
@@ -246,6 +274,8 @@ jobs:
       - name: Build
         run: nix build .#packages.x86_64-linux.rosenpass-oci-image --print-build-logs
   aarch64-linux---rosenpass-oci-image:
+    # Only run this for dependabot PRs if it's triggered by the workflow to regenerate cargo-vet exemptions
+    if: ${{ github.actor != 'dependabot[bot]' || github.event_name == 'workflow_run' }}
     name: Build aarch64-linux.rosenpass-oci-image
     runs-on:
       - ubicloud-standard-2-arm-ubuntu-2204
@@ -268,6 +298,8 @@ jobs:
       - name: Build
         run: nix build .#packages.aarch64-linux.rosenpass-oci-image --print-build-logs
   x86_64-linux---rosenpass-static:
+    # Only run this for dependabot PRs if it's triggered by the workflow to regenerate cargo-vet exemptions
+    if: ${{ github.actor != 'dependabot[bot]' || github.event_name == 'workflow_run' }}
     name: Build x86_64-linux.rosenpass-static
     runs-on:
       - ubicloud-standard-2-ubuntu-2204
@@ -284,6 +316,8 @@ jobs:
       - name: Build
         run: nix build .#packages.x86_64-linux.rosenpass-static --print-build-logs
   x86_64-linux---rp-static:
+    # Only run this for dependabot PRs if it's triggered by the workflow to regenerate cargo-vet exemptions
+    if: ${{ github.actor != 'dependabot[bot]' || github.event_name == 'workflow_run' }}
     name: Build x86_64-linux.rp-static
     runs-on:
       - ubicloud-standard-2-ubuntu-2204
@@ -300,6 +334,8 @@ jobs:
       - name: Build
         run: nix build .#packages.x86_64-linux.rp-static --print-build-logs
   x86_64-linux---rosenpass-static-oci-image:
+    # Only run this for dependabot PRs if it's triggered by the workflow to regenerate cargo-vet exemptions
+    if: ${{ github.actor != 'dependabot[bot]' || github.event_name == 'workflow_run' }}
     name: Build x86_64-linux.rosenpass-static-oci-image
     runs-on:
       - ubicloud-standard-2-ubuntu-2204
@@ -317,6 +353,8 @@ jobs:
       - name: Build
         run: nix build .#packages.x86_64-linux.rosenpass-static-oci-image --print-build-logs
   x86_64-linux---whitepaper:
+    # Only run this for dependabot PRs if it's triggered by the workflow to regenerate cargo-vet exemptions
+    if: ${{ github.actor != 'dependabot[bot]' || github.event_name == 'workflow_run' }}
     name: Build x86_64-linux.whitepaper
     runs-on:
       - ubicloud-standard-2-ubuntu-2204
@@ -333,6 +371,8 @@ jobs:
       - name: Build
         run: nix build .#packages.x86_64-linux.whitepaper --print-build-logs
   x86_64-linux---check:
+    # Only run this for dependabot PRs if it's triggered by the workflow to regenerate cargo-vet exemptions
+    if: ${{ github.actor != 'dependabot[bot]' || github.event_name == 'workflow_run' }}
     name: Run Nix checks on x86_64-linux
     runs-on:
       - ubicloud-standard-2-ubuntu-2204
@@ -350,7 +390,8 @@ jobs:
   x86_64-linux---whitepaper-upload:
     name: Upload whitepaper x86_64-linux
     runs-on: ubicloud-standard-2-ubuntu-2204
-    if: ${{ github.ref == 'refs/heads/main' }}
+    # Only run this for dependabot PRs if it's triggered by the workflow to regenerate cargo-vet exemptions
+    if: ${{ (github.ref == 'refs/heads/main') && (github.actor != 'dependabot[bot]' || github.event_name == 'workflow_run') }}
     steps:
       - uses: actions/checkout@v4
       - uses: cachix/install-nix-action@v30

--- a/.github/workflows/qc-mac.yaml
+++ b/.github/workflows/qc-mac.yaml
@@ -14,6 +14,8 @@ permissions:
 
 jobs:
   cargo-test-mac:
+    # Only run this for dependabot PRs if it's triggered by the workflow to regenerate cargo-vet exemptions or explicitly called
+    if: ${{ github.actor != 'dependabot[bot]' || github.event_name == 'workflow_run' || github.event_name == 'workflow_call'}}
     runs-on: warp-macos-13-arm64-6x
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/qc.yaml
+++ b/.github/workflows/qc.yaml
@@ -3,6 +3,10 @@ on:
   pull_request:
   push:
     branches: [main]
+  workflow_run:
+    workflows: [Regenerate cargo-vet exemptions for dependabot-PRs]
+    types:
+      - completed
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -14,6 +18,8 @@ permissions:
 
 jobs:
   prettier:
+    # Only run this for dependabot PRs if it's triggered by the workflow to regenerate cargo-vet exemptions
+    if: ${{ github.actor != 'dependabot[bot]' || github.event_name == 'workflow_run' }}
     runs-on: ubicloud-standard-2-ubuntu-2204
     steps:
       - uses: actions/checkout@v4
@@ -22,6 +28,8 @@ jobs:
           args: --check .
 
   shellcheck:
+    # Only run this for dependabot PRs if it's triggered by the workflow to regenerate cargo-vet exemptions
+    if: ${{ github.actor != 'dependabot[bot]' || github.event_name == 'workflow_run' }}
     name: Shellcheck
     runs-on: ubicloud-standard-2-ubuntu-2204
     steps:
@@ -30,6 +38,8 @@ jobs:
         uses: ludeeus/action-shellcheck@master
 
   rustfmt:
+    # Only run this for dependabot PRs if it's triggered by the workflow to regenerate cargo-vet exemptions
+    if: ${{ github.actor != 'dependabot[bot]' || github.event_name == 'workflow_run' }}
     name: Rust Format
     runs-on: ubicloud-standard-2-ubuntu-2204
     steps:
@@ -38,6 +48,8 @@ jobs:
         run: bash format_rust_code.sh --mode check
 
   cargo-bench:
+    # Only run this for dependabot PRs if it's triggered by the workflow to regenerate cargo-vet exemptions
+    if: ${{ github.actor != 'dependabot[bot]' || github.event_name == 'workflow_run' }}
     runs-on: ubicloud-standard-2-ubuntu-2204
     steps:
       - uses: actions/checkout@v4
@@ -56,6 +68,8 @@ jobs:
       - run: RUST_MIN_STACK=8388608 cargo bench --workspace --exclude rosenpass-fuzzing
 
   mandoc:
+    # Only run this for dependabot PRs if it's triggered by the workflow to regenerate cargo-vet exemptions
+    if: ${{ github.actor != 'dependabot[bot]' || github.event_name == 'workflow_run' }}
     name: mandoc
     runs-on: ubicloud-standard-2-ubuntu-2204
     steps:
@@ -66,6 +80,8 @@ jobs:
         run: doc/check.sh doc/rp.1
 
   cargo-audit:
+    # Only run this for dependabot PRs if it's triggered by the workflow to regenerate cargo-vet exemptions
+    if: ${{ github.actor != 'dependabot[bot]' || github.event_name == 'workflow_run' }}
     runs-on: ubicloud-standard-2-ubuntu-2204
     steps:
       - uses: actions/checkout@v4
@@ -74,6 +90,8 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
 
   cargo-clippy:
+    # Only run this for dependabot PRs if it's triggered by the workflow to regenerate cargo-vet exemptions
+    if: ${{ github.actor != 'dependabot[bot]' || github.event_name == 'workflow_run' }}
     runs-on: ubicloud-standard-2-ubuntu-2204
     steps:
       - uses: actions/checkout@v4
@@ -93,6 +111,8 @@ jobs:
           args: --all-features
 
   cargo-doc:
+    # Only run this for dependabot PRs if it's triggered by the workflow to regenerate cargo-vet exemptions
+    if: ${{ github.actor != 'dependabot[bot]' || github.event_name == 'workflow_run' }}
     runs-on: ubicloud-standard-2-ubuntu-2204
     steps:
       - uses: actions/checkout@v4
@@ -112,6 +132,8 @@ jobs:
       - run: RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --document-private-items
 
   cargo-test:
+    # Only run this for dependabot PRs if it's triggered by the workflow to regenerate cargo-vet exemptions
+    if: ${{ github.actor != 'dependabot[bot]' || github.event_name == 'workflow_run' }}
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -135,6 +157,8 @@ jobs:
       - run: RUST_MIN_STACK=8388608 cargo test --workspace --all-features
 
   cargo-test-nix-devshell-x86_64-linux:
+    # Only run this for dependabot PRs if it's triggered by the workflow to regenerate cargo-vet exemptions
+    if: ${{ github.actor != 'dependabot[bot]' || github.event_name == 'workflow_run' }}
     runs-on:
       - ubicloud-standard-2-ubuntu-2204
     steps:
@@ -158,6 +182,8 @@ jobs:
       - run: nix develop --command cargo test --workspace --all-features
 
   cargo-fuzz:
+    # Only run this for dependabot PRs if it's triggered by the workflow to regenerate cargo-vet exemptions
+    if: ${{ github.actor != 'dependabot[bot]' || github.event_name == 'workflow_run' }}
     runs-on: ubicloud-standard-2-ubuntu-2204
     env:
     steps:
@@ -192,6 +218,8 @@ jobs:
           cargo fuzz run fuzz_vec_secret_alloc_memfdsec_mallocfb -- -max_total_time=5
 
   codecov:
+    # Only run this for dependabot PRs if it's triggered by the workflow to regenerate cargo-vet exemptions
+    if: ${{ github.actor != 'dependabot[bot]' || github.event_name == 'workflow_run' }}
     runs-on: ubicloud-standard-2-ubuntu-2204
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/regenerate-cargo-vet-exemptions.yml
+++ b/.github/workflows/regenerate-cargo-vet-exemptions.yml
@@ -1,0 +1,54 @@
+name: Regenerate cargo-vet exemptions for dependabot-PRs
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  regen-cargo-vet-exemptions:
+    if: ${{ github.actor == 'dependabot[bot]' }}
+    name: Regenerate exemptions for cargo-vet for dependabot-PRs
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+          key: cargo-vet-cache
+      - name: Install stable toolchain # Since we are running/compiling cargo-vet, we should rely on the stable toolchain.
+        run: |
+          rustup toolchain install stable
+          rustup default stable
+      - uses: actions/cache@v4
+        with:
+          path: ${{ runner.tool_cache }}/cargo-vet
+          key: cargo-vet-bin
+      - name: Add the tool cache directory to the search path
+        run: echo "${{ runner.tool_cache }}/cargo-vet/bin" >> $GITHUB_PATH
+      - name: Ensure that the tool cache is populated with the cargo-vet binary
+        run: cargo install --root ${{ runner.tool_cache }}/cargo-vet cargo-vet
+      - name: Regenerate vet exemptions for dependabot PRs
+        run: cargo vet regenerate exemptions
+      - name: Check for changes in case of dependabot PR
+        run: git diff --exit-code || echo "Changes detected, committing..."
+      - name: Commit and push changes for dependabot PRs
+        if: ${{ success() }}
+        run: |
+          git fetch origin ${{ github.head_ref }}
+          git switch ${{ github.head_ref }}
+          git config --global user.name "github-actions[bot]"
+          git config --global user.email "github-actions@github.com"
+          git add supply-chain/*
+          git commit -m "Regenerate cargo vet exemptions"
+          git push origin ${{ github.head_ref }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/regressions.yml
+++ b/.github/workflows/regressions.yml
@@ -3,6 +3,10 @@ on:
   pull_request:
   push:
     branches: [main]
+  workflow_run:
+    workflows: [Regenerate cargo-vet exemptions for dependabot-PRs]
+    types:
+      - completed
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -14,6 +18,8 @@ permissions:
 
 jobs:
   multi-peer:
+    # Only run this for dependabot PRs if it's triggered by the workflow to regenerate cargo-vet exemptions
+    if: ${{ github.actor != 'dependabot[bot]' || github.event_name == 'workflow_run' }}
     runs-on: ubicloud-standard-2-ubuntu-2204
     steps:
       - uses: actions/checkout@v4
@@ -25,6 +31,8 @@ jobs:
           [ $(ls -1 output/ate/out | wc -l) -eq 100 ]
 
   boot-race:
+    # Only run this for dependabot PRs if it's triggered by the workflow to regenerate cargo-vet exemptions
+    if: ${{ github.actor != 'dependabot[bot]' || github.event_name == 'workflow_run' }}
     runs-on: ubicloud-standard-2-ubuntu-2204
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/supply-chain.yml
+++ b/.github/workflows/supply-chain.yml
@@ -3,6 +3,10 @@ on:
   pull_request:
   push:
     branches: [main]
+  workflow_run:
+    workflows: [Regenerate cargo-vet exemptions for dependabot-PRs]
+    types:
+      - completed
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -10,12 +14,16 @@ concurrency:
 
 jobs:
   cargo-deny:
+    # Only run this for dependabot PRs if it's triggered by the workflow to regenerate cargo-vet exemptions
+    if: ${{ github.actor != 'dependabot[bot]' || github.event_name == 'workflow_run' }}
     name: Deny dependencies with vulnerabilities or incompatible licenses
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: EmbarkStudios/cargo-deny-action@v2
   cargo-supply-chain:
+    # Only run this for dependabot PRs if it's triggered by the workflow to regenerate cargo-vet exemptions
+    if: ${{ github.actor != 'dependabot[bot]' || github.event_name == 'workflow_run' }}
     name: Supply Chain Report
     runs-on: ubuntu-latest
     steps:
@@ -44,10 +52,10 @@ jobs:
         run: cargo supply-chain crates
     # The setup for cargo-vet follows the recommendations in the cargo-vet documentation: https://mozilla.github.io/cargo-vet/configuring-ci.html
   cargo-vet:
+    # Only run this for dependabot PRs if it's triggered by the workflow to regenerate cargo-vet exemptions
+    if: ${{ github.actor != 'dependabot[bot]' || github.event_name == 'workflow_run' }}
     name: Vet Dependencies
     runs-on: ubuntu-latest
-    permissions:
-      contents: write
     steps:
       - uses: actions/checkout@v4
       - uses: actions/cache@v4
@@ -69,23 +77,5 @@ jobs:
         run: echo "${{ runner.tool_cache }}/cargo-vet/bin" >> $GITHUB_PATH
       - name: Ensure that the tool cache is populated with the cargo-vet binary
         run: cargo install --root ${{ runner.tool_cache }}/cargo-vet cargo-vet
-      - name: Regenerate vet exemptions for dependabot PRs
-        if: github.actor == 'dependabot[bot]' # Run only for Dependabot PRs
-        run: cargo vet regenerate exemptions
-      - name: Check for changes in case of dependabot PR
-        if: github.actor == 'dependabot[bot]' # Run only for Dependabot PRs
-        run: git diff --exit-code || echo "Changes detected, committing..."
-      - name: Commit and push changes for dependabot PRs
-        if: success() && github.actor == 'dependabot[bot]'
-        run: |
-          git fetch origin ${{ github.head_ref }}
-          git switch ${{ github.head_ref }}
-          git config --global user.name "github-actions[bot]"
-          git config --global user.email "github-actions@github.com"
-          git add supply-chain/*
-          git commit -m "Regenerate cargo vet exemptions"
-          git push origin ${{ github.head_ref }}
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Invoke cargo-vet
         run: cargo vet --locked


### PR DESCRIPTION
This PR changes the CI for dependabot PRs such that initially, only the exemptions for cargo vet are regenerated and pushed to the PR.
Only after that, all other workflows are triggered. This ensures that the CI result for dependabot PRs is properly presented on github.