### PR TITLE
feat(sha3+paper): add information on how SHAKE256 is used in rosenpass to the whitepaper

### DIFF
--- a/papers/references.bib
+++ b/papers/references.bib
@@ -196,3 +196,13 @@ Vadim Lyubashevsky and John M. Schanck and Peter Schwabe and Gregor Seiler and D
     type = {NIST Post-Quantum Cryptography Selected Algorithm},
     url = {https://pq-crystals.org/kyber/}
 }
+
+
+@misc{SHAKE256,
+  author   = "National Institute of Standards and Technology",
+  title    = "FIPS PUB 202: SHA-3 Standard: Permutation-Based Hash and Extendable-Output Functions",
+  year     = {2015},
+  month    = {August},
+  doi      = {10.6028/NIST.FIPS.202}
+}
+


### PR DESCRIPTION
This PR adds how SHAKE256 has been introduced to rosenpass and how it interfaces with the protocol in the reference implementation.