### PR TITLE
Use serde for JSON-encoding benchmark data

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2068,6 +2068,7 @@ dependencies = [
  "rosenpass-wireguard-broker",
  "rustix",
  "serde",
+ "serde_json",
  "serial_test",
  "signal-hook",
  "signal-hook-mio",
@@ -2376,9 +2377,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.139"
+version = "1.0.140"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44f86c3acccc9c65b153fe1b85a3be07fe5515274ec9f0653b4a0875731c72a6"
+checksum = "20068b6e96dc6c9bd23e01df8827e6c7e1f2fddd43c21810382803c136b99373"
 dependencies = [
  "itoa",
  "memchr",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,17 +2,17 @@
 resolver = "2"
 
 members = [
-    "rosenpass",
-    "cipher-traits",
-    "ciphers",
-    "util",
-    "constant-time",
-    "oqs",
-    "to",
-    "fuzz",
-    "secret-memory",
-    "rp",
-    "wireguard-broker",
+  "rosenpass",
+  "cipher-traits",
+  "ciphers",
+  "util",
+  "constant-time",
+  "oqs",
+  "to",
+  "fuzz",
+  "secret-memory",
+  "rp",
+  "wireguard-broker",
 ]
 
 default-members = ["rosenpass", "rp", "wireguard-broker"]
@@ -42,7 +42,7 @@ toml = "0.7.8"
 static_assertions = "1.1.0"
 allocator-api2 = "0.2.14"
 memsec = { git = "https://github.com/rosenpass/memsec.git", rev = "aceb9baee8aec6844125bd6612f92e9a281373df", features = [
-    "alloc_ext",
+  "alloc_ext",
 ] }
 rand = "0.8.5"
 typenum = "1.17.0"
@@ -57,14 +57,14 @@ mio = { version = "1.0.3", features = ["net", "os-poll"] }
 signal-hook-mio = { version = "0.2.4", features = ["support-v1_0"] }
 signal-hook = "0.3.17"
 oqs-sys = { version = "0.9.1", default-features = false, features = [
-    'classic_mceliece',
-    'kyber',
+  'classic_mceliece',
+  'kyber',
 ] }
 blake2 = "0.10.6"
 sha3 = "0.10.8"
 chacha20poly1305 = { version = "0.10.1", default-features = false, features = [
-    "std",
-    "heapless",
+  "std",
+  "heapless",
 ] }
 zerocopy = { version = "0.7.35", features = ["derive"] }
 home = "=0.5.9" # 5.11 requires rustc 1.81

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,17 +2,17 @@
 resolver = "2"
 
 members = [
-  "rosenpass",
-  "cipher-traits",
-  "ciphers",
-  "util",
-  "constant-time",
-  "oqs",
-  "to",
-  "fuzz",
-  "secret-memory",
-  "rp",
-  "wireguard-broker",
+    "rosenpass",
+    "cipher-traits",
+    "ciphers",
+    "util",
+    "constant-time",
+    "oqs",
+    "to",
+    "fuzz",
+    "secret-memory",
+    "rp",
+    "wireguard-broker",
 ]
 
 default-members = ["rosenpass", "rp", "wireguard-broker"]
@@ -42,7 +42,7 @@ toml = "0.7.8"
 static_assertions = "1.1.0"
 allocator-api2 = "0.2.14"
 memsec = { git = "https://github.com/rosenpass/memsec.git", rev = "aceb9baee8aec6844125bd6612f92e9a281373df", features = [
-  "alloc_ext",
+    "alloc_ext",
 ] }
 rand = "0.8.5"
 typenum = "1.17.0"
@@ -57,14 +57,14 @@ mio = { version = "1.0.3", features = ["net", "os-poll"] }
 signal-hook-mio = { version = "0.2.4", features = ["support-v1_0"] }
 signal-hook = "0.3.17"
 oqs-sys = { version = "0.9.1", default-features = false, features = [
-  'classic_mceliece',
-  'kyber',
+    'classic_mceliece',
+    'kyber',
 ] }
 blake2 = "0.10.6"
 sha3 = "0.10.8"
 chacha20poly1305 = { version = "0.10.1", default-features = false, features = [
-  "std",
-  "heapless",
+    "std",
+    "heapless",
 ] }
 zerocopy = { version = "0.7.35", features = ["derive"] }
 home = "=0.5.9" # 5.11 requires rustc 1.81
@@ -92,6 +92,7 @@ test_bin = "0.4.0"
 criterion = "0.5.1"
 allocator-api2-tests = "0.2.15"
 procspawn = { version = "1.0.1", features = ["test-support"] }
+serde_json = { version = "1.0.140" }
 
 #Broker dependencies (might need cleanup or changes)
 wireguard-uapi = { version = "3.0.0", features = ["xplatform"] }

--- a/rosenpass/Cargo.toml
+++ b/rosenpass/Cargo.toml
@@ -30,9 +30,9 @@ required-features = ["experiment_api", "internal_testing"]
 [[test]]
 name = "gen-ipc-msg-types"
 required-features = [
-  "experiment_api",
-  "internal_testing",
-  "internal_bin_gen_ipc_msg_types",
+    "experiment_api",
+    "internal_testing",
+    "internal_bin_gen_ipc_msg_types",
 ]
 
 [[bench]]
@@ -91,24 +91,24 @@ serial_test = { workspace = true }
 procspawn = { workspace = true }
 tempfile = { workspace = true }
 rustix = { workspace = true }
+serde_json = { workspace = true }
 
 [features]
-#default = ["experiment_libcrux_all"]
 experiment_cookie_dos_mitigation = []
 experiment_memfd_secret = ["rosenpass-wireguard-broker/experiment_memfd_secret"]
 experiment_libcrux_all = ["rosenpass-ciphers/experiment_libcrux_all"]
 experiment_libcrux_blake2 = ["rosenpass-ciphers/experiment_libcrux_blake2"]
 experiment_libcrux_chachapoly = [
-  "rosenpass-ciphers/experiment_libcrux_chachapoly",
+    "rosenpass-ciphers/experiment_libcrux_chachapoly",
 ]
 experiment_libcrux_kyber = ["rosenpass-ciphers/experiment_libcrux_kyber"]
 experiment_api = [
-  "hex-literal",
-  "uds",
-  "command-fds",
-  "rustix",
-  "rosenpass-util/experiment_file_descriptor_passing",
-  "rosenpass-wireguard-broker/experiment_api",
+    "hex-literal",
+    "uds",
+    "command-fds",
+    "rustix",
+    "rosenpass-util/experiment_file_descriptor_passing",
+    "rosenpass-wireguard-broker/experiment_api",
 ]
 internal_testing = []
 internal_bin_gen_ipc_msg_types = ["hex", "heck"]

--- a/rosenpass/Cargo.toml
+++ b/rosenpass/Cargo.toml
@@ -30,9 +30,9 @@ required-features = ["experiment_api", "internal_testing"]
 [[test]]
 name = "gen-ipc-msg-types"
 required-features = [
-    "experiment_api",
-    "internal_testing",
-    "internal_bin_gen_ipc_msg_types",
+  "experiment_api",
+  "internal_testing",
+  "internal_bin_gen_ipc_msg_types",
 ]
 
 [[bench]]
@@ -99,16 +99,16 @@ experiment_memfd_secret = ["rosenpass-wireguard-broker/experiment_memfd_secret"]
 experiment_libcrux_all = ["rosenpass-ciphers/experiment_libcrux_all"]
 experiment_libcrux_blake2 = ["rosenpass-ciphers/experiment_libcrux_blake2"]
 experiment_libcrux_chachapoly = [
-    "rosenpass-ciphers/experiment_libcrux_chachapoly",
+  "rosenpass-ciphers/experiment_libcrux_chachapoly",
 ]
 experiment_libcrux_kyber = ["rosenpass-ciphers/experiment_libcrux_kyber"]
 experiment_api = [
-    "hex-literal",
-    "uds",
-    "command-fds",
-    "rustix",
-    "rosenpass-util/experiment_file_descriptor_passing",
-    "rosenpass-wireguard-broker/experiment_api",
+  "hex-literal",
+  "uds",
+  "command-fds",
+  "rustix",
+  "rosenpass-util/experiment_file_descriptor_passing",
+  "rosenpass-wireguard-broker/experiment_api",
 ]
 internal_testing = []
 internal_bin_gen_ipc_msg_types = ["hex", "heck"]

--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -614,7 +614,7 @@ version = "3.0.7"
 criteria = "safe-to-run"
 
 [[exemptions.serde_json]]
-version = "1.0.139"
+version = "1.0.140"
 criteria = "safe-to-deploy"
 
 [[exemptions.serde_spanned]]

--- a/util/src/trace_bench.rs
+++ b/util/src/trace_bench.rs
@@ -10,7 +10,7 @@ static TRACE: OnceLock<RpTrace> = OnceLock::new();
 pub type RpTrace = tracing::MutexTrace<&'static str, Instant>;
 
 /// The trace event type used to trace Rosenpass for performance measurement.
-pub type RpEventType = tracing::TraceEvent<&'static str, Instant>;
+pub type RpEvent = tracing::TraceEvent<&'static str, Instant>;
 
 // Re-export to make functionality available and callers don't need to also directly depend on
 // [`libcrux_test_utils`].


### PR DESCRIPTION
This PR cleans up the way we serialize the JSON in the trace-based protocol benchmarks. We used to do manual serialization based on writing strings, but now we use serde.