### PR TITLE
fix(rosenpass): Fix the error message if the secret key is invalid

### DIFF
--- a/rosenpass/src/config.rs
+++ b/rosenpass/src/config.rs
@@ -364,7 +364,7 @@ impl Rosenpass {
             // check the secret-key file is a valid key
             ensure!(
                 SSk::load(&keypair.secret_key).is_ok(),
-                "could not load public-key file {:?}: invalid key",
+                "could not load secret-key file {:?}: invalid key",
                 keypair.secret_key
             );
         }


### PR DESCRIPTION
This PR fixes the error message that is given if the secret key can not be read. Currently, it incorrectly states that the public key can not be read.