### PR TITLE
fix: Regression caused by benchmarks

### DIFF
--- a/.github/workflows/bench-primitives.yml
+++ b/.github/workflows/bench-primitives.yml
@@ -4,7 +4,7 @@ permissions:
   contents: write
 
 on:
-  pull_request:
+  #pull_request:
   push:
 
 env:

--- a/.github/workflows/bench-protocol.yml
+++ b/.github/workflows/bench-protocol.yml
@@ -4,7 +4,7 @@ permissions:
   contents: write
 
 on:
-  pull_request:
+  #pull_request:
   push:
 
 env:


### PR DESCRIPTION
CI keeps failing for external pull requests as GH's permission model was not fully accounted for