### PR TITLE
fix: Make the i686 nix-checks actually use 32 bit

### DIFF
--- a/.github/workflows/nix.yaml
+++ b/.github/workflows/nix.yaml
@@ -71,6 +71,8 @@ jobs:
       - uses: cachix/install-nix-action@v30
         with:
           nix_path: nixpkgs=channel:nixos-unstable
+          extra_nix_config: |
+            system = i686-linux
       - uses: cachix/cachix-action@v15
         with:
           name: rosenpass


### PR DESCRIPTION
As of before this PR, the i686 nix-checks had no reference to the architecture and thus actually executed 64 bit checks.
This PR fixes this.