### PR TITLE
feat: add systemd-networkd integration for Rosenpass + WireGuard

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -40,6 +40,15 @@ The [`rp`](./rp) tool written in Rust makes it easy to create a VPN using WireGu
 `rp` is easy to get started with but has a few drawbacks; it runs as root, demanding access to both WireGuard
 and Rosenpass private keys, takes control of the interface and works with exactly one interface. If you do not feel confident about running Rosenpass as root, you should use the stand-alone mode to create a more secure setup using containers, jails, or virtual machines.
 
+### systemd-networkd integration
+
+On systems using systemd-networkd to manage WireGuard interfaces, Rosenpass can be
+integrated using the provided [systemd-networkd configuration](./systemd-networkd/).
+systemd-networkd handles WireGuard device creation and network configuration via `.netdev`
+and `.network` files, while Rosenpass supplies rotating post-quantum pre-shared keys.
+See the [systemd-networkd README](./systemd-networkd/README.md) for setup instructions
+and examples.
+
 ### Networking & ports
 
 rp allocates two UDP ports; if port N is specified for rosenpass, it will allocate port N+1 for WireGuard.

--- a/systemd-networkd/README.md
+++ b/systemd-networkd/README.md
@@ -1,0 +1,307 @@
+# Rosenpass with systemd-networkd
+
+This directory contains systemd service files, example configurations, and a
+setup script for running Rosenpass alongside WireGuard interfaces managed by
+[systemd-networkd](https://www.freedesktop.org/software/systemd/man/latest/systemd-networkd.html).
+
+## Overview
+
+systemd-networkd can natively create and configure WireGuard interfaces using
+`.netdev` and `.network` files. Rosenpass adds post-quantum security on top of
+WireGuard by continuously rotating the pre-shared key (PSK) that WireGuard uses
+for an additional layer of symmetric encryption.
+
+The integration works as follows:
+
+1. **systemd-networkd** creates the WireGuard device (via the `.netdev` file)
+   and configures addressing (via the `.network` file).
+2. **Rosenpass** performs a post-quantum key exchange with the remote peer and
+   supplies the resulting symmetric key to WireGuard as a PSK using `wg set`.
+   This key is rotated approximately every two minutes.
+3. The **`rosenpass-networkd@.service`** template ties the Rosenpass daemon to
+   the systemd-networkd managed interface, ensuring correct startup ordering
+   and lifecycle management.
+
+Because Rosenpass provides keys through WireGuard's PSK mechanism, using
+Rosenpass is cryptographically no less secure than using WireGuard alone
+("hybrid security"). If the post-quantum key exchange were somehow broken,
+WireGuard's own Curve25519-based key exchange still protects the tunnel.
+
+## Quick Start
+
+### Prerequisites
+
+- A Linux system running systemd-networkd
+- `rosenpass` and `wg` (wireguard-tools) installed
+- Root access
+
+### Automated Setup
+
+The `setup-rosenpass-networkd.sh` script generates all configuration files:
+
+```sh
+sudo ./setup-rosenpass-networkd.sh rp0
+```
+
+This creates:
+- `/etc/systemd/network/rp0.netdev` -- WireGuard device definition
+- `/etc/systemd/network/rp0.network` -- Network addressing
+- `/etc/rosenpass/rp0.toml` -- Rosenpass configuration
+- `/etc/rosenpass/rp0/pqsk` -- Rosenpass secret key
+- `/etc/rosenpass/rp0/pqpk` -- Rosenpass public key
+- `/etc/wireguard/rp0.key` -- WireGuard private key
+- `/etc/wireguard/rp0.pub` -- WireGuard public key
+
+### Manual Setup
+
+#### 1. Generate keys
+
+```sh
+# WireGuard keys
+wg genkey | sudo tee /etc/wireguard/rp0.key | wg pubkey | sudo tee /etc/wireguard/rp0.pub
+sudo chmod 0600 /etc/wireguard/rp0.key
+
+# Rosenpass keys
+sudo mkdir -p /etc/rosenpass/rp0/peers
+sudo rosenpass gen-keys --secret-key /etc/rosenpass/rp0/pqsk \
+                        --public-key /etc/rosenpass/rp0/pqpk
+sudo chmod 0600 /etc/rosenpass/rp0/pqsk
+```
+
+#### 2. Create the .netdev file
+
+Create `/etc/systemd/network/rp0.netdev`:
+
+```ini
+[NetDev]
+Name=rp0
+Kind=wireguard
+
+[WireGuard]
+PrivateKeyFile=/etc/wireguard/rp0.key
+ListenPort=51820
+
+[WireGuardPeer]
+PublicKey=<PEER_WG_PUBLIC_KEY>
+Endpoint=<PEER_IP>:51820
+AllowedIPs=10.0.0.2/32
+PersistentKeepalive=25
+# Do NOT set PresharedKey -- Rosenpass manages it.
+```
+
+**Important:** Do not set `PresharedKey` or `PresharedKeyFile` in the
+`[WireGuardPeer]` section. Rosenpass rotates the PSK automatically using
+`wg set`.
+
+#### 3. Create the .network file
+
+Create `/etc/systemd/network/rp0.network`:
+
+```ini
+[Match]
+Name=rp0
+
+[Network]
+Address=10.0.0.1/24
+```
+
+#### 4. Create the Rosenpass configuration
+
+Create `/etc/rosenpass/rp0.toml`:
+
+```toml
+public_key = "/etc/rosenpass/rp0/pqpk"
+secret_key = "/etc/rosenpass/rp0/pqsk"
+listen = ["0.0.0.0:9999"]
+verbosity = "Quiet"
+
+[[peers]]
+public_key = "/etc/rosenpass/rp0/peers/peer1-pqpk"
+endpoint = "<PEER_IP>:9999"
+device = "rp0"
+peer = "<PEER_WG_PUBLIC_KEY>"
+```
+
+Copy the remote peer's Rosenpass public key to
+`/etc/rosenpass/rp0/peers/peer1-pqpk`.
+
+#### 5. Install the service template and start
+
+```sh
+sudo cp rosenpass-networkd@.service /etc/systemd/system/
+sudo systemctl daemon-reload
+sudo systemctl restart systemd-networkd
+sudo systemctl enable --now rosenpass-networkd@rp0.service
+```
+
+#### 6. Verify
+
+```sh
+# Check the Rosenpass service
+systemctl status rosenpass-networkd@rp0.service
+
+# Check the WireGuard interface
+wg show rp0
+
+# Watch PSK rotation (updates every ~2 minutes)
+watch -n 5 'wg show rp0 preshared-keys'
+```
+
+## Two-Peer Example
+
+See the `examples/` directory for a complete two-peer setup:
+
+- **Peer A** (server at 198.51.100.1): `peer-a.netdev`, `peer-a.network`,
+  `peer-a-rosenpass.toml`
+- **Peer B** (client): `peer-b.netdev`, `peer-b.network`,
+  `peer-b-rosenpass.toml`
+
+### On Peer A (server)
+
+```sh
+# 1. Generate keys
+sudo ./setup-rosenpass-networkd.sh rp0
+
+# 2. Edit /etc/systemd/network/rp0.netdev: add Peer B's WireGuard public key
+# 3. Edit /etc/systemd/network/rp0.network: set Address=10.0.0.1/24
+# 4. Edit /etc/rosenpass/rp0.toml: add listen, peer section with Peer B's keys
+# 5. Copy Peer B's Rosenpass public key to /etc/rosenpass/rp0/peers/peer-b-pqpk
+
+sudo systemctl daemon-reload
+sudo systemctl restart systemd-networkd
+sudo systemctl enable --now rosenpass-networkd@rp0.service
+```
+
+### On Peer B (client)
+
+```sh
+# 1. Generate keys
+sudo ./setup-rosenpass-networkd.sh rp0
+
+# 2. Edit /etc/systemd/network/rp0.netdev: add Peer A's WireGuard public key, endpoint
+# 3. Edit /etc/systemd/network/rp0.network: set Address=10.0.0.2/24
+# 4. Edit /etc/rosenpass/rp0.toml: add peer section with Peer A's keys + endpoint
+# 5. Copy Peer A's Rosenpass public key to /etc/rosenpass/rp0/peers/peer-a-pqpk
+
+sudo systemctl daemon-reload
+sudo systemctl restart systemd-networkd
+sudo systemctl enable --now rosenpass-networkd@rp0.service
+```
+
+### Test
+
+```sh
+# From Peer B
+ping 10.0.0.1
+```
+
+## How It Works
+
+### Service Lifecycle
+
+The `rosenpass-networkd@.service` template uses systemd dependency management
+to ensure correct ordering:
+
+- **`After=systemd-networkd.service`**: Rosenpass starts only after
+  systemd-networkd is running.
+- **`BindsTo=sys-subsystem-net-devices-%i.device`**: Rosenpass is bound to the
+  network interface. If the interface disappears (e.g., systemd-networkd
+  reconfigures), Rosenpass stops.
+- **`Requires=systemd-networkd.service`**: If systemd-networkd stops,
+  Rosenpass stops too.
+- **`PartOf=rosenpass.target`**: All Rosenpass instances can be managed
+  together via the rosenpass.target.
+
+### Key Rotation
+
+Rosenpass performs a key exchange approximately every two minutes and writes
+the resulting symmetric key to WireGuard as a pre-shared key using:
+
+```
+wg set <INTERFACE> peer <PEER_PUBLIC_KEY> preshared-key /dev/stdin
+```
+
+This is the same mechanism used by the standalone `rosenpass` tool and is
+fully compatible with systemd-networkd managed interfaces because
+systemd-networkd only sets the initial device configuration -- runtime PSK
+updates via `wg set` work independently.
+
+### Security Hardening
+
+The service template includes the same security hardening as the existing
+`rosenpass@.service`:
+
+- Runs as a dynamic user (no persistent system user needed)
+- Minimal capability set (only `CAP_NET_ADMIN`)
+- System call filtering, namespace restrictions, and device access controls
+- Protected kernel tunables, control groups, and home directory
+
+## Differences from Standalone Rosenpass
+
+| Feature | `rosenpass@.service` | `rosenpass-networkd@.service` |
+|---|---|---|
+| WireGuard device creation | Rosenpass (or `rp`) creates the device | systemd-networkd creates the device |
+| Device lifecycle | Rosenpass owns the device | systemd-networkd owns the device |
+| Address configuration | Manual (`ip addr add`) or via `rp` | systemd-networkd (`.network` file) |
+| Routing | Manual or via `rp` | systemd-networkd (`.network` file) |
+| Service dependency | Binds to the device | Binds to device + systemd-networkd |
+
+## Troubleshooting
+
+### Rosenpass fails to start (interface not found)
+
+Make sure the `.netdev` file name matches the interface name in
+`systemctl enable rosenpass-networkd@<NAME>`:
+
+```sh
+# If your .netdev creates "rp0", use:
+systemctl enable --now rosenpass-networkd@rp0.service
+```
+
+### PSK is not being updated
+
+Check Rosenpass logs:
+
+```sh
+journalctl -u rosenpass-networkd@rp0.service -f
+```
+
+Verify the WireGuard peer public key in the Rosenpass config matches the one
+in the `.netdev` file:
+
+```sh
+wg show rp0
+grep peer /etc/rosenpass/rp0.toml
+```
+
+### systemd-networkd not picking up configuration
+
+After creating or modifying `.netdev`/`.network` files:
+
+```sh
+sudo systemctl restart systemd-networkd
+# or
+sudo networkctl reload
+```
+
+## File Layout
+
+```
+/etc/
+  systemd/
+    network/
+      rp0.netdev          # WireGuard device (systemd-networkd)
+      rp0.network         # Network config (systemd-networkd)
+    system/
+      rosenpass-networkd@.service  # Rosenpass service template
+  rosenpass/
+    rp0.toml              # Rosenpass configuration
+    rp0/
+      pqsk                # Rosenpass secret key (mode 0600)
+      pqpk                # Rosenpass public key
+      peers/
+        peer1-pqpk        # Remote peer's Rosenpass public key
+  wireguard/
+    rp0.key               # WireGuard private key (mode 0600)
+    rp0.pub               # WireGuard public key
+```

--- a/systemd-networkd/examples/peer-a-rosenpass.toml
+++ b/systemd-networkd/examples/peer-a-rosenpass.toml
@@ -1,0 +1,16 @@
+# /etc/rosenpass/rp0.toml (on Peer A / Server)
+#
+# Rosenpass configuration for a systemd-networkd managed WireGuard interface.
+# The WireGuard device "rp0" is created by systemd-networkd via rp0.netdev.
+# Rosenpass supplies rotating post-quantum pre-shared keys.
+
+public_key = "/etc/rosenpass/rp0/pqpk"
+secret_key = "/etc/rosenpass/rp0/pqsk"
+listen = ["0.0.0.0:9999"]
+verbosity = "Quiet"
+
+[[peers]]
+public_key = "/etc/rosenpass/rp0/peers/peer-b-pqpk"
+# endpoint is omitted: Peer A only responds, does not initiate.
+device = "rp0"
+peer = "PEER_B_WG_PUBLIC_KEY_HERE"

--- a/systemd-networkd/examples/peer-a.netdev
+++ b/systemd-networkd/examples/peer-a.netdev
@@ -1,0 +1,20 @@
+# /etc/systemd/network/rp0.netdev (on Peer A / Server)
+#
+# Complete example: Peer A listens on port 51820.
+# Peer B connects to Peer A.
+
+[NetDev]
+Name=rp0
+Kind=wireguard
+Description=WireGuard tunnel with Rosenpass (Peer A)
+
+[WireGuard]
+PrivateKeyFile=/etc/wireguard/rp0.key
+ListenPort=51820
+
+[WireGuardPeer]
+# Peer B's WireGuard public key
+PublicKey=PEER_B_WG_PUBLIC_KEY_HERE
+AllowedIPs=10.0.0.2/32
+PersistentKeepalive=25
+# Rosenpass manages the PresharedKey - do not set it here.

--- a/systemd-networkd/examples/peer-a.network
+++ b/systemd-networkd/examples/peer-a.network
@@ -1,0 +1,7 @@
+# /etc/systemd/network/rp0.network (on Peer A / Server)
+
+[Match]
+Name=rp0
+
+[Network]
+Address=10.0.0.1/24

--- a/systemd-networkd/examples/peer-b-rosenpass.toml
+++ b/systemd-networkd/examples/peer-b-rosenpass.toml
@@ -1,0 +1,16 @@
+# /etc/rosenpass/rp0.toml (on Peer B / Client)
+#
+# Rosenpass configuration for a systemd-networkd managed WireGuard interface.
+# The WireGuard device "rp0" is created by systemd-networkd via rp0.netdev.
+# Rosenpass supplies rotating post-quantum pre-shared keys.
+
+public_key = "/etc/rosenpass/rp0/pqpk"
+secret_key = "/etc/rosenpass/rp0/pqsk"
+# No listen address: client mode, Rosenpass connects to the server.
+verbosity = "Quiet"
+
+[[peers]]
+public_key = "/etc/rosenpass/rp0/peers/peer-a-pqpk"
+endpoint = "198.51.100.1:9999"
+device = "rp0"
+peer = "PEER_A_WG_PUBLIC_KEY_HERE"

--- a/systemd-networkd/examples/peer-b.netdev
+++ b/systemd-networkd/examples/peer-b.netdev
@@ -1,0 +1,20 @@
+# /etc/systemd/network/rp0.netdev (on Peer B / Client)
+#
+# Complete example: Peer B connects to Peer A at 198.51.100.1:51820.
+
+[NetDev]
+Name=rp0
+Kind=wireguard
+Description=WireGuard tunnel with Rosenpass (Peer B)
+
+[WireGuard]
+PrivateKeyFile=/etc/wireguard/rp0.key
+# No ListenPort: the OS picks a random port (client mode).
+
+[WireGuardPeer]
+# Peer A's WireGuard public key
+PublicKey=PEER_A_WG_PUBLIC_KEY_HERE
+Endpoint=198.51.100.1:51820
+AllowedIPs=10.0.0.1/32
+PersistentKeepalive=25
+# Rosenpass manages the PresharedKey - do not set it here.

--- a/systemd-networkd/examples/peer-b.network
+++ b/systemd-networkd/examples/peer-b.network
@@ -1,0 +1,7 @@
+# /etc/systemd/network/rp0.network (on Peer B / Client)
+
+[Match]
+Name=rp0
+
+[Network]
+Address=10.0.0.2/24

--- a/systemd-networkd/examples/rosenpass0.netdev
+++ b/systemd-networkd/examples/rosenpass0.netdev
@@ -1,0 +1,34 @@
+# /etc/systemd/network/rosenpass0.netdev
+#
+# systemd-networkd WireGuard device configuration for use with Rosenpass.
+#
+# This file creates a WireGuard interface named "rosenpass0". Rosenpass will
+# continuously rotate the PresharedKey via the `wg set` command, providing
+# post-quantum security on top of WireGuard's existing cryptography.
+#
+# Adjust PrivateKeyFile, PublicKey, Endpoint, AllowedIPs, and ListenPort
+# to match your deployment.
+#
+# See systemd.netdev(5) for full documentation.
+
+[NetDev]
+Name=rosenpass0
+Kind=wireguard
+Description=WireGuard tunnel with Rosenpass post-quantum key exchange
+
+[WireGuard]
+# Path to the WireGuard private key file.
+# Generate with: wg genkey > /etc/wireguard/rosenpass0.key
+# Restrict permissions: chmod 0600 /etc/wireguard/rosenpass0.key
+PrivateKeyFile=/etc/wireguard/rosenpass0.key
+ListenPort=51820
+
+[WireGuardPeer]
+# WireGuard public key of the remote peer.
+PublicKey=PEER_WG_PUBLIC_KEY_BASE64
+# Rosenpass will manage the PresharedKey automatically.
+# Do NOT set PresharedKey or PresharedKeyFile here; Rosenpass rotates it
+# every ~2 minutes via `wg set`.
+Endpoint=198.51.100.1:51820
+AllowedIPs=10.0.0.2/32
+PersistentKeepalive=25

--- a/systemd-networkd/examples/rosenpass0.network
+++ b/systemd-networkd/examples/rosenpass0.network
@@ -1,0 +1,25 @@
+# /etc/systemd/network/rosenpass0.network
+#
+# systemd-networkd network configuration for the WireGuard interface
+# managed alongside Rosenpass.
+#
+# This assigns addresses and routes to the "rosenpass0" WireGuard device
+# created by rosenpass0.netdev.
+#
+# See systemd.network(5) for full documentation.
+
+[Match]
+Name=rosenpass0
+
+[Network]
+# Address assigned to this end of the tunnel.
+Address=10.0.0.1/24
+
+# Optional: set DNS servers reachable through the tunnel.
+# DNS=10.0.0.2
+
+[Route]
+# Routes for traffic that should go through the tunnel.
+# This example routes the peer's address. For a full-tunnel VPN,
+# use 0.0.0.0/0 and ::/0 instead.
+Destination=10.0.0.2/32

--- a/systemd-networkd/examples/rosenpass0.toml
+++ b/systemd-networkd/examples/rosenpass0.toml
@@ -1,0 +1,38 @@
+# /etc/rosenpass/rosenpass0.toml
+#
+# Rosenpass configuration for use with a systemd-networkd managed
+# WireGuard interface.
+#
+# systemd-networkd creates and configures the WireGuard device (via
+# the .netdev file). Rosenpass only performs the post-quantum key
+# exchange and supplies the resulting pre-shared key to WireGuard
+# using the `wg set` command.
+#
+# Generate Rosenpass keys:
+#   rosenpass gen-keys --secret-key /etc/rosenpass/rosenpass0/pqsk \
+#                      --public-key /etc/rosenpass/rosenpass0/pqpk
+#
+# Exchange the pqpk (public key) file with the remote peer.
+
+public_key = "/etc/rosenpass/rosenpass0/pqpk"
+secret_key = "/etc/rosenpass/rosenpass0/pqsk"
+
+# The Rosenpass listen address. This is the UDP port used for the
+# Rosenpass key exchange protocol (separate from WireGuard's port).
+listen = ["0.0.0.0:9999"]
+verbosity = "Quiet"
+
+[[peers]]
+# Path to the remote peer's Rosenpass public key.
+public_key = "/etc/rosenpass/rosenpass0/peers/peer1-pqpk"
+
+# Rosenpass endpoint of the remote peer (host:port for the Rosenpass
+# protocol, not the WireGuard endpoint).
+endpoint = "198.51.100.1:9999"
+
+# WireGuard device name. Must match the [NetDev] Name in the .netdev file.
+device = "rosenpass0"
+
+# WireGuard public key of the remote peer. Must match the PublicKey
+# in the [WireGuardPeer] section of the .netdev file.
+peer = "PEER_WG_PUBLIC_KEY_BASE64"

--- a/systemd-networkd/rosenpass-networkd@.service
+++ b/systemd-networkd/rosenpass-networkd@.service
@@ -1,0 +1,64 @@
+[Unit]
+Description=Rosenpass post-quantum key exchange for systemd-networkd interface %I
+Documentation=man:rosenpass(1)
+Documentation=https://rosenpass.eu/docs
+
+# Wait for the WireGuard interface to be created by systemd-networkd.
+# sys-subsystem-net-devices-%i.device becomes available once the
+# .netdev file has been processed and the interface exists.
+After=systemd-networkd.service network-online.target nss-lookup.target sys-subsystem-net-devices-%i.device
+Wants=network-online.target nss-lookup.target
+Requires=systemd-networkd.service
+BindsTo=sys-subsystem-net-devices-%i.device
+PartOf=rosenpass.target
+
+[Service]
+Type=simple
+ExecStart=rosenpass exchange-config /etc/rosenpass/%i.toml
+
+# Load Rosenpass key material via systemd credentials.
+# Place the secret key at /etc/rosenpass/%i/pqsk and
+# the public key at /etc/rosenpass/%i/pqpk.
+LoadCredential=pqsk:/etc/rosenpass/%i/pqsk
+
+# Rosenpass needs CAP_NET_ADMIN to call `wg set` on the interface
+# managed by systemd-networkd.
+AmbientCapabilities=CAP_NET_ADMIN
+
+# Security hardening (matching the existing rosenpass@.service).
+CapabilityBoundingSet=~CAP_AUDIT_CONTROL CAP_AUDIT_READ CAP_AUDIT_WRITE CAP_BLOCK_SUSPEND CAP_BPF CAP_CHOWN CAP_FSETID CAP_SETFCAP CAP_DAC_OVERRIDE CAP_DAC_READ_SEARCH CAP_FOWNER CAP_IPC_OWNER CAP_IPC_LOCK CAP_KILL CAP_LEASE CAP_LINUX_IMMUTABLE CAP_MAC_ADMIN CAP_MAC_OVERRIDE CAP_MKNOD CAP_NET_BIND_SERVICE CAP_NET_BROADCAST CAP_NET_RAW CAP_SETUID CAP_SETGID CAP_SETPCAP CAP_SYS_ADMIN CAP_SYS_BOOT CAP_SYS_CHROOT CAP_SYSLOG CAP_SYS_MODULE CAP_SYS_NICE CAP_SYS_RESOURCE CAP_SYS_PACCT CAP_SYS_PTRACE CAP_SYS_RAWIO CAP_SYS_TIME CAP_SYS_TTY_CONFIG CAP_WAKE_ALARM
+DynamicUser=true
+LockPersonality=true
+MemoryDenyWriteExecute=true
+PrivateDevices=true
+ProcSubset=pid
+ProtectClock=true
+ProtectControlGroups=true
+ProtectHome=true
+ProtectHostname=true
+ProtectKernelLogs=true
+ProtectKernelModules=true
+ProtectKernelTunables=true
+ProtectProc=noaccess
+RestrictAddressFamilies=AF_NETLINK AF_INET AF_INET6
+RestrictNamespaces=true
+RestrictRealtime=true
+SystemCallArchitectures=native
+SystemCallFilter=~@clock
+SystemCallFilter=~@cpu-emulation
+SystemCallFilter=~@debug
+SystemCallFilter=~@module
+SystemCallFilter=~@mount
+SystemCallFilter=~@obsolete
+SystemCallFilter=~@privileged
+SystemCallFilter=~@raw-io
+SystemCallFilter=~@reboot
+SystemCallFilter=~@swap
+UMask=0077
+
+# Restart on failure to recover from transient issues.
+Restart=on-failure
+RestartSec=5
+
+[Install]
+WantedBy=multi-user.target

--- a/systemd-networkd/setup-rosenpass-networkd.sh
+++ b/systemd-networkd/setup-rosenpass-networkd.sh
@@ -1,0 +1,206 @@
+#!/usr/bin/env bash
+# setup-rosenpass-networkd.sh
+#
+# Helper script to set up a Rosenpass + WireGuard tunnel using
+# systemd-networkd.
+#
+# This script generates all necessary configuration files:
+#   - /etc/systemd/network/<IFACE>.netdev   (WireGuard device)
+#   - /etc/systemd/network/<IFACE>.network  (network addressing)
+#   - /etc/rosenpass/<IFACE>.toml           (Rosenpass config)
+#   - /etc/rosenpass/<IFACE>/pqsk           (Rosenpass secret key)
+#   - /etc/rosenpass/<IFACE>/pqpk           (Rosenpass public key)
+#   - /etc/wireguard/<IFACE>.key            (WireGuard private key)
+#
+# Usage:
+#   sudo ./setup-rosenpass-networkd.sh <INTERFACE_NAME>
+#
+# After running this script you still need to:
+#   1. Exchange Rosenpass public keys with the remote peer.
+#   2. Fill in peer-specific values (public keys, endpoints).
+#   3. Enable and start the services:
+#        systemctl daemon-reload
+#        systemctl restart systemd-networkd
+#        systemctl enable --now rosenpass-networkd@<IFACE>.service
+#
+# See the accompanying README for detailed instructions.
+
+set -euo pipefail
+
+usage() {
+    echo "Usage: $0 <INTERFACE_NAME>"
+    echo ""
+    echo "Creates Rosenpass + WireGuard configuration for systemd-networkd."
+    echo ""
+    echo "Example:"
+    echo "  sudo $0 rosenpass0"
+    exit 1
+}
+
+if [ $# -ne 1 ]; then
+    usage
+fi
+
+IFACE="$1"
+
+# Validate interface name (must be a valid Linux network interface name).
+if [[ ! "$IFACE" =~ ^[a-zA-Z][a-zA-Z0-9_-]*$ ]] || [ "${#IFACE}" -gt 15 ]; then
+    echo "Error: Invalid interface name '$IFACE'."
+    echo "Must start with a letter, contain only alphanumerics/hyphens/underscores,"
+    echo "and be at most 15 characters long."
+    exit 1
+fi
+
+# Check for required tools.
+for cmd in wg rosenpass; do
+    if ! command -v "$cmd" &>/dev/null; then
+        echo "Error: '$cmd' not found in PATH."
+        exit 1
+    fi
+done
+
+# Check for root.
+if [ "$(id -u)" -ne 0 ]; then
+    echo "Error: This script must be run as root."
+    exit 1
+fi
+
+NETWORKD_DIR="/etc/systemd/network"
+RP_DIR="/etc/rosenpass/${IFACE}"
+WG_DIR="/etc/wireguard"
+
+echo "Setting up Rosenpass + WireGuard for interface: $IFACE"
+echo ""
+
+# Create directories.
+mkdir -p "$NETWORKD_DIR" "$RP_DIR/peers" "$WG_DIR"
+
+# Generate WireGuard keypair if the private key does not exist.
+WG_KEY_FILE="${WG_DIR}/${IFACE}.key"
+WG_PUB_FILE="${WG_DIR}/${IFACE}.pub"
+if [ ! -f "$WG_KEY_FILE" ]; then
+    echo "Generating WireGuard keypair..."
+    wg genkey | tee "$WG_KEY_FILE" | wg pubkey > "$WG_PUB_FILE"
+    chmod 0600 "$WG_KEY_FILE"
+    chmod 0644 "$WG_PUB_FILE"
+else
+    echo "WireGuard private key already exists at $WG_KEY_FILE, skipping."
+    if [ ! -f "$WG_PUB_FILE" ]; then
+        wg pubkey < "$WG_KEY_FILE" > "$WG_PUB_FILE"
+        chmod 0644 "$WG_PUB_FILE"
+    fi
+fi
+
+WG_PUBKEY=$(cat "$WG_PUB_FILE")
+
+# Generate Rosenpass keypair if the secret key does not exist.
+if [ ! -f "${RP_DIR}/pqsk" ]; then
+    echo "Generating Rosenpass keypair..."
+    rosenpass gen-keys --secret-key "${RP_DIR}/pqsk" --public-key "${RP_DIR}/pqpk"
+    chmod 0600 "${RP_DIR}/pqsk"
+    chmod 0644 "${RP_DIR}/pqpk"
+else
+    echo "Rosenpass secret key already exists at ${RP_DIR}/pqsk, skipping."
+fi
+
+# Create the .netdev file for systemd-networkd.
+NETDEV_FILE="${NETWORKD_DIR}/${IFACE}.netdev"
+if [ ! -f "$NETDEV_FILE" ]; then
+    echo "Creating $NETDEV_FILE..."
+    cat > "$NETDEV_FILE" <<EOF
+[NetDev]
+Name=${IFACE}
+Kind=wireguard
+Description=WireGuard tunnel with Rosenpass post-quantum key exchange
+
+[WireGuard]
+PrivateKeyFile=${WG_KEY_FILE}
+ListenPort=51820
+
+# Add one or more [WireGuardPeer] sections below.
+# Do NOT set PresharedKey here; Rosenpass manages it automatically.
+#
+# [WireGuardPeer]
+# PublicKey=<PEER_WG_PUBLIC_KEY>
+# Endpoint=<PEER_IP>:51820
+# AllowedIPs=10.0.0.2/32
+# PersistentKeepalive=25
+EOF
+    chmod 0640 "$NETDEV_FILE"
+else
+    echo "$NETDEV_FILE already exists, skipping."
+fi
+
+# Create the .network file for systemd-networkd.
+NETWORK_FILE="${NETWORKD_DIR}/${IFACE}.network"
+if [ ! -f "$NETWORK_FILE" ]; then
+    echo "Creating $NETWORK_FILE..."
+    cat > "$NETWORK_FILE" <<EOF
+[Match]
+Name=${IFACE}
+
+[Network]
+# Assign an address to this end of the tunnel.
+# Address=10.0.0.1/24
+EOF
+    chmod 0644 "$NETWORK_FILE"
+else
+    echo "$NETWORK_FILE already exists, skipping."
+fi
+
+# Create the Rosenpass configuration file.
+RP_CONFIG="/etc/rosenpass/${IFACE}.toml"
+if [ ! -f "$RP_CONFIG" ]; then
+    echo "Creating $RP_CONFIG..."
+    cat > "$RP_CONFIG" <<EOF
+# Rosenpass configuration for systemd-networkd interface: ${IFACE}
+#
+# The WireGuard device is created and managed by systemd-networkd.
+# Rosenpass only handles the post-quantum key exchange, supplying
+# rotating pre-shared keys to WireGuard via \`wg set\`.
+
+public_key = "${RP_DIR}/pqpk"
+secret_key = "${RP_DIR}/pqsk"
+
+# Rosenpass protocol listen address (separate from WireGuard port).
+# listen = ["0.0.0.0:9999"]
+verbosity = "Quiet"
+
+# Add peers below. For each [WireGuardPeer] in your .netdev file,
+# add a corresponding [[peers]] section here.
+#
+# [[peers]]
+# public_key = "${RP_DIR}/peers/peer1-pqpk"
+# endpoint = "<PEER_IP>:9999"
+# device = "${IFACE}"
+# peer = "<PEER_WG_PUBLIC_KEY>"
+EOF
+    chmod 0644 "$RP_CONFIG"
+else
+    echo "$RP_CONFIG already exists, skipping."
+fi
+
+echo ""
+echo "============================================="
+echo "Setup complete for interface: $IFACE"
+echo "============================================="
+echo ""
+echo "Your WireGuard public key (share with peers):"
+echo "  $WG_PUBKEY"
+echo ""
+echo "Your Rosenpass public key (share with peers):"
+echo "  ${RP_DIR}/pqpk"
+echo ""
+echo "Next steps:"
+echo "  1. Edit $NETDEV_FILE and add [WireGuardPeer] sections"
+echo "  2. Edit $NETWORK_FILE and set the tunnel Address"
+echo "  3. Edit $RP_CONFIG and add [[peers]] sections"
+echo "  4. Copy peer Rosenpass public keys to ${RP_DIR}/peers/"
+echo "  5. Reload and start:"
+echo "       systemctl daemon-reload"
+echo "       systemctl restart systemd-networkd"
+echo "       systemctl enable --now rosenpass-networkd@${IFACE}.service"
+echo ""
+echo "To check status:"
+echo "  systemctl status rosenpass-networkd@${IFACE}.service"
+echo "  wg show ${IFACE}"

--- a/systemd-networkd/validate-config.sh
+++ b/systemd-networkd/validate-config.sh
@@ -1,0 +1,148 @@
+#!/usr/bin/env bash
+# validate-config.sh
+#
+# Validates the structure of systemd-networkd + Rosenpass configuration files
+# for a given interface without requiring root or a running system.
+#
+# Usage:
+#   ./validate-config.sh <INTERFACE_NAME>
+#
+# This checks:
+#   - Required files exist
+#   - .netdev file has correct structure
+#   - .network file references the right interface
+#   - Rosenpass .toml file references the same device name
+#   - PresharedKey is NOT set in the .netdev (Rosenpass manages it)
+
+set -euo pipefail
+
+usage() {
+    echo "Usage: $0 <INTERFACE_NAME>"
+    echo ""
+    echo "Validates systemd-networkd + Rosenpass configuration for the given interface."
+    exit 1
+}
+
+if [ $# -ne 1 ]; then
+    usage
+fi
+
+IFACE="$1"
+ERRORS=0
+WARNINGS=0
+
+info()    { echo "[INFO]    $*"; }
+warn()    { echo "[WARNING] $*"; WARNINGS=$((WARNINGS + 1)); }
+error()   { echo "[ERROR]   $*"; ERRORS=$((ERRORS + 1)); }
+ok()      { echo "[OK]      $*"; }
+
+NETWORKD_DIR="/etc/systemd/network"
+RP_DIR="/etc/rosenpass"
+
+# Check .netdev file
+NETDEV="${NETWORKD_DIR}/${IFACE}.netdev"
+if [ -f "$NETDEV" ]; then
+    ok "Found $NETDEV"
+
+    if grep -q "^Kind=wireguard" "$NETDEV"; then
+        ok ".netdev Kind is wireguard"
+    else
+        error ".netdev missing Kind=wireguard"
+    fi
+
+    if grep -q "^Name=${IFACE}" "$NETDEV"; then
+        ok ".netdev Name matches interface"
+    else
+        error ".netdev Name does not match interface '$IFACE'"
+    fi
+
+    if grep -qi "^PresharedKey=" "$NETDEV"; then
+        error "PresharedKey is set in .netdev -- Rosenpass should manage this"
+    elif grep -qi "^PresharedKeyFile=" "$NETDEV"; then
+        error "PresharedKeyFile is set in .netdev -- Rosenpass should manage this"
+    else
+        ok "No static PresharedKey in .netdev (correct for Rosenpass)"
+    fi
+
+    if grep -q "^PrivateKeyFile=" "$NETDEV"; then
+        ok ".netdev has PrivateKeyFile"
+        KEYFILE=$(grep "^PrivateKeyFile=" "$NETDEV" | cut -d= -f2)
+        if [ -f "$KEYFILE" ]; then
+            ok "WireGuard private key file exists: $KEYFILE"
+            PERMS=$(stat -c %a "$KEYFILE" 2>/dev/null || stat -f %Lp "$KEYFILE" 2>/dev/null)
+            if [ "$PERMS" = "600" ]; then
+                ok "WireGuard private key has correct permissions (0600)"
+            else
+                warn "WireGuard private key permissions are $PERMS (expected 0600)"
+            fi
+        else
+            warn "WireGuard private key file not found: $KEYFILE"
+        fi
+    else
+        error ".netdev missing PrivateKeyFile"
+    fi
+else
+    error "Missing $NETDEV"
+fi
+
+# Check .network file
+NETWORK="${NETWORKD_DIR}/${IFACE}.network"
+if [ -f "$NETWORK" ]; then
+    ok "Found $NETWORK"
+
+    if grep -q "^Name=${IFACE}" "$NETWORK"; then
+        ok ".network matches interface name"
+    else
+        warn ".network [Match] Name may not match interface '$IFACE'"
+    fi
+else
+    error "Missing $NETWORK"
+fi
+
+# Check Rosenpass config
+RP_CONFIG="${RP_DIR}/${IFACE}.toml"
+if [ -f "$RP_CONFIG" ]; then
+    ok "Found $RP_CONFIG"
+
+    if grep -q "public_key" "$RP_CONFIG" && grep -q "secret_key" "$RP_CONFIG"; then
+        ok "Rosenpass config has key paths"
+    else
+        error "Rosenpass config missing public_key or secret_key"
+    fi
+
+    if grep -q "device.*=.*\"${IFACE}\"" "$RP_CONFIG"; then
+        ok "Rosenpass config device matches interface"
+    else
+        warn "No peer with device = \"${IFACE}\" found (may be unconfigured)"
+    fi
+else
+    error "Missing $RP_CONFIG"
+fi
+
+# Check Rosenpass keys
+if [ -f "${RP_DIR}/${IFACE}/pqsk" ]; then
+    ok "Rosenpass secret key exists"
+    PERMS=$(stat -c %a "${RP_DIR}/${IFACE}/pqsk" 2>/dev/null || stat -f %Lp "${RP_DIR}/${IFACE}/pqsk" 2>/dev/null)
+    if [ "$PERMS" = "600" ]; then
+        ok "Rosenpass secret key has correct permissions (0600)"
+    else
+        warn "Rosenpass secret key permissions are $PERMS (expected 0600)"
+    fi
+else
+    warn "Rosenpass secret key not found at ${RP_DIR}/${IFACE}/pqsk"
+fi
+
+if [ -f "${RP_DIR}/${IFACE}/pqpk" ]; then
+    ok "Rosenpass public key exists"
+else
+    warn "Rosenpass public key not found at ${RP_DIR}/${IFACE}/pqpk"
+fi
+
+echo ""
+echo "============================================="
+echo "Validation complete: $ERRORS error(s), $WARNINGS warning(s)"
+echo "============================================="
+
+if [ "$ERRORS" -gt 0 ]; then
+    exit 1
+fi


### PR DESCRIPTION
## Summary

Adds systemd-networkd support for running Rosenpass alongside WireGuard interfaces managed by systemd-networkd, as requested in #81.

/claim #81

### What this provides

- **`rosenpass-networkd@.service`**: A systemd template unit specifically designed for systemd-networkd managed WireGuard interfaces. Key differences from the existing `rosenpass@.service`:
  - `Requires=systemd-networkd.service` ensures correct startup ordering
  - `BindsTo=sys-subsystem-net-devices-%i.device` ties Rosenpass lifecycle to the interface managed by systemd-networkd
  - `Restart=on-failure` for resilience against transient issues
  - Same security hardening as the existing service template

- **Setup helper script** (`setup-rosenpass-networkd.sh`): Automates the generation of WireGuard keys, Rosenpass keys, `.netdev`/`.network` files, and the Rosenpass TOML configuration for a given interface name.

- **Validation script** (`validate-config.sh`): Checks that the configuration files are consistent -- interface names match, no static PresharedKey is set in the `.netdev` file (since Rosenpass manages PSK rotation), correct file permissions, etc.

- **Example configurations**: Complete two-peer (server/client) examples with `.netdev`, `.network`, and Rosenpass `.toml` files showing how all the pieces fit together.

- **Documentation**: Comprehensive README covering quick start, manual setup, architecture explanation (how PSK rotation works with systemd-networkd), troubleshooting, and file layout reference.

### How it works

systemd-networkd creates and owns the WireGuard device via `.netdev`/`.network` files. Rosenpass performs the post-quantum key exchange and supplies the resulting symmetric key to WireGuard as a pre-shared key using `wg set`. The PSK is rotated approximately every two minutes. This is the same mechanism the standalone `rosenpass` tool already uses -- the key insight is that systemd-networkd only configures the initial device state, so runtime PSK updates via `wg set` work independently and without conflict.

### Files added

```
systemd-networkd/
  README.md                          # Comprehensive documentation
  rosenpass-networkd@.service        # systemd template unit
  setup-rosenpass-networkd.sh        # Setup automation script
  validate-config.sh                 # Configuration validator
  examples/
    rosenpass0.netdev                # Generic .netdev template
    rosenpass0.network               # Generic .network template
    rosenpass0.toml                  # Generic Rosenpass config template
    peer-a.netdev                    # Server-side .netdev
    peer-a.network                   # Server-side .network
    peer-a-rosenpass.toml            # Server-side Rosenpass config
    peer-b.netdev                    # Client-side .netdev
    peer-b.network                   # Client-side .network
    peer-b-rosenpass.toml            # Client-side Rosenpass config
```

Also added a brief reference to the systemd-networkd integration in the main `readme.md`.

## Test plan

- [ ] Verify `.netdev` and `.network` files are valid systemd-networkd configurations (can be tested with `systemd-analyze verify` on a systemd system)
- [ ] Verify the `rosenpass-networkd@.service` template loads correctly with `systemd-analyze verify`
- [ ] Run `setup-rosenpass-networkd.sh` on a test system to confirm it generates all files correctly
- [ ] Set up a two-peer test: start systemd-networkd with the generated configs, enable `rosenpass-networkd@rp0.service` on both peers, and verify that `wg show rp0 preshared-keys` shows rotating keys
- [ ] Confirm that stopping systemd-networkd (removing the interface) correctly stops the Rosenpass service via the `BindsTo` dependency