### PR TITLE
refactor(util): migrate `b64_decode` to `rosenpass-to` pattern

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2260,6 +2260,7 @@ dependencies = [
  "libcrux-test-utils",
  "log",
  "mio",
+ "rosenpass-to",
  "rustix",
  "static_assertions",
  "tempfile",

--- a/secret-memory/src/public.rs
+++ b/secret-memory/src/public.rs
@@ -159,7 +159,7 @@ impl<const N: usize> LoadValueB64 for Public<N> {
             .read_slice_to_end(&mut f)
             .with_context(|| format!("Could not load file {p:?}"))?;
 
-        b64_decode(&f[0..len], &mut v.value)
+        b64_decode(&f[0..len]).to(&mut v.value)
             .with_context(|| format!("Could not decode base64 file {p:?}"))?;
 
         Ok(v)
@@ -349,7 +349,7 @@ impl<const N: usize> LoadValueB64 for PublicBox<N> {
             .read_slice_to_end(&mut f)
             .with_context(|| format!("Could not load file {p:?}"))?;
 
-        b64_decode(&f[0..len], v.deref_mut())
+        b64_decode(&f[0..len]).to(v.deref_mut())
             .with_context(|| format!("Could not decode base64 file {p:?}"))?;
 
         Ok(v)

--- a/secret-memory/src/secret.rs
+++ b/secret-memory/src/secret.rs
@@ -8,6 +8,7 @@ use anyhow::Context;
 use rand::{Fill as Randomize, Rng};
 use zeroize::{Zeroize, ZeroizeOnDrop};
 
+use rosenpass_to::To;
 use rosenpass_util::b64::{b64_decode, b64_encode};
 use rosenpass_util::file::{
     fopen_r, LoadValue, LoadValueB64, ReadExactToEnd, ReadSliceToEnd, StoreValueB64,
@@ -317,7 +318,7 @@ impl<const N: usize> LoadValueB64 for Secret<N> {
             .read_slice_to_end(f.secret_mut())
             .with_context(|| format!("Could not load file {p:?}"))?;
 
-        b64_decode(&f.secret()[0..len], v.secret_mut())
+        b64_decode(&f.secret()[0..len]).to(v.secret_mut())
             .with_context(|| format!("Could not decode base64 file {p:?}"))?;
 
         Ok(v)

--- a/util/Cargo.toml
+++ b/util/Cargo.toml
@@ -15,6 +15,7 @@ rust-version = "1.77.0"
 [dependencies]
 base64ct = { workspace = true }
 anyhow = { workspace = true }
+rosenpass-to = { workspace = true }
 typenum = { workspace = true }
 static_assertions = { workspace = true }
 rustix = { workspace = true }

--- a/util/src/b64.rs
+++ b/util/src/b64.rs
@@ -1,6 +1,7 @@
 //! Utilities for working with Base64
 
 use base64ct::{Base64, Decoder as B64Reader, Encoder as B64Writer};
+use rosenpass_to::{with_destination, To};
 use zeroize::Zeroize;
 
 use std::fmt::Display;
@@ -59,28 +60,31 @@ impl<T: AsRef<[u8]>> B64Display for T {
 /// # Examples
 ///
 /// See [b64_encode].
-pub fn b64_decode(input: &[u8], output: &mut [u8]) -> anyhow::Result<()> {
-    let mut reader = B64Reader::<Base64>::new(input).map_err(|e| anyhow::anyhow!(e))?;
-    match reader.decode(output) {
-        Ok(_) => (),
-        Err(base64ct::Error::InvalidLength) => (),
-        Err(e) => {
-            return Err(anyhow::anyhow!(e));
+pub fn b64_decode(input: &[u8]) -> impl To<[u8], anyhow::Result<()>> + '_ {
+    with_destination(move |output: &mut [u8]| {
+        let mut reader = B64Reader::<Base64>::new(input).map_err(|e| anyhow::anyhow!(e))?;
+        match reader.decode(output) {
+            Ok(_) => (),
+            Err(base64ct::Error::InvalidLength) => (),
+            Err(e) => {
+                return Err(anyhow::anyhow!(e));
+            }
         }
-    }
-    if reader.is_finished() {
-        Ok(())
-    } else {
-        Err(anyhow::anyhow!(
-            "Input not decoded completely (buffer size too small?)"
-        ))
-    }
+        if reader.is_finished() {
+            Ok(())
+        } else {
+            Err(anyhow::anyhow!(
+                "Input not decoded completely (buffer size too small?)"
+            ))
+        }
+    })
 }
 
 /// Encode a value as base64.
 ///
 /// ```
 /// use rosenpass_util::b64::{b64_encode, b64_decode};
+/// use rosenpass_to::To;
 ///
 /// let bytes = b"Hello World";
 ///
@@ -88,7 +92,7 @@ pub fn b64_decode(input: &[u8], output: &mut [u8]) -> anyhow::Result<()> {
 /// let encoded = b64_encode(bytes, &mut encoder_buffer)?;
 ///
 /// let mut bytes_decoded = [0u8; 11];
-/// b64_decode(encoded.as_bytes(), &mut bytes_decoded);
+/// b64_decode(encoded.as_bytes()).to(&mut bytes_decoded);
 /// assert_eq!(bytes, &bytes_decoded);
 ///
 /// Ok::<(), anyhow::Error>(())
@@ -103,6 +107,7 @@ pub fn b64_encode<'o>(input: &[u8], output: &'o mut [u8]) -> anyhow::Result<&'o 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use rosenpass_to::To;
 
     #[test]
     fn test_b64_encode() {
@@ -135,7 +140,7 @@ mod tests {
     fn test_b64_decode() {
         let input = b"SGVsbG8sIFdvcmxkIQ==";
         let mut output = [0u8; 1000];
-        b64_decode(input, &mut output).unwrap();
+        b64_decode(input).to(&mut output).unwrap();
         assert_eq!(&output[..13], b"Hello, World!");
     }
 
@@ -143,7 +148,7 @@ mod tests {
     fn test_b64_decode_small_buffer() {
         let input = b"SGVsbG8sIFdvcmxkIQ==";
         let mut output = [0u8; 10]; // Small output buffer
-        let result = b64_decode(input, &mut output);
+        let result = b64_decode(input).to(&mut output);
         assert!(result.is_err());
         assert_eq!(
             result.unwrap_err().to_string(),
@@ -155,7 +160,7 @@ mod tests {
     fn test_b64_decode_empty_buffer() {
         let input = b"";
         let mut output = [0u8; 16];
-        let result = b64_decode(input, &mut output);
+        let result = b64_decode(input).to(&mut output);
         assert!(result.is_err());
     }
 

--- a/util/src/fd.rs
+++ b/util/src/fd.rs
@@ -1,6 +1,5 @@
 //! Utilities for working with file descriptors
 
-use anyhow::bail;
 use rustix::io::fcntl_dupfd_cloexec;
 use std::os::fd::{AsFd, BorrowedFd, FromRawFd, OwnedFd, RawFd};
 

--- a/util/src/file.rs
+++ b/util/src/file.rs
@@ -252,6 +252,7 @@ pub trait LoadValueB64 {
     /// ```
     /// use std::path::Path;
     /// use tempfile::tempdir;
+    /// use rosenpass_to::To;
     /// use rosenpass_util::b64::{b64_decode, b64_encode};
     /// use rosenpass_util::file::{
     ///     fopen_r, fopen_w, LoadValueB64, ReadSliceToEnd, StoreValueB64, StoreValueB64Writer,
@@ -303,7 +304,7 @@ pub trait LoadValueB64 {
     ///         let b64_dat = &b64_buf[..b64_len];
     ///
     ///         let mut buf = [0u8; 4];
-    ///         b64_decode(b64_dat, &mut buf)?;
+    ///         b64_decode(b64_dat).to(&mut buf)?;
     ///         Ok(MyInt(u32::from_le_bytes(buf)))
     ///     }
     /// }

--- a/wireguard-broker/src/brokers/native_unix.rs
+++ b/wireguard-broker/src/brokers/native_unix.rs
@@ -38,6 +38,7 @@ use derive_builder::Builder;
 use log::{debug, error};
 use postcard::{from_bytes, to_allocvec};
 use rosenpass_secret_memory::{Public, Secret};
+use rosenpass_to::To;
 use rosenpass_util::b64::b64_decode;
 use rosenpass_util::{b64::B64Display, file::StoreValueB64Writer};
 
@@ -216,7 +217,7 @@ impl NativeUnixBrokerConfigBaseBuilder {
         peer_id: &str,
     ) -> Result<&mut Self, NativeUnixBrokerConfigBaseBuilderError> {
         let mut peer_id_b64 = Public::<WG_PEER_LEN>::zero();
-        b64_decode(peer_id.as_bytes(), &mut peer_id_b64.value).map_err(|_e| {
+        b64_decode(peer_id.as_bytes()).to(&mut peer_id_b64.value).map_err(|_e| {
             NativeUnixBrokerConfigBaseBuilderError::ValidationError(
                 "Failed to parse peer id b64".to_string(),
             )


### PR DESCRIPTION
/claim #164

# PR Description

This PR starts the migration of destination-parameter functions to the `rosenpass-to` pattern as discussed in issue #164.

The scope of this change is intentionally small. The goal is to validate the migration approach on a single utility function before continuing with further refactors.

---

## Scope

This PR converts `b64_decode` in `util/src/b64.rs` from a destination-parameter function:

rust
`fn b64_decode(input: &[u8], output: &mut [u8]) -> anyhow::Result<()>`

to a function returning:

`impl To<[u8], anyhow::Result<()>>`

implemented using with_destination.
All direct call sites were updated accordingly.

## Changes Included
- Convert b64_decode to return impl To<[u8], anyhow::Result<()>>
- Preserve existing logic and error handling exactly
- Update direct call sites in:
- secret-memory
- wireguard-broker
- Update documentation examples to match the new usage pattern
- Add rosenpass-to dependency where required
- Remove unused import introduced during refactoring (anyhow::bail)

⸻

**Behavioral Changes**

None.

This is a mechanical refactor only:
- no logic changes
- no allocation changes
- no performance changes
- no cryptographic code modified

⸻

**Pattern Followed**

The refactor follows:
- the rosenpass-to pattern documented in /to/README.md
- existing usage already present in the repository
- the intended migration direction described in issue #164

No new abstractions or extension traits were introduced.

⸻

**Validation**

The following checks were performed:
- cargo check succeeds for all affected crates
- all existing tests pass unchanged:
- rosenpass-util
- rosenpass-secret-memory
- rosenpass-wireguard-broker
- no new compiler warnings introduced by this change
- diff intentionally kept small for ease of review
