### PR TITLE
feat: minimalist ConnMan integration support (#82)

### DIFF
--- a/config-examples/connman/setup.sh
+++ b/config-examples/connman/setup.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+# Rosenpass + ConnMan Integration (Minimalist)
+set -e
+
+INTERFACE="${1:-wg0}"
+ROLE="${2:-server}"
+CONFIG_DIR="/etc/rosenpass/${INTERFACE}"
+
+echo "===> Quick Setup: Rosenpass + ConnMan for ${INTERFACE}"
+
+# 1. Standard Key Generation (Consistency)
+mkdir -p "${CONFIG_DIR}/peers"
+chmod 700 "${CONFIG_DIR}"
+rosenpass gen-keys --secret-key "${CONFIG_DIR}/pqsk" --public-key "${CONFIG_DIR}/pqpk"
+
+# 2. ConnMan Configuration (The Lean Way)
+CONNMAN_CONF="/var/lib/connman/${INTERFACE}.config"
+
+echo "===> Generating ConnMan provisioning file: ${CONNMAN_CONF}"
+cat <<EOM | sudo tee "${CONNMAN_CONF}" > /dev/null
+[service_${INTERFACE}]
+Type = vpn
+Name = Rosenpass_${INTERFACE}
+VPN.Type = wireguard
+IPv4 = 10.0.0.1/24
+EOM
+
+echo "===> Done. Rosenpass keys generated in ${CONFIG_DIR}"
+echo "     ConnMan service created. Run 'connmanctl services' to verify."


### PR DESCRIPTION
Hi! I saw the ongoing discussion on #82. 

Instead of adding a whole new infrastructure, I’ve put together a single, lightweight setup script. I think it’s better to keep things simple: it just handles the keys and generates a basic ConnMan provisioning file, following the same pattern already used in the repo for other network managers.

It’s less than 30 lines of code—easy to review, easy to maintain, and get the job done without any bloat.

Let me know if this approach works for you!

/claim #82