### PR TITLE
feat: add Open vSwitch network manager support

### DIFF
--- a/config-examples/openvswitch/README.md
+++ b/config-examples/openvswitch/README.md
@@ -1,0 +1,104 @@
+# Rosenpass + WireGuard + Open vSwitch
+
+This directory contains an example setup for integrating **Rosenpass** post-quantum key exchange with **WireGuard** tunnels managed through **Open vSwitch** (OVS).
+
+## Overview
+
+```
+ Server                                 Client
++----------------------------+         +----------------------------+
+| OVS bridge (br-rp)        |         | OVS bridge (br-rp)        |
+|   +--- wg0 (WireGuard) ---|---------|--- wg0 (WireGuard) ---+   |
+|   |    PSK via Rosenpass   |  tunnel |    PSK via Rosenpass  |   |
+|   +--- other ports ...     |         |     other ports ... --+   |
++----------------------------+         +----------------------------+
+```
+
+Rosenpass performs a post-quantum key exchange and continuously rotates the
+WireGuard preshared key (PSK). Open vSwitch manages the WireGuard interface
+as a port on an OVS bridge, enabling software-defined networking features
+such as VLAN tagging, OpenFlow rules, and centralized management via OVSDB.
+
+## Layout
+
+```
+openvswitch/
+  server/
+    config.toml          Rosenpass server configuration
+  client/
+    config.toml          Rosenpass client configuration
+  setup.sh               Create WireGuard interface, OVS bridge, and keys
+  teardown.sh            Remove OVS bridge and WireGuard interface
+  validate.sh            Check configuration consistency
+```
+
+## Prerequisites
+
+- `rosenpass` installed and in `$PATH`
+- `wg` (wireguard-tools) installed
+- `ovs-vsctl` and `ovsdb-server` (Open vSwitch) installed and running
+- Kernel WireGuard support
+- Root privileges
+
+## Quick start
+
+On **both** machines (server and client):
+
+```bash
+# 1. Run the setup script
+sudo ./setup.sh wg0 server   # on the server
+sudo ./setup.sh wg0 client   # on the client
+
+# 2. Exchange public keys
+#    Copy /etc/rosenpass/wg0/pqpk        -> other side's peers/<name>/pqpk
+#    Copy /etc/rosenpass/wg0/wg-*.pub    -> use in WireGuard peer config
+
+# 3. Edit config.toml with the peer's WireGuard public key and endpoint
+
+# 4. Bring the interface up
+sudo ip link set wg0 up
+
+# 5. Start Rosenpass
+rosenpass exchange-config /etc/rosenpass/wg0/config.toml
+# or use the systemd service:
+sudo systemctl start rosenpass@wg0
+```
+
+## Verifying
+
+```bash
+# Check OVS bridge
+ovs-vsctl show
+
+# Check WireGuard handshake and PSK
+wg show wg0
+
+# Validate config consistency
+sudo ./validate.sh wg0
+```
+
+## How it works
+
+1. `setup.sh` creates a WireGuard interface, generates Rosenpass and WireGuard
+   keys, then creates an OVS bridge and adds the WireGuard interface as a port.
+
+2. Rosenpass runs its post-quantum key exchange protocol and delivers the
+   resulting PSK to WireGuard via `wg set <dev> peer <id> preshared-key`.
+   This happens continuously -- keys are rotated every two minutes.
+
+3. OVS treats the WireGuard interface like any other port. You can apply VLAN
+   tags, OpenFlow rules, or mirror traffic as needed. OVS does not interfere
+   with the key exchange; it only sees encrypted WireGuard packets.
+
+## OVS-specific considerations
+
+- The WireGuard interface is added as an **OVS port**, not an OVS internal
+  interface. WireGuard manages its own interface type.
+- If you need VLAN tagging on the tunnel, set it on the OVS port:
+  ```bash
+  ovs-vsctl set port wg0 tag=100
+  ```
+- For OpenFlow-based routing, use `ovs-ofctl` to add flow rules to `br-rp`.
+- OVS configuration persists in `ovsdb-server` across reboots. WireGuard and
+  Rosenpass configuration is managed separately via their config files and
+  systemd units.

--- a/config-examples/openvswitch/client/config.toml
+++ b/config-examples/openvswitch/client/config.toml
@@ -1,0 +1,16 @@
+# Rosenpass client configuration for Open vSwitch integration
+#
+# The WireGuard interface (wg0) is added as an OVS port on bridge br-rp.
+# Rosenpass manages PSK rotation independently of the OVS layer.
+
+public_key = "/etc/rosenpass/wg0/pqpk"
+secret_key = "/etc/rosenpass/wg0/pqsk"
+listen = []
+verbosity = "Verbose"
+
+[[peers]]
+public_key = "/etc/rosenpass/wg0/peers/server/pqpk"
+endpoint = "SERVER_IP:9999"
+# WireGuard interface and peer for PSK delivery
+device = "wg0"
+peer = "SERVER_WG_PUBLIC_KEY_HERE"

--- a/config-examples/openvswitch/server/config.toml
+++ b/config-examples/openvswitch/server/config.toml
@@ -1,0 +1,15 @@
+# Rosenpass server configuration for Open vSwitch integration
+#
+# The WireGuard interface (wg0) is added as an OVS port on bridge br-rp.
+# Rosenpass manages PSK rotation independently of the OVS layer.
+
+public_key = "/etc/rosenpass/wg0/pqpk"
+secret_key = "/etc/rosenpass/wg0/pqsk"
+listen = ["0.0.0.0:9999"]
+verbosity = "Verbose"
+
+[[peers]]
+public_key = "/etc/rosenpass/wg0/peers/client/pqpk"
+# WireGuard interface and peer for PSK delivery
+device = "wg0"
+peer = "CLIENT_WG_PUBLIC_KEY_HERE"

--- a/config-examples/openvswitch/setup.sh
+++ b/config-examples/openvswitch/setup.sh
@@ -1,0 +1,132 @@
+#!/bin/bash
+# Setup script for Rosenpass + WireGuard + Open vSwitch integration
+#
+# Creates a WireGuard interface, generates Rosenpass and WireGuard keys,
+# creates an OVS bridge, and adds the WireGuard interface as a port.
+#
+# Usage: sudo ./setup.sh [INTERFACE] [ROLE]
+#   INTERFACE  WireGuard interface name (default: wg0)
+#   ROLE       "server" or "client" (default: server)
+#
+# Environment variables:
+#   BRIDGE     OVS bridge name (default: br-rp)
+#   RP_PORT    Rosenpass listen port, server only (default: 9999)
+#   WG_PORT    WireGuard listen port, server only (default: 51820)
+
+set -euo pipefail
+
+INTERFACE="${1:-wg0}"
+ROLE="${2:-server}"
+BRIDGE="${BRIDGE:-br-rp}"
+RP_PORT="${RP_PORT:-9999}"
+WG_PORT="${WG_PORT:-51820}"
+CONFIG_DIR="/etc/rosenpass/${INTERFACE}"
+
+if [ "$(id -u)" -ne 0 ]; then
+    echo "Error: this script must be run as root" >&2
+    exit 1
+fi
+
+if ! command -v ovs-vsctl >/dev/null 2>&1; then
+    echo "Error: ovs-vsctl not found. Install Open vSwitch first." >&2
+    exit 1
+fi
+
+if ! command -v wg >/dev/null 2>&1; then
+    echo "Error: wg not found. Install wireguard-tools first." >&2
+    exit 1
+fi
+
+if ! command -v rosenpass >/dev/null 2>&1; then
+    echo "Error: rosenpass not found. Install Rosenpass first." >&2
+    exit 1
+fi
+
+echo "==> Setting up Rosenpass + WireGuard + OVS (interface=${INTERFACE}, role=${ROLE}, bridge=${BRIDGE})"
+
+# --- Key generation ---
+
+mkdir -p "${CONFIG_DIR}/peers"
+chmod 700 "${CONFIG_DIR}"
+
+echo "==> Generating WireGuard keys..."
+wg genkey | tee "${CONFIG_DIR}/wg.key" | wg pubkey > "${CONFIG_DIR}/wg.pub"
+chmod 600 "${CONFIG_DIR}/wg.key"
+echo "    WireGuard public key: $(cat "${CONFIG_DIR}/wg.pub")"
+
+echo "==> Generating Rosenpass keys..."
+rosenpass gen-keys --secret-key "${CONFIG_DIR}/pqsk" --public-key "${CONFIG_DIR}/pqpk"
+echo "    Rosenpass public key: ${CONFIG_DIR}/pqpk"
+
+# --- WireGuard interface ---
+
+echo "==> Creating WireGuard interface ${INTERFACE}..."
+ip link add dev "${INTERFACE}" type wireguard 2>/dev/null || true
+
+if [ "${ROLE}" = "server" ]; then
+    wg set "${INTERFACE}" listen-port "${WG_PORT}" private-key "${CONFIG_DIR}/wg.key"
+else
+    wg set "${INTERFACE}" private-key "${CONFIG_DIR}/wg.key"
+fi
+
+# --- OVS bridge and port ---
+
+echo "==> Configuring Open vSwitch bridge ${BRIDGE}..."
+ovs-vsctl --may-exist add-br "${BRIDGE}"
+ovs-vsctl --may-exist add-port "${BRIDGE}" "${INTERFACE}"
+echo "    Added ${INTERFACE} to bridge ${BRIDGE}"
+
+# --- Rosenpass config ---
+
+echo "==> Writing Rosenpass config to ${CONFIG_DIR}/config.toml..."
+if [ "${ROLE}" = "server" ]; then
+    cat > "${CONFIG_DIR}/config.toml" << EOF
+public_key = "${CONFIG_DIR}/pqpk"
+secret_key = "${CONFIG_DIR}/pqsk"
+listen = ["0.0.0.0:${RP_PORT}"]
+verbosity = "Verbose"
+
+# Add peers below. For each peer:
+# [[peers]]
+# public_key = "${CONFIG_DIR}/peers/<name>/pqpk"
+# device = "${INTERFACE}"
+# peer = "<PEER_WG_PUBLIC_KEY>"
+EOF
+else
+    cat > "${CONFIG_DIR}/config.toml" << EOF
+public_key = "${CONFIG_DIR}/pqpk"
+secret_key = "${CONFIG_DIR}/pqsk"
+listen = []
+verbosity = "Verbose"
+
+# Add peers below. For each peer:
+# [[peers]]
+# public_key = "${CONFIG_DIR}/peers/<name>/pqpk"
+# endpoint = "<SERVER_IP>:${RP_PORT}"
+# device = "${INTERFACE}"
+# peer = "<PEER_WG_PUBLIC_KEY>"
+EOF
+fi
+chmod 600 "${CONFIG_DIR}/config.toml"
+
+echo ""
+echo "==> Setup complete!"
+echo ""
+echo "    WireGuard public key : $(cat "${CONFIG_DIR}/wg.pub")"
+echo "    Rosenpass public key : ${CONFIG_DIR}/pqpk"
+echo "    Rosenpass config     : ${CONFIG_DIR}/config.toml"
+echo "    OVS bridge           : ${BRIDGE}"
+echo ""
+echo "==> Next steps:"
+echo "    1. Exchange public keys with peer"
+echo "    2. Copy peer's Rosenpass public key to ${CONFIG_DIR}/peers/<name>/pqpk"
+echo "    3. Add peer to ${CONFIG_DIR}/config.toml (see comments in file)"
+echo "    4. Configure WireGuard peer:"
+echo "       wg set ${INTERFACE} peer <PEER_WG_PUB> endpoint <IP>:<PORT> allowed-ips <CIDR>"
+echo "    5. Assign IP and bring interface up:"
+echo "       ip addr add <IP>/<CIDR> dev ${BRIDGE}"
+echo "       ip link set ${INTERFACE} up"
+echo "       ip link set ${BRIDGE} up"
+echo "    6. Start Rosenpass:"
+echo "       rosenpass exchange-config ${CONFIG_DIR}/config.toml"
+echo "       # or: systemctl start rosenpass@${INTERFACE}"

--- a/config-examples/openvswitch/teardown.sh
+++ b/config-examples/openvswitch/teardown.sh
@@ -1,0 +1,76 @@
+#!/bin/bash
+# Teardown script for Rosenpass + WireGuard + Open vSwitch integration
+#
+# Removes the WireGuard interface from the OVS bridge and optionally
+# deletes the bridge if no other ports remain.
+#
+# Usage: sudo ./teardown.sh [INTERFACE] [--delete-bridge] [--delete-keys]
+#   INTERFACE      WireGuard interface name (default: wg0)
+#   --delete-bridge  Also delete the OVS bridge if empty
+#   --delete-keys    Also remove keys from /etc/rosenpass/<INTERFACE>
+#
+# Environment variables:
+#   BRIDGE     OVS bridge name (default: br-rp)
+
+set -euo pipefail
+
+INTERFACE="${1:-wg0}"
+BRIDGE="${BRIDGE:-br-rp}"
+DELETE_BRIDGE=false
+DELETE_KEYS=false
+
+shift || true
+for arg in "$@"; do
+    case "${arg}" in
+        --delete-bridge) DELETE_BRIDGE=true ;;
+        --delete-keys)   DELETE_KEYS=true ;;
+        *)               echo "Unknown option: ${arg}" >&2; exit 1 ;;
+    esac
+done
+
+if [ "$(id -u)" -ne 0 ]; then
+    echo "Error: this script must be run as root" >&2
+    exit 1
+fi
+
+echo "==> Tearing down Rosenpass + WireGuard + OVS (interface=${INTERFACE}, bridge=${BRIDGE})"
+
+# Stop Rosenpass if running via systemd
+if systemctl is-active --quiet "rosenpass@${INTERFACE}" 2>/dev/null; then
+    echo "==> Stopping rosenpass@${INTERFACE}..."
+    systemctl stop "rosenpass@${INTERFACE}"
+fi
+
+# Remove WireGuard port from OVS bridge
+if ovs-vsctl port-to-br "${INTERFACE}" >/dev/null 2>&1; then
+    echo "==> Removing ${INTERFACE} from OVS bridge..."
+    ovs-vsctl --if-exists del-port "${BRIDGE}" "${INTERFACE}"
+fi
+
+# Delete WireGuard interface
+if ip link show "${INTERFACE}" >/dev/null 2>&1; then
+    echo "==> Deleting WireGuard interface ${INTERFACE}..."
+    ip link del dev "${INTERFACE}"
+fi
+
+# Optionally delete the bridge if empty
+if [ "${DELETE_BRIDGE}" = true ]; then
+    PORT_COUNT=$(ovs-vsctl list-ports "${BRIDGE}" 2>/dev/null | wc -l)
+    if [ "${PORT_COUNT}" -eq 0 ]; then
+        echo "==> Deleting empty OVS bridge ${BRIDGE}..."
+        ovs-vsctl --if-exists del-br "${BRIDGE}"
+    else
+        echo "==> Bridge ${BRIDGE} still has ${PORT_COUNT} port(s), keeping it"
+    fi
+fi
+
+# Optionally delete keys
+if [ "${DELETE_KEYS}" = true ]; then
+    CONFIG_DIR="/etc/rosenpass/${INTERFACE}"
+    if [ -d "${CONFIG_DIR}" ]; then
+        echo "==> Removing keys and config from ${CONFIG_DIR}..."
+        rm -rf "${CONFIG_DIR}"
+    fi
+fi
+
+echo "==> Teardown complete"

--- a/config-examples/openvswitch/validate.sh
+++ b/config-examples/openvswitch/validate.sh
@@ -1,0 +1,137 @@
+#!/bin/bash
+# Validation script for Rosenpass + WireGuard + Open vSwitch configuration
+#
+# Checks that all pieces of the integration are consistent:
+#   - OVS bridge exists and contains the WireGuard interface
+#   - WireGuard interface is configured
+#   - Rosenpass config references the correct interface
+#   - Key file permissions are secure
+#   - No static PresharedKey is set (Rosenpass manages this)
+#
+# Usage: sudo ./validate.sh [INTERFACE]
+#   INTERFACE  WireGuard interface name (default: wg0)
+#
+# Environment variables:
+#   BRIDGE     OVS bridge name (default: br-rp)
+
+set -euo pipefail
+
+INTERFACE="${1:-wg0}"
+BRIDGE="${BRIDGE:-br-rp}"
+CONFIG_DIR="/etc/rosenpass/${INTERFACE}"
+ERRORS=0
+
+err() {
+    echo "  [FAIL] $*" >&2
+    ERRORS=$((ERRORS + 1))
+}
+
+ok() {
+    echo "  [ OK ] $*"
+}
+
+echo "==> Validating Rosenpass + WireGuard + OVS for ${INTERFACE} (bridge ${BRIDGE})"
+echo ""
+
+# --- Check OVS ---
+
+echo "--- Open vSwitch ---"
+
+if command -v ovs-vsctl >/dev/null 2>&1; then
+    ok "ovs-vsctl found"
+else
+    err "ovs-vsctl not found"
+fi
+
+if ovs-vsctl br-exists "${BRIDGE}" 2>/dev/null; then
+    ok "Bridge ${BRIDGE} exists"
+else
+    err "Bridge ${BRIDGE} does not exist"
+fi
+
+ACTUAL_BRIDGE=$(ovs-vsctl port-to-br "${INTERFACE}" 2>/dev/null || echo "")
+if [ "${ACTUAL_BRIDGE}" = "${BRIDGE}" ]; then
+    ok "${INTERFACE} is a port on ${BRIDGE}"
+elif [ -n "${ACTUAL_BRIDGE}" ]; then
+    err "${INTERFACE} is on bridge ${ACTUAL_BRIDGE}, expected ${BRIDGE}"
+else
+    err "${INTERFACE} is not an OVS port"
+fi
+
+echo ""
+
+# --- Check WireGuard ---
+
+echo "--- WireGuard ---"
+
+if ip link show "${INTERFACE}" >/dev/null 2>&1; then
+    ok "Interface ${INTERFACE} exists"
+else
+    err "Interface ${INTERFACE} does not exist"
+fi
+
+WG_OUTPUT=$(wg show "${INTERFACE}" 2>/dev/null || echo "")
+if [ -n "${WG_OUTPUT}" ]; then
+    ok "WireGuard is configured on ${INTERFACE}"
+
+    # Check no static PSK is set (Rosenpass manages this)
+    PSK_LINES=$(wg show "${INTERFACE}" preshared-keys 2>/dev/null | grep -cv "(none)" || echo "0")
+    if [ "${PSK_LINES}" -gt 0 ]; then
+        ok "Preshared keys active (Rosenpass is delivering PSKs)"
+    else
+        echo "  [INFO] No preshared keys yet -- Rosenpass may not have completed a handshake"
+    fi
+else
+    err "WireGuard not configured on ${INTERFACE}"
+fi
+
+echo ""
+
+# --- Check Rosenpass config ---
+
+echo "--- Rosenpass ---"
+
+CONFIG_FILE="${CONFIG_DIR}/config.toml"
+if [ -f "${CONFIG_FILE}" ]; then
+    ok "Config file ${CONFIG_FILE} exists"
+
+    # Check that config references the correct WireGuard device
+    if grep -q "device = \"${INTERFACE}\"" "${CONFIG_FILE}" 2>/dev/null; then
+        ok "Config references device ${INTERFACE}"
+    else
+        err "Config does not reference device ${INTERFACE}"
+    fi
+else
+    err "Config file ${CONFIG_FILE} not found"
+fi
+
+echo ""
+
+# --- Check key permissions ---
+
+echo "--- Key permissions ---"
+
+for keyfile in "${CONFIG_DIR}/pqsk" "${CONFIG_DIR}/wg.key"; do
+    if [ -f "${keyfile}" ]; then
+        # Use portable stat: try GNU first, then BSD
+        PERMS=$(stat -c "%a" "${keyfile}" 2>/dev/null || stat -f "%Lp" "${keyfile}" 2>/dev/null || echo "unknown")
+        if [ "${PERMS}" = "600" ]; then
+            ok "${keyfile} has correct permissions (600)"
+        else
+            err "${keyfile} has permissions ${PERMS} (should be 600)"
+        fi
+    else
+        echo "  [INFO] ${keyfile} not found (may not be generated yet)"
+    fi
+done
+
+echo ""
+
+# --- Summary ---
+
+if [ "${ERRORS}" -eq 0 ]; then
+    echo "==> All checks passed"
+else
+    echo "==> ${ERRORS} error(s) found" >&2
+    exit 1
+fi

--- a/tests/openvswitch/rosenpass-ovs.nix
+++ b/tests/openvswitch/rosenpass-ovs.nix
@@ -1,0 +1,194 @@
+# NixOS integration test: Rosenpass + WireGuard + Open vSwitch
+#
+# Verifies that Rosenpass can perform post-quantum key exchange over a
+# WireGuard tunnel whose interfaces are managed as ports on OVS bridges.
+#
+# Topology:
+#   server (192.168.0.1) <--eth1--> client (192.168.0.2)
+#   WireGuard tunnel: server wg0 (10.23.42.1) <-> client wg0 (10.23.42.2)
+#   OVS bridge br-rp on each side with wg0 as a port
+{ pkgs, ... }:
+
+let
+  server = {
+    ip4 = "192.168.0.1";
+    wg = {
+      ip4 = "10.23.42.1";
+      public = "mQufmDFeQQuU/fIaB2hHgluhjjm1ypK4hJr1cW3WqAw=";
+      secret = "4N5Y1dldqrpsbaEiY8O0XBUGUFf8vkvtBtm8AoOX7Eo=";
+      listen = 10000;
+    };
+  };
+
+  client = {
+    ip4 = "192.168.0.2";
+    wg = {
+      ip4 = "10.23.42.2";
+      public = "Mb3GOlT7oS+F3JntVKiaD7SpHxLxNdtEmWz/9FMnRFU=";
+      secret = "uC5dfGMv7Oxf5UDfdPkj6rZiRZT2dRWp5x8IQxrNcUE=";
+    };
+  };
+
+  server_config = {
+    listen = [ "0.0.0.0:9999" ];
+    public_key = "/etc/rosenpass/wg0/pqpk";
+    secret_key = "/etc/rosenpass/wg0/pqsk";
+    verbosity = "Verbose";
+    peers = [
+      {
+        device = "wg0";
+        peer = client.wg.public;
+        public_key = "/etc/rosenpass/wg0/peers/client/pqpk";
+      }
+    ];
+  };
+
+  client_config = {
+    listen = [ ];
+    public_key = "/etc/rosenpass/wg0/pqpk";
+    secret_key = "/etc/rosenpass/wg0/pqsk";
+    verbosity = "Verbose";
+    peers = [
+      {
+        device = "wg0";
+        peer = server.wg.public;
+        public_key = "/etc/rosenpass/wg0/peers/server/pqpk";
+        endpoint = "${server.ip4}:9999";
+      }
+    ];
+  };
+
+  config = pkgs.runCommand "config" { } ''
+    mkdir -pv $out
+    cp -v ${(pkgs.formats.toml { }).generate "wg0.toml" server_config} $out/server
+    cp -v ${(pkgs.formats.toml { }).generate "wg0.toml" client_config} $out/client
+  '';
+in
+{
+  name = "rosenpass-ovs";
+
+  nodes =
+    let
+      shared =
+        peer:
+        { pkgs, ... }:
+        {
+          virtualisation.vlans = [ 1 ];
+
+          environment.systemPackages = with pkgs; [
+            wireguard-tools
+            rosenpass
+          ];
+
+          # Use networkd with OVS -- the idiomatic NixOS way
+          networking = {
+            useNetworkd = true;
+            useDHCP = false;
+            firewall.enable = false;
+
+            # Create an OVS bridge; eth1 provides L2 connectivity between VMs
+            vswitches.br-rp = {
+              interfaces = {
+                eth1 = { };
+              };
+            };
+          };
+
+          # Assign the underlay IP to the OVS bridge
+          systemd.network.networks."40-br-rp" = {
+            name = "br-rp";
+            networkConfig.Address = "${peer.ip4}/24";
+          };
+        };
+    in
+    {
+      server = {
+        imports = [ (shared server) ];
+      };
+      client = {
+        imports = [ (shared client) ];
+      };
+    };
+
+  testScript =
+    { ... }:
+    ''
+      from os import system
+      rosenpass = "${pkgs.rosenpass}/bin/rosenpass"
+
+      start_all()
+
+      for machine in [server, client]:
+        machine.wait_for_unit("ovsdb.service")
+        machine.wait_for_unit("ovs-vswitchd.service")
+        machine.wait_for_unit("multi-user.target")
+
+      with subtest("Underlay connectivity via OVS bridge"):
+        server.wait_until_succeeds("ping -c1 ${client.ip4}", timeout=30)
+
+      with subtest("Create WireGuard interfaces and add to OVS bridge"):
+        server.succeed(
+          "ip link add dev wg0 type wireguard",
+          "wg set wg0 listen-port ${toString server.wg.listen} private-key <(echo '${server.wg.secret}')",
+          "wg set wg0 peer '${client.wg.public}' allowed-ips ${client.wg.ip4}/32",
+          "ip addr add ${server.wg.ip4}/24 dev wg0",
+          "ip link set wg0 up",
+          "ovs-vsctl add-port br-rp wg0",
+        )
+        client.succeed(
+          "ip link add dev wg0 type wireguard",
+          "wg set wg0 private-key <(echo '${client.wg.secret}')",
+          "wg set wg0 peer '${server.wg.public}' allowed-ips ${server.wg.ip4}/32 endpoint ${server.ip4}:${toString server.wg.listen}",
+          "ip addr add ${client.wg.ip4}/24 dev wg0",
+          "ip link set wg0 up",
+          "ovs-vsctl add-port br-rp wg0",
+        )
+
+      with subtest("Verify OVS port membership"):
+        server.succeed("ovs-vsctl list-ports br-rp | grep wg0")
+        client.succeed("ovs-vsctl list-ports br-rp | grep wg0")
+
+      with subtest("WireGuard tunnel connectivity (no PSK yet)"):
+        client.succeed("wg show wg0 preshared-keys | grep none")
+        client.wait_until_succeeds("ping -c1 ${server.wg.ip4}", timeout=10)
+
+      with subtest("Generate and distribute Rosenpass keys"):
+        for name, machine, remote in [("server", server, client), ("client", client, server)]:
+          machine.succeed("mkdir -p /etc/rosenpass/wg0/peers")
+          system(f"{rosenpass} gen-keys --public-key {name}-pqpk --secret-key {name}-pqsk")
+          machine.copy_from_host(f"{name}-pqsk", "/etc/rosenpass/wg0/pqsk")
+          machine.copy_from_host(f"{name}-pqpk", "/etc/rosenpass/wg0/pqpk")
+          remote.succeed(f"mkdir -p /etc/rosenpass/wg0/peers/{name}")
+          remote.copy_from_host(f"{name}-pqpk", f"/etc/rosenpass/wg0/peers/{name}/pqpk")
+          machine.copy_from_host(f"${config}/{name}", "/etc/rosenpass/wg0/config.toml")
+
+      with subtest("Start Rosenpass and verify PSK exchange"):
+        for machine in [server, client]:
+          machine.succeed("rosenpass exchange-config /etc/rosenpass/wg0/config.toml >/dev/null 2>&1 &")
+
+        # Wait for Rosenpass to complete a key exchange and deliver PSKs
+        client.wait_until_succeeds(
+          "wg show wg0 preshared-keys | grep --invert-match none",
+          timeout=30,
+        )
+        server.wait_until_succeeds(
+          "wg show wg0 preshared-keys | grep --invert-match none",
+          timeout=30,
+        )
+
+        def get_psk(m):
+          psk = m.succeed("wg show wg0 preshared-keys | awk '{print $2}'")
+          psk = psk.strip()
+          assert len(psk.split()) == 1, "Expected exactly one PSK"
+          return psk
+
+        assert get_psk(client) == get_psk(server), "Preshared keys must match"
+
+      with subtest("WireGuard tunnel connectivity with Rosenpass PSK"):
+        client.succeed("ping -c3 ${server.wg.ip4}")
+
+      with subtest("OVS bridge still intact after key exchange"):
+        server.succeed("ovs-vsctl list-ports br-rp | grep wg0")
+        client.succeed("ovs-vsctl list-ports br-rp | grep wg0")
+    '';
+}


### PR DESCRIPTION
/claim #79
  
## Summary

Adds Open vSwitch integration for Rosenpass, addressing #79.

Rosenpass performs post-quantum key exchange and delivers PSKs to WireGuard. This PR adds the plumbing to run that WireGuard interface as a port on an OVS bridge, enabling software-defined networking features (VLANs, OpenFlow rules, OVSDB management) on top of post-quantum-secured tunnels.

### What's included

**Config examples** (`config-examples/openvswitch/`):
- `server/config.toml` and `client/config.toml` -- Rosenpass TOML configs with the correct `device`/`peer` fields for WireGuard PSK delivery
- `setup.sh` -- generates WireGuard + Rosenpass keys, creates the WireGuard interface, creates an OVS bridge, adds the interface as a port, and writes a ready-to-use Rosenpass config. Validates prerequisites (`ovs-vsctl`, `wg`, `rosenpass`) and enforces correct permissions
- `teardown.sh` -- removes the OVS port, deletes the WireGuard interface, optionally cleans up the bridge and keys
- `validate.sh` -- checks OVS bridge/port membership, WireGuard state, Rosenpass config consistency, and key file permissions
- `README.md` -- architecture diagram, quick start guide, OVS-specific considerations

**NixOS integration test** (`tests/openvswitch/rosenpass-ovs.nix`):
- Two-node VM test using `networking.vswitches` (idiomatic NixOS OVS support)
- Creates OVS bridges, WireGuard tunnels, runs Rosenpass key exchange
- Verifies: OVS port membership, WireGuard connectivity before/after PSK, PSK match between peers, bridge integrity after key exchange

### Design decisions

- WireGuard interfaces are added as **OVS ports** (not internal interfaces) because WireGuard manages its own interface type
- The setup script generates a Rosenpass config with `device` and `peer` fields, which tells Rosenpass to deliver PSKs via `wg set` -- the same mechanism used in all other integrations
- OVS is purely a Layer 2 concern; it does not interfere with the Rosenpass key exchange protocol. The PSK delivery goes directly to the WireGuard kernel module via netlink
- All shell scripts pass `shellcheck` and use `set -euo pipefail`
- The NixOS test uses the same patterns as `tests/systemd/rosenpass.nix` and the upstream `nixos/tests/openvswitch.nix`

### How this differs from #717

- Proper Rosenpass TOML config files (not just a shell script)
- Teardown and validation scripts
- NixOS integration test with automated PSK verification
- Does not include unrelated systemd-networkd files
- Architecture documentation

Fixes #79