### PR TITLE
feat(broker): add netctl support for Arch Linux

### DIFF
--- a/rosenpass/src/cli.rs
+++ b/rosenpass/src/cli.rs
@@ -12,6 +12,7 @@ use rosenpass_util::file::{LoadValue, LoadValueB64, StoreValue};
 use rosenpass_wireguard_broker::brokers::native_unix::{
     NativeUnixBroker, NativeUnixBrokerConfigBaseBuilder, NativeUnixBrokerConfigBaseBuilderError,
 };
+use rosenpass_wireguard_broker::brokers::netctl::NetctlBroker;
 use std::ops::DerefMut;
 use std::path::PathBuf;
 
@@ -37,7 +38,7 @@ use {
 };
 
 /// How to reach a WireGuard PSK Broker
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub enum BrokerInterface {
     /// The PSK Broker is listening on a unix socket at the given path
     Socket(PathBuf),
@@ -457,15 +458,20 @@ impl CliArgs {
 
         config.apply_to_app_server(&mut srv)?;
 
-        let broker = Self::create_broker(broker_interface)?;
-        let broker_store_ptr = srv.register_broker(broker)?;
-
         fn cfg_err_map(e: NativeUnixBrokerConfigBaseBuilderError) -> anyhow::Error {
             anyhow::Error::msg(format!("NativeUnixBrokerConfigBaseBuilderError: {:?}", e))
         }
 
         for cfg_peer in config.peers {
             let broker_peer = if let Some(wg) = &cfg_peer.wg {
+                let broker: Box<dyn rosenpass_wireguard_broker::WireguardBrokerMio<MioError = anyhow::Error, Error = anyhow::Error> + Send> = if wg.netctl {
+                    Box::new(NetctlBroker::new())
+                } else {
+                    Self::create_broker(broker_interface.clone())?
+                };
+
+                let broker_store_ptr = srv.register_broker(broker)?;
+
                 let peer_cfg = NativeUnixBrokerConfigBaseBuilder::default()
                     .peer_id_b64(&wg.peer)?
                     .interface(wg.device.clone())
@@ -473,7 +479,7 @@ impl CliArgs {
                     .build()
                     .map_err(cfg_err_map)?;
 
-                let broker_peer = BrokerPeer::new(broker_store_ptr.clone(), Box::new(peer_cfg));
+                let broker_peer = BrokerPeer::new(broker_store_ptr, Box::new(peer_cfg));
 
                 Some(broker_peer)
             } else {

--- a/rosenpass/src/config.rs
+++ b/rosenpass/src/config.rs
@@ -234,6 +234,10 @@ pub struct WireGuard {
     /// WireGuard public key of the peer to supply with pre-shared keys
     pub peer: String,
 
+    /// Use netctl to supply the pre-shared key
+    #[serde(default)]
+    pub netctl: bool,
+
     /// Extra parameters passed to the `wg` command
     #[serde(default)]
     pub extra_params: Vec<String>,

--- a/wireguard-broker/src/brokers/mod.rs
+++ b/wireguard-broker/src/brokers/mod.rs
@@ -4,3 +4,4 @@ pub mod mio_client;
 pub mod netlink;
 
 pub mod native_unix;
+pub mod netctl;

--- a/wireguard-broker/src/brokers/netctl.rs
+++ b/wireguard-broker/src/brokers/netctl.rs
@@ -1,0 +1,103 @@
+//! netctl implementation of the WireGuard PSK broker.
+//!
+//! This module provides an implementation that works on Arch Linux systems by updating
+//! netctl profiles to set pre-shared keys.
+
+use std::fmt::Debug;
+use std::process::Command;
+use std::fs;
+use std::path::PathBuf;
+
+use rosenpass_util::b64::b64_encode;
+use crate::{SerializedBrokerConfig, WireGuardBroker, WireguardBrokerMio};
+use crate::WG_KEY_LEN;
+
+/// A WireGuard broker implementation that uses netctl.
+#[derive(Debug, Default)]
+pub struct NetctlBroker {
+    mio_token: Option<mio::Token>,
+}
+
+impl NetctlBroker {
+    pub fn new() -> Self {
+        Self { mio_token: None }
+    }
+
+    fn find_profile(&self, interface: &str) -> anyhow::Result<PathBuf> {
+        let profile_dir = PathBuf::from("/etc/netctl");
+        for entry in fs::read_dir(profile_dir)? {
+            let entry = entry?;
+            let path = entry.path();
+            if path.is_file() {
+                let content = match fs::read_to_string(&path) {
+                    Ok(c) => c,
+                    Err(_) => continue,
+                };
+                if content.contains(&format!("Interface={}", interface)) && content.contains("Connection=wireguard") {
+                    return Ok(path);
+                }
+            }
+        }
+        anyhow::bail!("Could not find netctl profile for interface {}", interface)
+    }
+}
+
+impl WireGuardBroker for NetctlBroker {
+    type Error = anyhow::Error;
+
+    fn set_psk(&mut self, config: SerializedBrokerConfig<'_>) -> Result<(), Self::Error> {
+        let interface = std::str::from_utf8(config.interface)?;
+        let profile_path = self.find_profile(interface)?;
+
+        // Read the profile
+        let mut content = fs::read_to_string(&profile_path)?;
+
+        // Format the PSK as base64
+        let mut psk_b64_buf = [0u8; WG_KEY_LEN * 4 / 3 + 4];
+        let psk_b64 = b64_encode(config.psk.secret(), &mut psk_b64_buf)?;
+
+        // Update or add PresharedKey
+        if content.contains("PresharedKey=") {
+            let lines: Vec<String> = content.lines().map(|line| {
+                if line.trim().starts_with("PresharedKey=") {
+                    format!("PresharedKey={}", psk_b64)
+                } else {
+                    line.to_string()
+                }
+            }).collect();
+            content = lines.join("\n");
+        } else {
+            content.push_str(&format!("\nPresharedKey={}\n", psk_b64));
+        }
+
+        fs::write(&profile_path, content)?;
+
+        // Restart the profile if it was already active
+        let profile_name = profile_path.file_name().unwrap().to_str().unwrap();
+        let _ = Command::new("netctl").arg("restart").arg(profile_name).status();
+
+        Ok(())
+    }
+}
+
+impl WireguardBrokerMio for NetctlBroker {
+    type MioError = anyhow::Error;
+
+    fn register(&mut self, _registry: &mio::Registry, token: mio::Token) -> Result<(), Self::MioError> {
+        self.mio_token = Some(token);
+        Ok(())
+    }
+
+    fn process_poll(&mut self) -> Result<(), Self::MioError> {
+        Ok(())
+    }
+
+    fn unregister(&mut self, _registry: &mio::Registry) -> Result<(), Self::MioError> {
+        self.mio_token = None;
+        Ok(())
+    }
+
+    fn mio_token(&self) -> Option<mio::Token> {
+        self.mio_token
+    }
+}


### PR DESCRIPTION
This PR implements a `NetctlBroker` to support key distribution on Arch Linux systems using `netctl`.

### Changes
- Added `NetctlBroker` implementation in `wireguard-broker`.
- Added `netctl` configuration option to `rosenpass.toml`.
- Updated CLI to utilize the new broker when configured.

Tested locally by verifying profile updates and restart commands.

/claim #80