### PR TITLE
feat: add systemd-networkd network manager support

### DIFF
--- a/config-examples/systemd-networkd/README.md
+++ b/config-examples/systemd-networkd/README.md
@@ -1,0 +1,120 @@
+# Rosenpass + WireGuard + systemd-networkd
+
+This directory contains an example setup for integrating **Rosenpass** post-quantum key exchange with **WireGuard** tunnels managed by **systemd-networkd**.
+
+## Overview
+
+```
+ Server                                         Client
++-------------------------------------------+  +-------------------------------------------+
+| systemd-networkd                          |  | systemd-networkd                          |
+|   wg0.netdev  → creates WireGuard device  |  |   wg0.netdev  → creates WireGuard device  |
+|   wg0.network → assigns tunnel IP         |  |   wg0.network → assigns tunnel IP         |
+|                                           |  |                                           |
+| Rosenpass                                 |  | Rosenpass                                 |
+|   config.toml → PSK delivery via wg set   |  |   config.toml → PSK delivery via wg set   |
++--------------------WireGuard tunnel-------+--+-------------------------------------------+
+```
+
+systemd-networkd creates and owns the WireGuard device through `.netdev` and
+`.network` unit files. Rosenpass runs alongside as a companion service,
+performing a post-quantum key exchange and continuously rotating the WireGuard
+preshared key (PSK) via `wg set`. The two do not conflict: systemd-networkd
+handles device lifecycle and IP configuration, while Rosenpass handles runtime
+PSK updates through the WireGuard netlink API.
+
+## Layout
+
+```
+systemd-networkd/
+  server/
+    config.toml          Rosenpass server configuration
+  client/
+    config.toml          Rosenpass client configuration
+  setup.sh               Generate keys, write .netdev/.network, write Rosenpass config
+  teardown.sh            Stop services, remove config files
+  validate.sh            Check configuration consistency
+```
+
+## Prerequisites
+
+- `rosenpass` installed and in `$PATH`
+- `wg` (wireguard-tools) installed
+- `systemd-networkd` enabled and running
+- Kernel WireGuard support
+- Root privileges
+
+## Quick start
+
+On **both** machines (server and client):
+
+```bash
+# 1. Run the setup script
+sudo TUNNEL_IP=10.0.0.1/24 ./setup.sh wg0 server   # on the server
+sudo TUNNEL_IP=10.0.0.2/24 ./setup.sh wg0 client   # on the client
+
+# 2. Exchange public keys
+#    Copy /etc/rosenpass/wg0/pqpk        → other side's peers/<name>/pqpk
+#    Copy /etc/rosenpass/wg0/wg.pub      → use in WireGuard peer config
+
+# 3. Add [WireGuardPeer] to /etc/systemd/network/50-wg0.netdev:
+#    [WireGuardPeer]
+#    PublicKey=<PEER_WG_PUBLIC_KEY>
+#    AllowedIPs=<PEER_TUNNEL_CIDR>
+#    Endpoint=<PEER_IP>:<WG_PORT>     # client side only
+
+# 4. Add [[peers]] to /etc/rosenpass/wg0/config.toml (see comments in file)
+
+# 5. Reload systemd-networkd
+sudo networkctl reload
+
+# 6. Start Rosenpass
+rosenpass exchange-config /etc/rosenpass/wg0/config.toml
+# or use the systemd service:
+sudo systemctl start rosenpass@wg0
+```
+
+## Verifying
+
+```bash
+# Check networkd status
+networkctl status wg0
+
+# Check WireGuard handshake and PSK
+wg show wg0
+
+# Validate config consistency
+sudo ./validate.sh wg0
+```
+
+## How it works
+
+1. `setup.sh` generates WireGuard and Rosenpass keys, then writes
+   systemd-networkd `.netdev` and `.network` files plus a Rosenpass
+   `config.toml`.
+
+2. systemd-networkd reads the `.netdev` file and creates the WireGuard
+   interface with the configured private key and peer(s). The `.network`
+   file assigns the tunnel IP address.
+
+3. Rosenpass performs its post-quantum key exchange and delivers the
+   resulting PSK to WireGuard via `wg set <dev> peer <id> preshared-key`.
+   Keys are rotated approximately every two minutes.
+
+4. **Important**: Do NOT set `PresharedKey=` in the `.netdev` file.
+   Rosenpass manages PSK rotation at runtime. A static PSK in the
+   `.netdev` would be overwritten and serves no purpose.
+
+## systemd-networkd-specific considerations
+
+- systemd-networkd `.netdev` files with `Kind=wireguard` support
+  `PrivateKeyFile=` for secure key storage (no key in the unit file).
+- The `[WireGuardPeer]` section in `.netdev` configures static peer
+  information (public key, endpoint, allowed IPs). PSK rotation is
+  handled by Rosenpass at runtime, not by networkd.
+- Use `networkctl reload` after modifying `.netdev`/`.network` files
+  to apply changes without restarting the service.
+- Interface lifecycle is tied to networkd. If networkd restarts, it
+  recreates the interface. Rosenpass should be configured to restart
+  alongside it (the existing `rosenpass@.service` handles this via
+  `Restart=on-failure`).

--- a/config-examples/systemd-networkd/client/config.toml
+++ b/config-examples/systemd-networkd/client/config.toml
@@ -1,0 +1,17 @@
+# Rosenpass client configuration for systemd-networkd integration
+#
+# systemd-networkd creates and manages the WireGuard interface via .netdev
+# and .network files. Rosenpass delivers post-quantum PSKs independently
+# via `wg set`.
+
+public_key = "/etc/rosenpass/wg0/pqpk"
+secret_key = "/etc/rosenpass/wg0/pqsk"
+listen = []
+verbosity = "Verbose"
+
+[[peers]]
+public_key = "/etc/rosenpass/wg0/peers/server/pqpk"
+endpoint = "SERVER_IP:9999"
+# WireGuard interface and peer for PSK delivery
+device = "wg0"
+peer = "SERVER_WG_PUBLIC_KEY_HERE"

--- a/config-examples/systemd-networkd/server/config.toml
+++ b/config-examples/systemd-networkd/server/config.toml
@@ -1,0 +1,16 @@
+# Rosenpass server configuration for systemd-networkd integration
+#
+# systemd-networkd creates and manages the WireGuard interface via .netdev
+# and .network files. Rosenpass delivers post-quantum PSKs independently
+# via `wg set`.
+
+public_key = "/etc/rosenpass/wg0/pqpk"
+secret_key = "/etc/rosenpass/wg0/pqsk"
+listen = ["0.0.0.0:9999"]
+verbosity = "Verbose"
+
+[[peers]]
+public_key = "/etc/rosenpass/wg0/peers/client/pqpk"
+# WireGuard interface and peer for PSK delivery
+device = "wg0"
+peer = "CLIENT_WG_PUBLIC_KEY_HERE"

--- a/config-examples/systemd-networkd/setup.sh
+++ b/config-examples/systemd-networkd/setup.sh
@@ -1,0 +1,170 @@
+#!/bin/bash
+# Setup script for Rosenpass + WireGuard + systemd-networkd integration
+#
+# Generates WireGuard and Rosenpass keys, writes systemd-networkd .netdev
+# and .network unit files, and produces a ready-to-use Rosenpass config.
+#
+# Usage: sudo ./setup.sh [INTERFACE] [ROLE]
+#   INTERFACE  WireGuard interface name (default: wg0)
+#   ROLE       "server" or "client" (default: server)
+#
+# Environment variables:
+#   RP_PORT    Rosenpass listen port, server only (default: 9999)
+#   WG_PORT    WireGuard listen port, server only (default: 51820)
+#   TUNNEL_IP  IP address for the WireGuard tunnel (required)
+
+set -euo pipefail
+
+INTERFACE="${1:-wg0}"
+ROLE="${2:-server}"
+RP_PORT="${RP_PORT:-9999}"
+WG_PORT="${WG_PORT:-51820}"
+TUNNEL_IP="${TUNNEL_IP:-}"
+CONFIG_DIR="/etc/rosenpass/${INTERFACE}"
+NETWORKD_DIR="/etc/systemd/network"
+
+if [ "$(id -u)" -ne 0 ]; then
+    echo "Error: this script must be run as root" >&2
+    exit 1
+fi
+
+if [ -z "${TUNNEL_IP}" ]; then
+    echo "Error: TUNNEL_IP must be set (e.g. TUNNEL_IP=10.0.0.1/24)" >&2
+    exit 1
+fi
+
+if ! command -v wg >/dev/null 2>&1; then
+    echo "Error: wg not found. Install wireguard-tools first." >&2
+    exit 1
+fi
+
+if ! command -v rosenpass >/dev/null 2>&1; then
+    echo "Error: rosenpass not found. Install Rosenpass first." >&2
+    exit 1
+fi
+
+if ! systemctl is-active --quiet systemd-networkd 2>/dev/null; then
+    echo "Warning: systemd-networkd is not running. Start it before using this config." >&2
+fi
+
+echo "==> Setting up Rosenpass + WireGuard + systemd-networkd (interface=${INTERFACE}, role=${ROLE})"
+
+# --- Key generation ---
+
+mkdir -p "${CONFIG_DIR}/peers"
+chmod 700 "${CONFIG_DIR}"
+
+echo "==> Generating WireGuard keys..."
+wg genkey | tee "${CONFIG_DIR}/wg.key" | wg pubkey > "${CONFIG_DIR}/wg.pub"
+chmod 600 "${CONFIG_DIR}/wg.key"
+echo "    WireGuard public key: $(cat "${CONFIG_DIR}/wg.pub")"
+
+echo "==> Generating Rosenpass keys..."
+rosenpass gen-keys --secret-key "${CONFIG_DIR}/pqsk" --public-key "${CONFIG_DIR}/pqpk"
+echo "    Rosenpass public key: ${CONFIG_DIR}/pqpk"
+
+# --- systemd-networkd .netdev file ---
+
+echo "==> Writing systemd-networkd .netdev file..."
+mkdir -p "${NETWORKD_DIR}"
+
+if [ "${ROLE}" = "server" ]; then
+    cat > "${NETWORKD_DIR}/50-${INTERFACE}.netdev" << EOF
+[NetDev]
+Name=${INTERFACE}
+Kind=wireguard
+Description=WireGuard tunnel (Rosenpass post-quantum PSK)
+
+[WireGuard]
+ListenPort=${WG_PORT}
+PrivateKeyFile=${CONFIG_DIR}/wg.key
+
+# Peers are added below. Do NOT set PresharedKey here --
+# Rosenpass manages PSK rotation via wg set.
+# [WireGuardPeer]
+# PublicKey=PEER_WG_PUBLIC_KEY_HERE
+# AllowedIPs=PEER_TUNNEL_CIDR
+EOF
+else
+    cat > "${NETWORKD_DIR}/50-${INTERFACE}.netdev" << EOF
+[NetDev]
+Name=${INTERFACE}
+Kind=wireguard
+Description=WireGuard tunnel (Rosenpass post-quantum PSK)
+
+[WireGuard]
+PrivateKeyFile=${CONFIG_DIR}/wg.key
+
+# Peers are added below. Do NOT set PresharedKey here --
+# Rosenpass manages PSK rotation via wg set.
+# [WireGuardPeer]
+# PublicKey=PEER_WG_PUBLIC_KEY_HERE
+# Endpoint=SERVER_IP:${WG_PORT}
+# AllowedIPs=PEER_TUNNEL_CIDR
+EOF
+fi
+chmod 640 "${NETWORKD_DIR}/50-${INTERFACE}.netdev"
+
+# --- systemd-networkd .network file ---
+
+echo "==> Writing systemd-networkd .network file..."
+cat > "${NETWORKD_DIR}/50-${INTERFACE}.network" << EOF
+[Match]
+Name=${INTERFACE}
+
+[Network]
+Address=${TUNNEL_IP}
+EOF
+
+# --- Rosenpass config ---
+
+echo "==> Writing Rosenpass config to ${CONFIG_DIR}/config.toml..."
+if [ "${ROLE}" = "server" ]; then
+    cat > "${CONFIG_DIR}/config.toml" << EOF
+public_key = "${CONFIG_DIR}/pqpk"
+secret_key = "${CONFIG_DIR}/pqsk"
+listen = ["0.0.0.0:${RP_PORT}"]
+verbosity = "Verbose"
+
+# Add peers below. For each peer:
+# [[peers]]
+# public_key = "${CONFIG_DIR}/peers/<name>/pqpk"
+# device = "${INTERFACE}"
+# peer = "<PEER_WG_PUBLIC_KEY>"
+EOF
+else
+    cat > "${CONFIG_DIR}/config.toml" << EOF
+public_key = "${CONFIG_DIR}/pqpk"
+secret_key = "${CONFIG_DIR}/pqsk"
+listen = []
+verbosity = "Verbose"
+
+# Add peers below. For each peer:
+# [[peers]]
+# public_key = "${CONFIG_DIR}/peers/<name>/pqpk"
+# endpoint = "<SERVER_IP>:${RP_PORT}"
+# device = "${INTERFACE}"
+# peer = "<PEER_WG_PUBLIC_KEY>"
+EOF
+fi
+chmod 600 "${CONFIG_DIR}/config.toml"
+
+echo ""
+echo "==> Setup complete!"
+echo ""
+echo "    WireGuard public key : $(cat "${CONFIG_DIR}/wg.pub")"
+echo "    Rosenpass public key : ${CONFIG_DIR}/pqpk"
+echo "    Rosenpass config     : ${CONFIG_DIR}/config.toml"
+echo "    systemd-networkd     : ${NETWORKD_DIR}/50-${INTERFACE}.netdev"
+echo "                           ${NETWORKD_DIR}/50-${INTERFACE}.network"
+echo ""
+echo "==> Next steps:"
+echo "    1. Exchange public keys with peer"
+echo "    2. Copy peer's Rosenpass public key to ${CONFIG_DIR}/peers/<name>/pqpk"
+echo "    3. Add [WireGuardPeer] section to ${NETWORKD_DIR}/50-${INTERFACE}.netdev"
+echo "    4. Add [[peers]] section to ${CONFIG_DIR}/config.toml"
+echo "    5. Reload systemd-networkd:"
+echo "       networkctl reload"
+echo "    6. Start Rosenpass:"
+echo "       rosenpass exchange-config ${CONFIG_DIR}/config.toml"
+echo "       # or: systemctl start rosenpass@${INTERFACE}"

--- a/config-examples/systemd-networkd/teardown.sh
+++ b/config-examples/systemd-networkd/teardown.sh
@@ -1,0 +1,67 @@
+#!/bin/bash
+# Teardown script for Rosenpass + WireGuard + systemd-networkd integration
+#
+# Stops Rosenpass, removes systemd-networkd .netdev and .network files,
+# and optionally deletes keys.
+#
+# Usage: sudo ./teardown.sh [INTERFACE] [--delete-keys]
+#   INTERFACE      WireGuard interface name (default: wg0)
+#   --delete-keys  Also remove keys from /etc/rosenpass/<INTERFACE>
+
+set -euo pipefail
+
+INTERFACE="${1:-wg0}"
+DELETE_KEYS=false
+NETWORKD_DIR="/etc/systemd/network"
+
+shift || true
+for arg in "$@"; do
+    case "${arg}" in
+        --delete-keys) DELETE_KEYS=true ;;
+        *)             echo "Unknown option: ${arg}" >&2; exit 1 ;;
+    esac
+done
+
+if [ "$(id -u)" -ne 0 ]; then
+    echo "Error: this script must be run as root" >&2
+    exit 1
+fi
+
+echo "==> Tearing down Rosenpass + WireGuard + systemd-networkd (interface=${INTERFACE})"
+
+# Stop Rosenpass if running via systemd
+if systemctl is-active --quiet "rosenpass@${INTERFACE}" 2>/dev/null; then
+    echo "==> Stopping rosenpass@${INTERFACE}..."
+    systemctl stop "rosenpass@${INTERFACE}"
+fi
+
+# Remove systemd-networkd unit files
+for f in "${NETWORKD_DIR}/50-${INTERFACE}.netdev" "${NETWORKD_DIR}/50-${INTERFACE}.network"; do
+    if [ -f "${f}" ]; then
+        echo "==> Removing ${f}..."
+        rm -f "${f}"
+    fi
+done
+
+# Reload networkd so it drops the interface
+if systemctl is-active --quiet systemd-networkd 2>/dev/null; then
+    echo "==> Reloading systemd-networkd..."
+    networkctl reload 2>/dev/null || systemctl restart systemd-networkd
+fi
+
+# The interface may linger if networkd doesn't remove it
+if ip link show "${INTERFACE}" >/dev/null 2>&1; then
+    echo "==> Deleting WireGuard interface ${INTERFACE}..."
+    ip link del dev "${INTERFACE}" 2>/dev/null || true
+fi
+
+# Optionally delete keys
+if [ "${DELETE_KEYS}" = true ]; then
+    CONFIG_DIR="/etc/rosenpass/${INTERFACE}"
+    if [ -d "${CONFIG_DIR}" ]; then
+        echo "==> Removing keys and config from ${CONFIG_DIR}..."
+        rm -rf "${CONFIG_DIR}"
+    fi
+fi
+
+echo "==> Teardown complete"

--- a/config-examples/systemd-networkd/validate.sh
+++ b/config-examples/systemd-networkd/validate.sh
@@ -1,0 +1,156 @@
+#!/bin/bash
+# Validation script for Rosenpass + WireGuard + systemd-networkd configuration
+#
+# Checks that all pieces of the integration are consistent:
+#   - systemd-networkd is running and managing the WireGuard interface
+#   - .netdev file exists with Kind=wireguard and no static PresharedKey
+#   - .network file assigns the expected address
+#   - Rosenpass config references the correct interface
+#   - Key file permissions are secure
+#
+# Usage: sudo ./validate.sh [INTERFACE]
+#   INTERFACE  WireGuard interface name (default: wg0)
+
+set -euo pipefail
+
+INTERFACE="${1:-wg0}"
+CONFIG_DIR="/etc/rosenpass/${INTERFACE}"
+NETWORKD_DIR="/etc/systemd/network"
+ERRORS=0
+
+err() {
+    echo "  [FAIL] $*" >&2
+    ERRORS=$((ERRORS + 1))
+}
+
+ok() {
+    echo "  [ OK ] $*"
+}
+
+echo "==> Validating Rosenpass + WireGuard + systemd-networkd for ${INTERFACE}"
+echo ""
+
+# --- Check systemd-networkd ---
+
+echo "--- systemd-networkd ---"
+
+if systemctl is-active --quiet systemd-networkd 2>/dev/null; then
+    ok "systemd-networkd is running"
+else
+    err "systemd-networkd is not running"
+fi
+
+# Check .netdev file
+NETDEV_FILE="${NETWORKD_DIR}/50-${INTERFACE}.netdev"
+if [ -f "${NETDEV_FILE}" ]; then
+    ok ".netdev file exists: ${NETDEV_FILE}"
+
+    if grep -qi "Kind=wireguard" "${NETDEV_FILE}" 2>/dev/null; then
+        ok ".netdev has Kind=wireguard"
+    else
+        err ".netdev missing Kind=wireguard"
+    fi
+
+    if grep -qi "PresharedKey" "${NETDEV_FILE}" 2>/dev/null; then
+        err ".netdev contains PresharedKey -- Rosenpass should manage PSK rotation"
+    else
+        ok "No static PresharedKey in .netdev (correct -- Rosenpass manages PSKs)"
+    fi
+else
+    err ".netdev file not found: ${NETDEV_FILE}"
+fi
+
+# Check .network file
+NETWORK_FILE="${NETWORKD_DIR}/50-${INTERFACE}.network"
+if [ -f "${NETWORK_FILE}" ]; then
+    ok ".network file exists: ${NETWORK_FILE}"
+
+    if grep -qi "Name=${INTERFACE}" "${NETWORK_FILE}" 2>/dev/null; then
+        ok ".network matches interface ${INTERFACE}"
+    else
+        err ".network does not match interface ${INTERFACE}"
+    fi
+else
+    err ".network file not found: ${NETWORK_FILE}"
+fi
+
+echo ""
+
+# --- Check WireGuard ---
+
+echo "--- WireGuard ---"
+
+if ip link show "${INTERFACE}" >/dev/null 2>&1; then
+    ok "Interface ${INTERFACE} exists"
+
+    # Verify systemd-networkd is managing it
+    NETWORKCTL_STATE=$(networkctl status "${INTERFACE}" 2>/dev/null | grep -i "setup state" || echo "")
+    if [ -n "${NETWORKCTL_STATE}" ]; then
+        ok "networkctl reports: ${NETWORKCTL_STATE}"
+    fi
+else
+    err "Interface ${INTERFACE} does not exist"
+fi
+
+WG_OUTPUT=$(wg show "${INTERFACE}" 2>/dev/null || echo "")
+if [ -n "${WG_OUTPUT}" ]; then
+    ok "WireGuard is configured on ${INTERFACE}"
+
+    PSK_LINES=$(wg show "${INTERFACE}" preshared-keys 2>/dev/null | grep -cv "(none)" || echo "0")
+    if [ "${PSK_LINES}" -gt 0 ]; then
+        ok "Preshared keys active (Rosenpass is delivering PSKs)"
+    else
+        echo "  [INFO] No preshared keys yet -- Rosenpass may not have completed a handshake"
+    fi
+else
+    err "WireGuard not configured on ${INTERFACE}"
+fi
+
+echo ""
+
+# --- Check Rosenpass config ---
+
+echo "--- Rosenpass ---"
+
+CONFIG_FILE="${CONFIG_DIR}/config.toml"
+if [ -f "${CONFIG_FILE}" ]; then
+    ok "Config file ${CONFIG_FILE} exists"
+
+    if grep -q "device = \"${INTERFACE}\"" "${CONFIG_FILE}" 2>/dev/null; then
+        ok "Config references device ${INTERFACE}"
+    else
+        err "Config does not reference device ${INTERFACE}"
+    fi
+else
+    err "Config file ${CONFIG_FILE} not found"
+fi
+
+echo ""
+
+# --- Check key permissions ---
+
+echo "--- Key permissions ---"
+
+for keyfile in "${CONFIG_DIR}/pqsk" "${CONFIG_DIR}/wg.key"; do
+    if [ -f "${keyfile}" ]; then
+        PERMS=$(stat -c "%a" "${keyfile}" 2>/dev/null || stat -f "%Lp" "${keyfile}" 2>/dev/null || echo "unknown")
+        if [ "${PERMS}" = "600" ]; then
+            ok "${keyfile} has correct permissions (600)"
+        else
+            err "${keyfile} has permissions ${PERMS} (should be 600)"
+        fi
+    else
+        echo "  [INFO] ${keyfile} not found (may not be generated yet)"
+    fi
+done
+
+echo ""
+
+# --- Summary ---
+
+if [ "${ERRORS}" -eq 0 ]; then
+    echo "==> All checks passed"
+else
+    echo "==> ${ERRORS} error(s) found" >&2
+    exit 1
+fi

--- a/tests/systemd-networkd/rosenpass-networkd.nix
+++ b/tests/systemd-networkd/rosenpass-networkd.nix
@@ -1,0 +1,243 @@
+# NixOS integration test: Rosenpass + WireGuard + systemd-networkd
+#
+# Verifies that Rosenpass can perform post-quantum key exchange over a
+# WireGuard tunnel whose interfaces are managed entirely by systemd-networkd
+# via .netdev and .network unit files.
+#
+# Topology:
+#   server (192.168.0.1) <--eth1--> client (192.168.0.2)
+#   WireGuard tunnel: server wg0 (10.23.42.1) <-> client wg0 (10.23.42.2)
+#   systemd-networkd manages wg0 on each side via netdev/network units
+{ pkgs, ... }:
+
+let
+  server = {
+    ip4 = "192.168.0.1";
+    wg = {
+      ip4 = "10.23.42.1";
+      public = "mQufmDFeQQuU/fIaB2hHgluhjjm1ypK4hJr1cW3WqAw=";
+      secret = "4N5Y1dldqrpsbaEiY8O0XBUGUFf8vkvtBtm8AoOX7Eo=";
+      listen = 10000;
+    };
+  };
+
+  client = {
+    ip4 = "192.168.0.2";
+    wg = {
+      ip4 = "10.23.42.2";
+      public = "Mb3GOlT7oS+F3JntVKiaD7SpHxLxNdtEmWz/9FMnRFU=";
+      secret = "uC5dfGMv7Oxf5UDfdPkj6rZiRZT2dRWp5x8IQxrNcUE=";
+    };
+  };
+
+  server_config = {
+    listen = [ "0.0.0.0:9999" ];
+    public_key = "/etc/rosenpass/wg0/pqpk";
+    secret_key = "/etc/rosenpass/wg0/pqsk";
+    verbosity = "Verbose";
+    peers = [
+      {
+        device = "wg0";
+        peer = client.wg.public;
+        public_key = "/etc/rosenpass/wg0/peers/client/pqpk";
+      }
+    ];
+  };
+
+  client_config = {
+    listen = [ ];
+    public_key = "/etc/rosenpass/wg0/pqpk";
+    secret_key = "/etc/rosenpass/wg0/pqsk";
+    verbosity = "Verbose";
+    peers = [
+      {
+        device = "wg0";
+        peer = server.wg.public;
+        public_key = "/etc/rosenpass/wg0/peers/server/pqpk";
+        endpoint = "${server.ip4}:9999";
+      }
+    ];
+  };
+
+  config = pkgs.runCommand "config" { } ''
+    mkdir -pv $out
+    cp -v ${(pkgs.formats.toml { }).generate "wg0.toml" server_config} $out/server
+    cp -v ${(pkgs.formats.toml { }).generate "wg0.toml" client_config} $out/client
+  '';
+in
+{
+  name = "rosenpass-networkd";
+
+  nodes =
+    let
+      shared =
+        peer:
+        { pkgs, ... }:
+        {
+          virtualisation.vlans = [ 1 ];
+
+          environment.systemPackages = with pkgs; [
+            wireguard-tools
+            rosenpass
+          ];
+
+          # Use systemd-networkd exclusively
+          networking = {
+            useNetworkd = true;
+            useDHCP = false;
+            firewall.enable = false;
+          };
+
+          # Underlay: assign physical IP to eth1 via networkd
+          systemd.network.networks."40-eth1" = {
+            name = "eth1";
+            networkConfig.Address = "${peer.ip4}/24";
+          };
+        };
+
+      # Server: WireGuard .netdev with listen port + peer
+      serverNode =
+        { pkgs, ... }:
+        {
+          imports = [ (shared server) ];
+
+          # WireGuard private key for systemd-networkd
+          environment.etc."wireguard/wg0.key" = {
+            text = server.wg.secret;
+            mode = "0600";
+          };
+
+          # systemd-networkd creates the WireGuard interface
+          systemd.network.netdevs."50-wg0" = {
+            netdevConfig = {
+              Name = "wg0";
+              Kind = "wireguard";
+            };
+            wireguardConfig = {
+              ListenPort = server.wg.listen;
+              PrivateKeyFile = "/etc/wireguard/wg0.key";
+            };
+            wireguardPeers = [
+              {
+                PublicKey = client.wg.public;
+                AllowedIPs = [ "${client.wg.ip4}/32" ];
+              }
+            ];
+          };
+
+          # systemd-networkd assigns the tunnel IP
+          systemd.network.networks."50-wg0" = {
+            name = "wg0";
+            address = [ "${server.wg.ip4}/24" ];
+          };
+        };
+
+      # Client: WireGuard .netdev with endpoint, no listen port
+      clientNode =
+        { pkgs, ... }:
+        {
+          imports = [ (shared client) ];
+
+          environment.etc."wireguard/wg0.key" = {
+            text = client.wg.secret;
+            mode = "0600";
+          };
+
+          systemd.network.netdevs."50-wg0" = {
+            netdevConfig = {
+              Name = "wg0";
+              Kind = "wireguard";
+            };
+            wireguardConfig = {
+              PrivateKeyFile = "/etc/wireguard/wg0.key";
+            };
+            wireguardPeers = [
+              {
+                PublicKey = server.wg.public;
+                AllowedIPs = [ "${server.wg.ip4}/32" ];
+                Endpoint = "${server.ip4}:${toString server.wg.listen}";
+              }
+            ];
+          };
+
+          systemd.network.networks."50-wg0" = {
+            name = "wg0";
+            address = [ "${client.wg.ip4}/24" ];
+          };
+        };
+    in
+    {
+      server = serverNode;
+      client = clientNode;
+    };
+
+  testScript =
+    { ... }:
+    ''
+      from os import system
+      rosenpass = "${pkgs.rosenpass}/bin/rosenpass"
+
+      start_all()
+
+      for machine in [server, client]:
+        machine.wait_for_unit("systemd-networkd.service")
+        machine.wait_for_unit("multi-user.target")
+
+      with subtest("systemd-networkd creates WireGuard interface"):
+        # Wait for networkd to bring up the wg0 interface
+        server.wait_until_succeeds("networkctl status wg0 | grep -i routable", timeout=30)
+        client.wait_until_succeeds("networkctl status wg0 | grep -i routable", timeout=30)
+
+        # Verify interface exists and is managed by networkd
+        server.succeed("ip link show wg0")
+        client.succeed("ip link show wg0")
+
+      with subtest("Underlay connectivity"):
+        server.wait_until_succeeds("ping -c1 ${client.ip4}", timeout=30)
+
+      with subtest("WireGuard tunnel connectivity (no PSK yet)"):
+        client.succeed("wg show wg0 preshared-keys | grep none")
+        client.wait_until_succeeds("ping -c1 ${server.wg.ip4}", timeout=10)
+
+      with subtest("Generate and distribute Rosenpass keys"):
+        for name, machine, remote in [("server", server, client), ("client", client, server)]:
+          machine.succeed("mkdir -p /etc/rosenpass/wg0/peers")
+          system(f"{rosenpass} gen-keys --public-key {name}-pqpk --secret-key {name}-pqsk")
+          machine.copy_from_host(f"{name}-pqsk", "/etc/rosenpass/wg0/pqsk")
+          machine.copy_from_host(f"{name}-pqpk", "/etc/rosenpass/wg0/pqpk")
+          remote.succeed(f"mkdir -p /etc/rosenpass/wg0/peers/{name}")
+          remote.copy_from_host(f"{name}-pqpk", f"/etc/rosenpass/wg0/peers/{name}/pqpk")
+          machine.copy_from_host(f"${config}/{name}", "/etc/rosenpass/wg0/config.toml")
+
+      with subtest("Start Rosenpass and verify PSK delivery"):
+        for machine in [server, client]:
+          machine.succeed("rosenpass exchange-config /etc/rosenpass/wg0/config.toml >/dev/null 2>&1 &")
+
+        # Wait for Rosenpass to complete a key exchange and deliver PSKs
+        client.wait_until_succeeds(
+          "wg show wg0 preshared-keys | grep --invert-match none",
+          timeout=30,
+        )
+        server.wait_until_succeeds(
+          "wg show wg0 preshared-keys | grep --invert-match none",
+          timeout=30,
+        )
+
+      with subtest("PSK match between peers"):
+        def get_psk(m):
+          psk = m.succeed("wg show wg0 preshared-keys | awk '{print $2}'")
+          psk = psk.strip()
+          assert len(psk.split()) == 1, "Expected exactly one PSK"
+          return psk
+
+        assert get_psk(client) == get_psk(server), "Preshared keys must match between peers"
+
+      with subtest("WireGuard tunnel connectivity with Rosenpass PSK"):
+        client.succeed("ping -c3 ${server.wg.ip4}")
+        server.succeed("ping -c3 ${client.wg.ip4}")
+
+      with subtest("Interface still managed by systemd-networkd after key exchange"):
+        server.succeed("networkctl status wg0 | grep -i routable")
+        client.succeed("networkctl status wg0 | grep -i routable")
+    '';
+}


### PR DESCRIPTION
/claim #81

## Summary

Adds systemd-networkd integration for Rosenpass, addressing #81.

Rosenpass performs post-quantum key exchange and delivers PSKs to WireGuard. This PR adds the configuration and tooling to run WireGuard interfaces managed entirely by systemd-networkd (via `.netdev` and `.network` unit files), with Rosenpass as a companion service delivering PSKs via `wg set`.

### What's included

**Config examples** (`config-examples/systemd-networkd/`):
- `server/config.toml` and `client/config.toml` -- Rosenpass TOML configs with the correct `device`/`peer` fields for WireGuard PSK delivery
- `setup.sh` -- generates WireGuard + Rosenpass keys, writes systemd-networkd `.netdev` (with `Kind=wireguard`) and `.network` unit files, and writes a ready-to-use Rosenpass config. Validates prerequisites (`wg`, `rosenpass`, `systemd-networkd`) and enforces correct permissions
- `teardown.sh` -- stops Rosenpass, removes `.netdev`/`.network` files, reloads networkd, optionally cleans up keys
- `validate.sh` -- checks systemd-networkd is managing the interface, `.netdev` has `Kind=wireguard` and no static `PresharedKey`, Rosenpass config consistency, and key file permissions
- `README.md` -- architecture diagram, quick start guide, systemd-networkd-specific considerations

**NixOS integration test** (`tests/systemd-networkd/rosenpass-networkd.nix`):
- Two-node VM test using `networking.useNetworkd = true` (idiomatic NixOS networkd support)
- WireGuard interfaces created via `systemd.network.netdevs` with `Kind = "wireguard"`
- IP assignment via `systemd.network.networks`
- Verifies: systemd-networkd creates the WireGuard interface, tunnel connectivity before/after PSK, PSK delivery by Rosenpass, PSK match between peers, interface remains managed by networkd after key exchange

### Design decisions

- systemd-networkd owns the WireGuard device lifecycle via `.netdev` files. Rosenpass operates independently, delivering PSKs through `wg set` -- the same netlink mechanism used in all other integrations
- **No static `PresharedKey` in `.netdev`**: Rosenpass rotates PSKs at runtime (~every 2 minutes). A static key would be immediately overwritten and serves no purpose
- The NixOS test uses `systemd.network.netdevs` and `systemd.network.networks` rather than `networking.wireguard`, proving the full systemd-networkd path works end-to-end
- All shell scripts pass `shellcheck` and use `set -euo pipefail`
- The NixOS test follows the same patterns as `tests/systemd/rosenpass.nix`

### How this differs from competing PRs

- NixOS integration test with automated two-node verification of the full stack (systemd-networkd device creation, WireGuard tunnel, Rosenpass PSK delivery, PSK match)
- Uses `config-examples/` path consistent with the existing repository layout
- Separate teardown and validation scripts
- No unrelated files or service unit files (the existing `rosenpass@.service` already works)

Fixes #81