### PR TITLE
feat: add netctl network manager support

### DIFF
--- a/config-examples/netctl-peer-a-config.toml
+++ b/config-examples/netctl-peer-a-config.toml
@@ -1,0 +1,25 @@
+# Rosenpass configuration example for use with netctl on Arch Linux.
+#
+# This config is referenced by the netctl profile via the ROSENPASS_CONFIG
+# environment variable. The rosenpass-setup hook (ExecUpPost) starts the
+# daemon with this file after the WireGuard interface is up.
+#
+# Peer A (server) configuration.
+
+public_key = "/etc/rosenpass/wg0/pqpk"
+secret_key = "/etc/rosenpass/wg0/pqsk"
+listen = ["0.0.0.0:9999"]
+verbosity = "Quiet"
+
+[[peers]]
+public_key = "/etc/rosenpass/wg0/peers/peer-b/pqpk"
+endpoint = "peer-b.example.com:9999"
+exchange_command = [
+    "wg",
+    "set",
+    "wg0",
+    "peer",
+    "<PEER_B_WG_PUBLIC_KEY>",
+    "preshared-key",
+    "/dev/stdin",
+]

--- a/config-examples/netctl-peer-b-config.toml
+++ b/config-examples/netctl-peer-b-config.toml
@@ -1,0 +1,20 @@
+# Rosenpass configuration example for use with netctl on Arch Linux.
+#
+# Peer B (client) configuration — does not listen, connects to Peer A.
+
+public_key = "/etc/rosenpass/wg0/pqpk"
+secret_key = "/etc/rosenpass/wg0/pqsk"
+verbosity = "Quiet"
+
+[[peers]]
+public_key = "/etc/rosenpass/wg0/peers/peer-a/pqpk"
+endpoint = "peer-a.example.com:9999"
+exchange_command = [
+    "wg",
+    "set",
+    "wg0",
+    "peer",
+    "<PEER_A_WG_PUBLIC_KEY>",
+    "preshared-key",
+    "/dev/stdin",
+]

--- a/netctl/README.md
+++ b/netctl/README.md
@@ -1,0 +1,64 @@
+# netctl integration for Rosenpass
+
+This directory contains scripts and example profiles for integrating Rosenpass
+with [netctl](https://wiki.archlinux.org/title/Netctl), the profile-based
+network manager for Arch Linux.
+
+## Overview
+
+netctl manages WireGuard interfaces via `Connection=wireguard` profiles stored
+in `/etc/netctl/`. Rosenpass is hooked into the interface lifecycle using
+netctl's `ExecUpPost` and `ExecDownPre` directives:
+
+- **rosenpass-setup** — started after the WireGuard interface comes up; launches
+  the Rosenpass key exchange daemon in the background.
+- **rosenpass-teardown** — called before the interface goes down; gracefully
+  stops the Rosenpass daemon.
+
+## Installation
+
+```bash
+# Install the hook scripts
+install -Dm755 rosenpass-setup   /usr/lib/rosenpass/rosenpass-setup
+install -Dm755 rosenpass-teardown /usr/lib/rosenpass/rosenpass-teardown
+```
+
+## Usage
+
+1. Create your WireGuard configuration as usual (either inline in the netctl
+   profile or via a `WGConfigFile`).
+
+2. Generate Rosenpass keys:
+   ```bash
+   rosenpass gen-keys \
+     --secret-key /etc/rosenpass/wg0/pqsk \
+     --public-key /etc/rosenpass/wg0/pqpk
+   ```
+
+3. Write a Rosenpass config (see `examples/rosenpass-wg0.toml`).
+
+4. Add the Rosenpass hooks to your netctl profile:
+   ```
+   ROSENPASS_CONFIG='/etc/rosenpass/wg0.toml'
+   ExecUpPost='/usr/lib/rosenpass/rosenpass-setup'
+   ExecDownPre='/usr/lib/rosenpass/rosenpass-teardown'
+   ```
+
+5. Start the profile:
+   ```bash
+   netctl start wg0-rosenpass
+   ```
+
+## Environment variables
+
+| Variable | Required | Default | Description |
+|----------|----------|---------|-------------|
+| `INTERFACE` | yes (set by netctl) | — | WireGuard interface name |
+| `ROSENPASS_CONFIG` | yes | — | Path to Rosenpass TOML config |
+| `ROSENPASS_BIN` | no | `rosenpass` | Path to the rosenpass binary |
+| `ROSENPASS_PIDFILE` | no | `/run/rosenpass-$INTERFACE.pid` | PID file path |
+
+## Examples
+
+See the `examples/` subdirectory for complete netctl profiles and a matching
+Rosenpass configuration file.

--- a/netctl/examples/rosenpass-wg0.toml
+++ b/netctl/examples/rosenpass-wg0.toml
@@ -1,0 +1,29 @@
+# Example Rosenpass configuration for use with netctl.
+#
+# This file should be placed at the path referenced by ROSENPASS_CONFIG
+# in your netctl profile (e.g. /etc/rosenpass/wg0.toml).
+#
+# Key generation:
+#   rosenpass gen-keys --secret-key /etc/rosenpass/wg0/pqsk --public-key /etc/rosenpass/wg0/pqpk
+#
+# Exchange the public key (pqpk) with your peer out-of-band.
+
+public_key = "/etc/rosenpass/wg0/pqpk"
+secret_key = "/etc/rosenpass/wg0/pqsk"
+listen = ["0.0.0.0:9999"]
+verbosity = "Quiet"
+
+[[peers]]
+public_key = "/etc/rosenpass/wg0/peers/peer1/pqpk"
+endpoint = "peer1.example.com:9999"
+# The exchange_command is called each time a new PSK is derived.
+# It sets the WireGuard preshared key for the peer via wg(8).
+exchange_command = [
+    "wg",
+    "set",
+    "wg0",
+    "peer",
+    "<PEER_WG_PUBLIC_KEY>",
+    "preshared-key",
+    "/dev/stdin",
+]

--- a/netctl/examples/wg0-rosenpass
+++ b/netctl/examples/wg0-rosenpass
@@ -1,0 +1,26 @@
+# Example netctl profile for a WireGuard interface with Rosenpass
+# post-quantum preshared key rotation.
+#
+# Place this file in /etc/netctl/ (e.g. /etc/netctl/wg0-rosenpass)
+# and the corresponding Rosenpass config in /etc/rosenpass/.
+#
+# Start with: netctl start wg0-rosenpass
+# Enable at boot: netctl enable wg0-rosenpass
+#
+# See also:
+#   - netctl.profile(5)
+#   - wg(8)
+#   - https://rosenpass.eu/docs
+
+Description='WireGuard VPN with Rosenpass post-quantum key exchange'
+Interface=wg0
+Connection=wireguard
+
+# WireGuard configuration
+WGConfigFile='/etc/wireguard/wg0.conf'
+
+# --- Rosenpass hooks ---
+# Adjust paths if you installed rosenpass-setup/teardown elsewhere.
+ROSENPASS_CONFIG='/etc/rosenpass/wg0.toml'
+ExecUpPost='/usr/lib/rosenpass/rosenpass-setup'
+ExecDownPre='/usr/lib/rosenpass/rosenpass-teardown'

--- a/netctl/examples/wg0-server-rosenpass
+++ b/netctl/examples/wg0-server-rosenpass
@@ -1,0 +1,31 @@
+# Example netctl profile for a WireGuard server with Rosenpass.
+#
+# This profile demonstrates inline WireGuard configuration (without a
+# separate wg0.conf file) combined with Rosenpass post-quantum key exchange.
+#
+# Place this file in /etc/netctl/ (e.g. /etc/netctl/wg0-server-rosenpass)
+#
+# See also:
+#   - netctl.profile(5)
+#   - wg(8)
+#   - https://rosenpass.eu/docs
+
+Description='WireGuard server with Rosenpass post-quantum key exchange'
+Interface=wg0
+Connection=wireguard
+
+# WireGuard interface settings
+WGKey='/etc/wireguard/server-private-key'
+WGListenPort=51820
+
+# IP address for the WireGuard interface
+Address=('10.0.0.1/24' 'fd00::1/64')
+
+# Peers
+WGPeer=('peer-public-key-base64' '10.0.0.2/32,fd00::2/128' '' '25')
+# Format: WGPeer=('<public-key>' '<allowed-ips>' '<endpoint>' '<keepalive>')
+
+# --- Rosenpass hooks ---
+ROSENPASS_CONFIG='/etc/rosenpass/wg0.toml'
+ExecUpPost='/usr/lib/rosenpass/rosenpass-setup'
+ExecDownPre='/usr/lib/rosenpass/rosenpass-teardown'

--- a/netctl/rosenpass-setup
+++ b/netctl/rosenpass-setup
@@ -1,0 +1,32 @@
+#!/bin/bash
+# rosenpass-setup — Bring up a WireGuard interface managed by netctl and start
+# the Rosenpass key exchange daemon for post-quantum preshared key rotation.
+#
+# This script is intended to be called from a netctl profile's ExecUpPost hook.
+#
+# Required environment variables (set by netctl or the profile):
+#   INTERFACE       — WireGuard interface name (e.g. wg0)
+#   ROSENPASS_CONFIG — Path to the Rosenpass TOML config file
+#
+# Optional:
+#   ROSENPASS_BIN   — Path to the rosenpass binary (default: rosenpass)
+#   ROSENPASS_PIDFILE — PID file location (default: /run/rosenpass-$INTERFACE.pid)
+
+set -euo pipefail
+
+: "${INTERFACE:?INTERFACE must be set}"
+: "${ROSENPASS_CONFIG:?ROSENPASS_CONFIG must be set}"
+: "${ROSENPASS_BIN:=rosenpass}"
+: "${ROSENPASS_PIDFILE:=/run/rosenpass-${INTERFACE}.pid}"
+
+if [[ ! -f "$ROSENPASS_CONFIG" ]]; then
+    echo "rosenpass-setup: config file not found: $ROSENPASS_CONFIG" >&2
+    exit 1
+fi
+
+# Start rosenpass in the background and record its PID
+"$ROSENPASS_BIN" exchange-config "$ROSENPASS_CONFIG" &
+ROSENPASS_PID=$!
+echo "$ROSENPASS_PID" > "$ROSENPASS_PIDFILE"
+
+echo "rosenpass-setup: started rosenpass (PID $ROSENPASS_PID) for interface $INTERFACE"

--- a/netctl/rosenpass-teardown
+++ b/netctl/rosenpass-teardown
@@ -1,0 +1,43 @@
+#!/bin/bash
+# rosenpass-teardown — Stop the Rosenpass daemon associated with a WireGuard
+# interface managed by netctl.
+#
+# This script is intended to be called from a netctl profile's ExecDownPre hook.
+#
+# Required environment variables (set by netctl or the profile):
+#   INTERFACE       — WireGuard interface name (e.g. wg0)
+#
+# Optional:
+#   ROSENPASS_PIDFILE — PID file location (default: /run/rosenpass-$INTERFACE.pid)
+
+set -euo pipefail
+
+: "${INTERFACE:?INTERFACE must be set}"
+: "${ROSENPASS_PIDFILE:=/run/rosenpass-${INTERFACE}.pid}"
+
+if [[ ! -f "$ROSENPASS_PIDFILE" ]]; then
+    echo "rosenpass-teardown: no PID file found at $ROSENPASS_PIDFILE, nothing to do" >&2
+    exit 0
+fi
+
+ROSENPASS_PID=$(cat "$ROSENPASS_PIDFILE")
+
+if kill -0 "$ROSENPASS_PID" 2>/dev/null; then
+    kill "$ROSENPASS_PID"
+    # Wait briefly for graceful shutdown
+    for i in $(seq 1 10); do
+        if ! kill -0 "$ROSENPASS_PID" 2>/dev/null; then
+            break
+        fi
+        sleep 0.1
+    done
+    # Force kill if still running
+    if kill -0 "$ROSENPASS_PID" 2>/dev/null; then
+        kill -9 "$ROSENPASS_PID" 2>/dev/null || true
+    fi
+    echo "rosenpass-teardown: stopped rosenpass (PID $ROSENPASS_PID) for interface $INTERFACE"
+else
+    echo "rosenpass-teardown: rosenpass (PID $ROSENPASS_PID) already stopped" >&2
+fi
+
+rm -f "$ROSENPASS_PIDFILE"

--- a/tests/netctl/rosenpass.nix
+++ b/tests/netctl/rosenpass.nix
@@ -1,0 +1,216 @@
+# NixOS integration test for the netctl + Rosenpass integration.
+#
+# This test verifies that:
+# 1. A WireGuard interface can be brought up via netctl
+# 2. The rosenpass-setup hook starts the Rosenpass daemon
+# 3. Preshared keys are exchanged between peers
+# 4. The rosenpass-teardown hook cleanly stops the daemon
+#
+# Run with: nix build .#checks.<system>.netctl
+{ pkgs, ... }:
+
+let
+  server = {
+    ip4 = "192.168.0.1";
+    ip6 = "fd00::1";
+    wg = {
+      ip4 = "10.23.42.1";
+      ip6 = "fc00::1";
+      public = "mQufmDFeQQuU/fIaB2hHgluhjjm1ypK4hJr1cW3WqAw=";
+      secret = "4N5Y1dldqrpsbaEiY8O0XBUGUFf8vkvtBtm8AoOX7Eo=";
+      listen = 10000;
+    };
+  };
+
+  client = {
+    ip4 = "192.168.0.2";
+    ip6 = "fd00::2";
+    wg = {
+      ip4 = "10.23.42.2";
+      ip6 = "fc00::2";
+      public = "Mb3GOlT7oS+F3JntVKiaD7SpHxLxNdtEmWz/9FMnRFU=";
+      secret = "uC5dfGMv7Oxf5UDfdPkj6rZiRZT2dRWp5x8IQxrNcUE=";
+    };
+  };
+
+  server_rp_config = {
+    listen = [ "0.0.0.0:9999" ];
+    public_key = "/etc/rosenpass/wg0/pqpk";
+    secret_key = "/etc/rosenpass/wg0/pqsk";
+    verbosity = "Verbose";
+    peers = [
+      {
+        public_key = "/etc/rosenpass/wg0/peers/client/pqpk";
+        exchange_command = [
+          "wg" "set" "wg0" "peer" client.wg.public "preshared-key" "/dev/stdin"
+        ];
+      }
+    ];
+  };
+
+  client_rp_config = {
+    listen = [ ];
+    public_key = "/etc/rosenpass/wg0/pqpk";
+    secret_key = "/etc/rosenpass/wg0/pqsk";
+    verbosity = "Verbose";
+    peers = [
+      {
+        public_key = "/etc/rosenpass/wg0/peers/server/pqpk";
+        endpoint = "${server.ip4}:9999";
+        exchange_command = [
+          "wg" "set" "wg0" "peer" server.wg.public "preshared-key" "/dev/stdin"
+        ];
+      }
+    ];
+  };
+
+  rpConfig = pkgs.runCommand "rp-config" { } ''
+    mkdir -pv $out
+    cp -v ${(pkgs.formats.toml { }).generate "wg0.toml" server_rp_config} $out/server
+    cp -v ${(pkgs.formats.toml { }).generate "wg0.toml" client_rp_config} $out/client
+  '';
+
+  # netctl profile template for WireGuard
+  mkNetctlProfile = peer: remotePeer: ''
+    Description='WireGuard with Rosenpass (test)'
+    Interface=wg0
+    Connection=wireguard
+    WGKey='/etc/wireguard/private-key'
+    ${if peer ? wg && peer.wg ? listen then "WGListenPort=${toString peer.wg.listen}" else ""}
+    Address=('${peer.wg.ip4}/24' '${peer.wg.ip6}/64')
+    WGPeer=('${remotePeer.wg.public}' '${remotePeer.wg.ip4}/32,${remotePeer.wg.ip6}/128' '${if remotePeer ? ip4 then "${remotePeer.ip4}:${toString remotePeer.wg.listen}" else ""}' '25')
+    ROSENPASS_CONFIG='/etc/rosenpass/wg0.toml'
+    ExecUpPost='/usr/lib/rosenpass/rosenpass-setup'
+    ExecDownPre='/usr/lib/rosenpass/rosenpass-teardown'
+  '';
+in
+{
+  name = "netctl-rosenpass";
+
+  nodes =
+    let
+      shared =
+        peer:
+        { pkgs, ... }:
+        {
+          environment.systemPackages = with pkgs; [
+            wireguard-tools
+            netctl
+            rosenpass
+          ];
+          networking.interfaces.eth1 = {
+            ipv4.addresses = [
+              {
+                address = peer.ip4;
+                prefixLength = 24;
+              }
+            ];
+            ipv6.addresses = [
+              {
+                address = peer.ip6;
+                prefixLength = 64;
+              }
+            ];
+          };
+          # Install the rosenpass-setup/teardown scripts
+          environment.etc."usr/lib/rosenpass/rosenpass-setup" = {
+            source = "${pkgs.rosenpass.src}/netctl/rosenpass-setup";
+            mode = "0755";
+          };
+          environment.etc."usr/lib/rosenpass/rosenpass-teardown" = {
+            source = "${pkgs.rosenpass.src}/netctl/rosenpass-teardown";
+            mode = "0755";
+          };
+        };
+    in
+    {
+      server = {
+        imports = [ (shared server) ];
+        networking.firewall.allowedUDPPorts = [
+          9999
+          server.wg.listen
+        ];
+      };
+      client = {
+        imports = [ (shared client) ];
+      };
+    };
+
+  testScript =
+    { ... }:
+    ''
+      from os import system
+      rosenpass = "${pkgs.rosenpass}/bin/rosenpass"
+
+      start_all()
+
+      for machine in [server, client]:
+        machine.wait_for_unit("multi-user.target")
+        machine.wait_for_unit("network-online.target")
+
+      with subtest("Generate keys and deploy configs"):
+        for name, machine, remote, peer, remote_peer in [
+          ("server", server, client, ${builtins.toJSON server}, ${builtins.toJSON client}),
+          ("client", client, server, ${builtins.toJSON client}, ${builtins.toJSON server}),
+        ]:
+          # Generate Rosenpass keys
+          system(f"{rosenpass} gen-keys --public-key {name}-pqpk --secret-key {name}-pqsk")
+
+          # Deploy keys
+          machine.copy_from_host(f"{name}-pqsk", "/etc/rosenpass/wg0/pqsk")
+          machine.copy_from_host(f"{name}-pqpk", "/etc/rosenpass/wg0/pqpk")
+          remote.copy_from_host(f"{name}-pqpk", f"/etc/rosenpass/wg0/peers/{name}/pqpk")
+
+          # Deploy Rosenpass config
+          machine.copy_from_host(f"${rpConfig}/{name}", "/etc/rosenpass/wg0.toml")
+
+          # Deploy WireGuard private key
+          machine.succeed(f"mkdir -p /etc/wireguard")
+
+        # Write WireGuard private keys
+        server.succeed("echo '${server.wg.secret}' > /etc/wireguard/private-key")
+        client.succeed("echo '${client.wg.secret}' > /etc/wireguard/private-key")
+
+      with subtest("Create and start netctl profiles"):
+        server.succeed("mkdir -p /etc/netctl")
+        server.succeed("""cat > /etc/netctl/wg0-rosenpass << 'EOF'
+    ${mkNetctlProfile server client}
+    EOF""")
+
+        client.succeed("mkdir -p /etc/netctl")
+        client.succeed("""cat > /etc/netctl/wg0-rosenpass << 'EOF'
+    ${mkNetctlProfile client server}
+    EOF""")
+
+        server.succeed("netctl start wg0-rosenpass")
+        client.succeed("netctl start wg0-rosenpass")
+
+      with subtest("Verify Rosenpass is running"):
+        server.wait_until_succeeds("test -f /run/rosenpass-wg0.pid", timeout=5)
+        client.wait_until_succeeds("test -f /run/rosenpass-wg0.pid", timeout=5)
+        server.succeed("kill -0 $(cat /run/rosenpass-wg0.pid)")
+        client.succeed("kill -0 $(cat /run/rosenpass-wg0.pid)")
+
+      with subtest("Verify preshared keys are exchanged"):
+        server.wait_until_succeeds("wg show wg0 preshared-keys | grep --invert-match none", timeout=10)
+        client.wait_until_succeeds("wg show wg0 preshared-keys | grep --invert-match none", timeout=10)
+
+        def get_psk(m):
+          psk = m.succeed("wg show wg0 preshared-keys | awk '{print $2}'")
+          psk = psk.strip()
+          assert len(psk.split()) == 1, "Only one PSK expected"
+          return psk
+
+        assert get_psk(client) == get_psk(server), "Preshared keys must match"
+
+      with subtest("Verify network connectivity"):
+        client.succeed("ping -c5 ${server.wg.ip4}")
+        server.succeed("ping -c5 ${client.wg.ip6}")
+
+      with subtest("Teardown via netctl stop"):
+        client.succeed("netctl stop wg0-rosenpass")
+        client.succeed("test ! -f /run/rosenpass-wg0.pid")
+        # Verify the rosenpass process is gone
+        client.fail("pgrep -f 'rosenpass exchange-config'")
+    '';
+}


### PR DESCRIPTION
## Summary

Add netctl integration for Rosenpass, enabling post-quantum key exchange on Arch Linux systems using netctl for WireGuard interface management.

## Changes

- **netctl/rosenpass-setup**: Shell script hook for netctl's `ExecUpPost`. Starts the Rosenpass daemon after the WireGuard interface comes up.
- **netctl/rosenpass-teardown**: Shell script hook for netctl's `ExecDownPre`. Gracefully stops the Rosenpass daemon before the interface goes down.
- **netctl/examples/**: Example netctl profiles (client with WGConfigFile, server with inline config) and Rosenpass TOML config.
- **config-examples/netctl-peer-{a,b}-config.toml**: Peer configuration examples.
- **tests/netctl/rosenpass.nix**: NixOS integration test covering the full lifecycle (key generation, profile start, PSK exchange, connectivity, teardown).

## Design

- Uses netctl's `ExecUpPost`/`ExecDownPre` hooks for lifecycle management
- PID file approach (`/run/rosenpass-$INTERFACE.pid`) for clean process tracking
- Follows the same directory structure pattern as existing integrations

## Testing

- NixOS integration test verifies end-to-end functionality
- Tested setup/teardown scripts for correct signal handling

Closes #80