### PR TITLE
feat: add systemd-networkd network manager support

### DIFF
--- a/config-examples/systemd-networkd-peer-a-config.toml
+++ b/config-examples/systemd-networkd-peer-a-config.toml
@@ -1,0 +1,24 @@
+# Rosenpass configuration example for use with systemd-networkd.
+#
+# Peer A (server) configuration — listens for incoming connections.
+#
+# Used with rosenpass-networkd@wg0.service.
+# Place at /etc/rosenpass/wg0.toml.
+
+public_key = "/etc/rosenpass/wg0/pqpk"
+secret_key = "/etc/rosenpass/wg0/pqsk"
+listen = ["0.0.0.0:9999"]
+verbosity = "Quiet"
+
+[[peers]]
+public_key = "/etc/rosenpass/wg0/peers/peer-b/pqpk"
+endpoint = "peer-b.example.com:9999"
+exchange_command = [
+    "wg",
+    "set",
+    "wg0",
+    "peer",
+    "<PEER_B_WG_PUBLIC_KEY>",
+    "preshared-key",
+    "/dev/stdin",
+]

--- a/config-examples/systemd-networkd-peer-b-config.toml
+++ b/config-examples/systemd-networkd-peer-b-config.toml
@@ -1,0 +1,23 @@
+# Rosenpass configuration example for use with systemd-networkd.
+#
+# Peer B (client) configuration — does not listen, connects to Peer A.
+#
+# Used with rosenpass-networkd@wg0.service.
+# Place at /etc/rosenpass/wg0.toml.
+
+public_key = "/etc/rosenpass/wg0/pqpk"
+secret_key = "/etc/rosenpass/wg0/pqsk"
+verbosity = "Quiet"
+
+[[peers]]
+public_key = "/etc/rosenpass/wg0/peers/peer-a/pqpk"
+endpoint = "peer-a.example.com:9999"
+exchange_command = [
+    "wg",
+    "set",
+    "wg0",
+    "peer",
+    "<PEER_A_WG_PUBLIC_KEY>",
+    "preshared-key",
+    "/dev/stdin",
+]

--- a/flake.nix
+++ b/flake.nix
@@ -217,6 +217,7 @@
               // {
                 systemd-rosenpass = pkgs.testers.runNixOSTest ./tests/systemd/rosenpass.nix;
                 systemd-rp = pkgs.testers.runNixOSTest ./tests/systemd/rp.nix;
+                systemd-networkd = pkgs.testers.runNixOSTest ./tests/systemd-networkd/rosenpass.nix;
                 formatting = treefmtEval.config.build.check self;
                 rosenpass-msrv-check =
                   let

--- a/pkgs/rosenpass.nix
+++ b/pkgs/rosenpass.nix
@@ -102,6 +102,7 @@ rustPlatform.buildRustPackage {
     install systemd/rosenpass@.service $out/lib/systemd/system
     install systemd/rp@.service $out/lib/systemd/system
     install systemd/rosenpass.target $out/lib/systemd/system
+    install systemd-networkd/rosenpass-networkd@.service $out/lib/systemd/system
   '';
 
   meta = {

--- a/systemd-networkd/README.md
+++ b/systemd-networkd/README.md
@@ -1,0 +1,84 @@
+# systemd-networkd integration for Rosenpass
+
+This directory contains systemd unit files and example configurations for
+integrating Rosenpass with [systemd-networkd](https://www.freedesktop.org/software/systemd/man/systemd-networkd.html),
+the network manager built into systemd.
+
+## Overview
+
+systemd-networkd manages WireGuard interfaces via `.netdev` and `.network` files
+in `/etc/systemd/network/`. Rosenpass is started after the WireGuard interface
+comes up, using a template service unit that binds to the network device:
+
+- **rosenpass-networkd@.service** — template unit that starts the Rosenpass key
+  exchange daemon for a given WireGuard interface. It binds to the device so
+  that stopping or removing the interface also stops Rosenpass.
+
+## Installation
+
+```bash
+# Install the systemd service unit
+install -Dm644 rosenpass-networkd@.service /usr/lib/systemd/system/rosenpass-networkd@.service
+
+# Install the shared rosenpass.target (if not already installed)
+install -Dm644 ../systemd/rosenpass.target /usr/lib/systemd/system/rosenpass.target
+
+# Reload systemd
+systemctl daemon-reload
+```
+
+## Usage
+
+1. Create your WireGuard `.netdev` and `.network` files in `/etc/systemd/network/`
+   (see `examples/wg0.netdev` and `examples/wg0.network`).
+
+2. Generate Rosenpass keys:
+   ```bash
+   rosenpass gen-keys \
+     --secret-key /etc/rosenpass/wg0/pqsk \
+     --public-key /etc/rosenpass/wg0/pqpk
+   ```
+
+3. Write a Rosenpass config (see `examples/rosenpass-wg0.toml`) and place it at
+   `/etc/rosenpass/wg0.toml` (the filename must match the interface name).
+
+4. Enable and start the service:
+   ```bash
+   systemctl enable --now rosenpass-networkd@wg0.service
+   ```
+
+   The service will automatically start when the `wg0` interface appears and
+   stop when it is removed.
+
+5. Restart networkd to bring up the interface:
+   ```bash
+   systemctl restart systemd-networkd
+   ```
+
+## How it works
+
+The `rosenpass-networkd@.service` unit uses `BindsTo=sys-subsystem-net-devices-%i.device`
+to tie its lifecycle to the WireGuard interface. When systemd-networkd creates
+the interface from the `.netdev` file, systemd detects the device and the
+rosenpass service can start. When the interface is removed, the service stops
+automatically.
+
+The service reads its configuration from `/etc/rosenpass/%i.toml` and loads
+the secret key via systemd's `LoadCredential=` mechanism from
+`/etc/rosenpass/%i/pqsk`.
+
+## Security hardening
+
+The service unit includes the same security hardening as the existing
+`rosenpass@.service` unit:
+- `DynamicUser=true` — runs as an ephemeral unprivileged user
+- Minimal capability set (only `CAP_NET_ADMIN`)
+- Filesystem, network, and syscall restrictions
+
+## Examples
+
+See the `examples/` subdirectory for:
+- `wg0.netdev` — client-side WireGuard interface definition
+- `wg0-server.netdev` — server-side WireGuard interface definition
+- `wg0.network` — network configuration (addresses and routes)
+- `rosenpass-wg0.toml` — Rosenpass daemon configuration

--- a/systemd-networkd/examples/rosenpass-wg0.toml
+++ b/systemd-networkd/examples/rosenpass-wg0.toml
@@ -1,0 +1,29 @@
+# Rosenpass configuration example for use with systemd-networkd.
+#
+# This config is used by the rosenpass-networkd@.service unit.
+# Place it at /etc/rosenpass/wg0.toml (matching the interface name).
+#
+# Key generation:
+#   rosenpass gen-keys --secret-key /etc/rosenpass/wg0/pqsk --public-key /etc/rosenpass/wg0/pqpk
+#
+# Exchange the public key (pqpk) with your peer out-of-band.
+
+public_key = "/etc/rosenpass/wg0/pqpk"
+secret_key = "/etc/rosenpass/wg0/pqsk"
+listen = ["0.0.0.0:9999"]
+verbosity = "Quiet"
+
+[[peers]]
+public_key = "/etc/rosenpass/wg0/peers/peer1/pqpk"
+endpoint = "peer1.example.com:9999"
+# The exchange_command is called each time a new PSK is derived.
+# It sets the WireGuard preshared key for the peer via wg(8).
+exchange_command = [
+    "wg",
+    "set",
+    "wg0",
+    "peer",
+    "<PEER_WG_PUBLIC_KEY>",
+    "preshared-key",
+    "/dev/stdin",
+]

--- a/systemd-networkd/examples/wg0-server.netdev
+++ b/systemd-networkd/examples/wg0-server.netdev
@@ -1,0 +1,24 @@
+# Example systemd-networkd .netdev file for a WireGuard server with Rosenpass.
+#
+# Place this file in /etc/systemd/network/ (e.g. /etc/systemd/network/90-wg0.netdev)
+#
+# Server configuration: listens on a fixed port and accepts connections
+# from multiple peers.
+#
+# See also:
+#   - systemd.netdev(5)
+#   - https://rosenpass.eu/docs
+
+[NetDev]
+Name=wg0
+Kind=wireguard
+Description=WireGuard server with Rosenpass post-quantum key exchange
+
+[WireGuard]
+ListenPort=51820
+PrivateKeyFile=/etc/wireguard/wg0-private-key
+
+[WireGuardPeer]
+PublicKey=<CLIENT_WG_PUBLIC_KEY>
+AllowedIPs=10.0.0.2/32,fd00::2/128
+PersistentKeepalive=25

--- a/systemd-networkd/examples/wg0.netdev
+++ b/systemd-networkd/examples/wg0.netdev
@@ -1,0 +1,25 @@
+# Example systemd-networkd .netdev file for a WireGuard interface with Rosenpass.
+#
+# Place this file in /etc/systemd/network/ (e.g. /etc/systemd/network/90-wg0.netdev)
+#
+# This defines the WireGuard interface. Rosenpass runs alongside to rotate
+# the preshared key for post-quantum security.
+#
+# See also:
+#   - systemd.netdev(5)
+#   - https://rosenpass.eu/docs
+
+[NetDev]
+Name=wg0
+Kind=wireguard
+Description=WireGuard tunnel with Rosenpass post-quantum key exchange
+
+[WireGuard]
+ListenPort=51820
+PrivateKeyFile=/etc/wireguard/wg0-private-key
+
+[WireGuardPeer]
+PublicKey=<PEER_WG_PUBLIC_KEY>
+AllowedIPs=10.0.0.2/32,fd00::2/128
+Endpoint=peer.example.com:51820
+PersistentKeepalive=25

--- a/systemd-networkd/examples/wg0.network
+++ b/systemd-networkd/examples/wg0.network
@@ -1,0 +1,21 @@
+# Example systemd-networkd .network file for a WireGuard interface with Rosenpass.
+#
+# Place this file in /etc/systemd/network/ (e.g. /etc/systemd/network/90-wg0.network)
+#
+# This assigns addresses and routes to the WireGuard interface defined in
+# the corresponding .netdev file.
+#
+# See also:
+#   - systemd.network(5)
+#   - https://rosenpass.eu/docs
+
+[Match]
+Name=wg0
+
+[Network]
+Address=10.0.0.1/24
+Address=fd00::1/64
+
+[Route]
+Destination=10.0.0.0/24
+Scope=link

--- a/systemd-networkd/rosenpass-networkd@.service
+++ b/systemd-networkd/rosenpass-networkd@.service
@@ -1,0 +1,47 @@
+[Unit]
+Description=Rosenpass post-quantum key exchange for %I (systemd-networkd)
+Documentation=man:rosenpass(1)
+Documentation=https://rosenpass.eu/docs
+
+After=network-online.target nss-lookup.target sys-subsystem-net-devices-%i.device
+Wants=network-online.target nss-lookup.target
+BindsTo=sys-subsystem-net-devices-%i.device
+PartOf=rosenpass.target
+
+[Service]
+ExecStart=rosenpass exchange-config /etc/rosenpass/%i.toml
+LoadCredential=pqsk:/etc/rosenpass/%i/pqsk
+
+AmbientCapabilities=CAP_NET_ADMIN
+CapabilityBoundingSet=~CAP_AUDIT_CONTROL CAP_AUDIT_READ CAP_AUDIT_WRITE CAP_BLOCK_SUSPEND CAP_BPF CAP_CHOWN CAP_FSETID CAP_SETFCAP CAP_DAC_OVERRIDE CAP_DAC_READ_SEARCH CAP_FOWNER CAP_IPC_OWNER CAP_IPC_LOCK CAP_KILL CAP_LEASE CAP_LINUX_IMMUTABLE CAP_MAC_ADMIN CAP_MAC_OVERRIDE CAP_MKNOD CAP_NET_BIND_SERVICE CAP_NET_BROADCAST CAP_NET_RAW CAP_SETUID CAP_SETGID CAP_SETPCAP CAP_SYS_ADMIN CAP_SYS_BOOT CAP_SYS_CHROOT CAP_SYSLOG CAP_SYS_MODULE CAP_SYS_NICE CAP_SYS_RESOURCE CAP_SYS_PACCT CAP_SYS_PTRACE CAP_SYS_RAWIO CAP_SYS_TIME CAP_SYS_TTY_CONFIG CAP_WAKE_ALARM
+DynamicUser=true
+LockPersonality=true
+MemoryDenyWriteExecute=true
+PrivateDevices=true
+ProcSubset=pid
+ProtectClock=true
+ProtectControlGroups=true
+ProtectHome=true
+ProtectHostname=true
+ProtectKernelLogs=true
+ProtectKernelModules=true
+ProtectKernelTunables=true
+ProtectProc=noaccess
+RestrictAddressFamilies=AF_NETLINK AF_INET AF_INET6
+RestrictNamespaces=true
+RestrictRealtime=true
+SystemCallArchitectures=native
+SystemCallFilter=~@clock
+SystemCallFilter=~@cpu-emulation
+SystemCallFilter=~@debug
+SystemCallFilter=~@module
+SystemCallFilter=~@mount
+SystemCallFilter=~@obsolete
+SystemCallFilter=~@privileged
+SystemCallFilter=~@raw-io
+SystemCallFilter=~@reboot
+SystemCallFilter=~@swap
+UMask=0077
+
+[Install]
+WantedBy=multi-user.target

--- a/tests/systemd-networkd/rosenpass.nix
+++ b/tests/systemd-networkd/rosenpass.nix
@@ -1,0 +1,236 @@
+# NixOS integration test for the systemd-networkd + Rosenpass integration.
+#
+# This test verifies that:
+# 1. A WireGuard interface can be brought up via systemd-networkd (.netdev/.network)
+# 2. The rosenpass-networkd@.service starts after the interface appears
+# 3. Preshared keys are exchanged between peers
+# 4. Network connectivity works over the WireGuard tunnel
+#
+# Run with: nix build .#checks.<system>.systemd-networkd
+{ pkgs, ... }:
+
+let
+  server = {
+    ip4 = "192.168.0.1";
+    ip6 = "fd00::1";
+    wg = {
+      ip4 = "10.23.42.1";
+      ip6 = "fc00::1";
+      public = "mQufmDFeQQuU/fIaB2hHgluhjjm1ypK4hJr1cW3WqAw=";
+      secret = "4N5Y1dldqrpsbaEiY8O0XBUGUFf8vkvtBtm8AoOX7Eo=";
+      listen = 10000;
+    };
+  };
+
+  client = {
+    ip4 = "192.168.0.2";
+    ip6 = "fd00::2";
+    wg = {
+      ip4 = "10.23.42.2";
+      ip6 = "fc00::2";
+      public = "Mb3GOlT7oS+F3JntVKiaD7SpHxLxNdtEmWz/9FMnRFU=";
+      secret = "uC5dfGMv7Oxf5UDfdPkj6rZiRZT2dRWp5x8IQxrNcUE=";
+    };
+  };
+
+  server_rp_config = {
+    listen = [ "0.0.0.0:9999" ];
+    public_key = "/etc/rosenpass/wg0/pqpk";
+    secret_key = "/etc/rosenpass/wg0/pqsk";
+    verbosity = "Verbose";
+    peers = [
+      {
+        public_key = "/etc/rosenpass/wg0/peers/client/pqpk";
+        exchange_command = [
+          "wg" "set" "wg0" "peer" client.wg.public "preshared-key" "/dev/stdin"
+        ];
+      }
+    ];
+  };
+
+  client_rp_config = {
+    listen = [ ];
+    public_key = "/etc/rosenpass/wg0/pqpk";
+    secret_key = "/etc/rosenpass/wg0/pqsk";
+    verbosity = "Verbose";
+    peers = [
+      {
+        public_key = "/etc/rosenpass/wg0/peers/server/pqpk";
+        endpoint = "${server.ip4}:9999";
+        exchange_command = [
+          "wg" "set" "wg0" "peer" server.wg.public "preshared-key" "/dev/stdin"
+        ];
+      }
+    ];
+  };
+
+  rpConfig = pkgs.runCommand "rp-config" { } ''
+    mkdir -pv $out
+    cp -v ${(pkgs.formats.toml { }).generate "wg0.toml" server_rp_config} $out/server
+    cp -v ${(pkgs.formats.toml { }).generate "wg0.toml" client_rp_config} $out/client
+  '';
+in
+{
+  name = "systemd-networkd-rosenpass";
+
+  nodes =
+    let
+      shared =
+        peer: remotePeer:
+        { pkgs, ... }:
+        {
+          environment.systemPackages = [ pkgs.wireguard-tools ];
+
+          # Use systemd-networkd for network management
+          networking.useNetworkd = true;
+          systemd.network.enable = true;
+
+          # Disable default NixOS networking for the WireGuard interface
+          # (we manage it via systemd-networkd .netdev/.network files)
+
+          # Physical network interface
+          networking.interfaces.eth1 = {
+            ipv4.addresses = [
+              {
+                address = peer.ip4;
+                prefixLength = 24;
+              }
+            ];
+            ipv6.addresses = [
+              {
+                address = peer.ip6;
+                prefixLength = 64;
+              }
+            ];
+          };
+
+          # WireGuard .netdev configuration via systemd-networkd
+          systemd.network.netdevs."90-wg0" = {
+            netdevConfig = {
+              Name = "wg0";
+              Kind = "wireguard";
+              Description = "WireGuard tunnel with Rosenpass";
+            };
+            wireguardConfig = {
+              PrivateKeyFile = "/etc/wireguard/wg0-private-key";
+            } // (if peer.wg ? listen then {
+              ListenPort = peer.wg.listen;
+            } else { });
+            wireguardPeers = [
+              {
+                wireguardPeerConfig = {
+                  PublicKey = remotePeer.wg.public;
+                  AllowedIPs = [ "${remotePeer.wg.ip4}/32" "${remotePeer.wg.ip6}/128" ];
+                  PersistentKeepalive = 25;
+                } // (if remotePeer ? ip4 && remotePeer.wg ? listen then {
+                  Endpoint = "${remotePeer.ip4}:${toString remotePeer.wg.listen}";
+                } else { });
+              }
+            ];
+          };
+
+          # WireGuard .network configuration
+          systemd.network.networks."90-wg0" = {
+            matchConfig.Name = "wg0";
+            address = [
+              "${peer.wg.ip4}/24"
+              "${peer.wg.ip6}/64"
+            ];
+            networkConfig = {
+              IPForward = true;
+            };
+          };
+
+          # Install the rosenpass-networkd@ service unit
+          systemd.packages = [
+            (pkgs.runCommand "rosenpass-networkd" { } ''
+              mkdir -p $out/lib/systemd/system
+              < ${pkgs.rosenpass}/lib/systemd/system/rosenpass.target > $out/lib/systemd/system/rosenpass.target
+              < ${pkgs.rosenpass.src}/systemd-networkd/rosenpass-networkd@.service \
+              sed 's@^ExecStart=rosenpass @ExecStart='"${pkgs.rosenpass}"'/bin/rosenpass @' |
+              sed 's@^\(\[Service]\)$@\1\nEnvironment=PATH=${pkgs.wireguard-tools}/bin@' \
+              > $out/lib/systemd/system/rosenpass-networkd@.service
+            '')
+          ];
+
+          # Deploy WireGuard private key
+          environment.etc."wireguard/wg0-private-key" = {
+            text = peer.wg.secret;
+            mode = "0600";
+          };
+        };
+    in
+    {
+      server = {
+        imports = [ (shared server client) ];
+        networking.firewall.allowedUDPPorts = [
+          9999
+          server.wg.listen
+        ];
+      };
+      client = {
+        imports = [ (shared client server) ];
+      };
+    };
+
+  testScript =
+    { ... }:
+    ''
+      from os import system
+      rosenpass = "${pkgs.rosenpass}/bin/rosenpass"
+
+      start_all()
+
+      for machine in [server, client]:
+        machine.wait_for_unit("multi-user.target")
+        machine.wait_for_unit("systemd-networkd.service")
+
+      with subtest("Generate keys and deploy configs"):
+        for name, machine, remote in [
+          ("server", server, client),
+          ("client", client, server),
+        ]:
+          # Generate Rosenpass keys
+          system(f"{rosenpass} gen-keys --public-key {name}-pqpk --secret-key {name}-pqsk")
+
+          # Deploy keys
+          machine.copy_from_host(f"{name}-pqsk", "/etc/rosenpass/wg0/pqsk")
+          machine.copy_from_host(f"{name}-pqpk", "/etc/rosenpass/wg0/pqpk")
+          remote.copy_from_host(f"{name}-pqpk", f"/etc/rosenpass/wg0/peers/{name}/pqpk")
+
+          # Deploy Rosenpass config
+          machine.copy_from_host(f"${rpConfig}/{name}", "/etc/rosenpass/wg0.toml")
+
+      with subtest("Verify WireGuard interface is up via systemd-networkd"):
+        for machine in [server, client]:
+          machine.wait_until_succeeds("ip link show wg0", timeout=10)
+          machine.wait_until_succeeds("wg show wg0", timeout=10)
+
+      with subtest("Start rosenpass-networkd service"):
+        for machine in [server, client]:
+          machine.succeed("systemctl start rosenpass-networkd@wg0.service")
+
+        for machine in [server, client]:
+          machine.wait_for_unit("rosenpass-networkd@wg0.service")
+
+      with subtest("Verify preshared keys are exchanged"):
+        server.wait_until_succeeds("wg show wg0 preshared-keys | grep --invert-match none", timeout=10)
+        client.wait_until_succeeds("wg show wg0 preshared-keys | grep --invert-match none", timeout=10)
+
+        def get_psk(m):
+          psk = m.succeed("wg show wg0 preshared-keys | awk '{print $2}'")
+          psk = psk.strip()
+          assert len(psk.split()) == 1, "Only one PSK expected"
+          return psk
+
+        assert get_psk(client) == get_psk(server), "Preshared keys must match"
+
+      with subtest("Verify network connectivity over WireGuard tunnel"):
+        client.succeed("ping -c5 ${server.wg.ip4}")
+        server.succeed("ping -c5 ${client.wg.ip6}")
+
+      with subtest("Service stops when interface is removed"):
+        client.succeed("ip link del wg0")
+        client.wait_until_fails("systemctl is-active rosenpass-networkd@wg0.service", timeout=10)
+    '';
+}


### PR DESCRIPTION
## Summary

Add systemd-networkd integration for Rosenpass, enabling post-quantum key exchange on systems using systemd-networkd for WireGuard interface management.

## Changes

- **systemd-networkd/rosenpass-networkd@.service**: Template systemd unit bound to the network device. Automatically starts/stops Rosenpass when the WireGuard interface is created/removed by systemd-networkd.
- **systemd-networkd/examples/**: Example .netdev, .network files and Rosenpass TOML config.
- **config-examples/systemd-networkd-peer-{a,b}-config.toml**: Peer configuration examples.
- **tests/systemd-networkd/rosenpass.nix**: NixOS integration test covering interface creation, service startup, PSK exchange, connectivity, and automatic cleanup on interface removal.
- **flake.nix**: Added systemd-networkd check entry.
- **pkgs/rosenpass.nix**: Install the new service unit.

## Design

- Uses `BindsTo=sys-subsystem-net-devices-%i.device` to tie service lifecycle to the network interface
- Same security hardening as existing systemd service units
- Native systemd-networkd configuration via .netdev/.network files

## Testing

- NixOS integration test verifies end-to-end functionality

Closes #81