### PR TITLE
Fix `rosenpass` tool link in `readme.md`

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -8,7 +8,7 @@
 This repository contains
 
 1. A description of the [Rosenpass protocol](https://github.com/rosenpass/rosenpass/raw/papers-pdf/whitepaper.pdf)
-2. The reference implementation of the protocol – the [rosenpass tool](./src)
+2. The reference implementation of the protocol – the [rosenpass tool](./rosenpass)
 3. A frontend integrating Rosenpass and WireGuard to create a vpn – the [rp frontend](./rp)
 4. [Security analysis](./analysis) of the protocol using proverif
 


### PR DESCRIPTION
The README link for the `rosenpass` tool presently points to the (now missing) `src/` directory which has been replaced with `rosenpass/`; this commit simply updates the link to this new path.