### PR TITLE
CI: rework cargo audit

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -16,7 +16,6 @@ on:
   schedule:
     - cron: "0 3 * * *"
 
-
 jobs:
   cargo-deny:
     runs-on: ubicloud-standard-2-ubuntu-2404

--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -1,0 +1,28 @@
+# Audits the code regularly e.g. for bad dependencies and security advisories
+# This Workflow is different from `qc.yml`:
+# - runs regularly
+# - does not work on the code itself but on its depdencies
+
+name: Audit
+
+on:
+  pull_request:
+  push:
+    paths:
+      - "**/Cargo.toml"
+      - "**/Cargo.lock"
+      - ".github/workflows/audit.yml"
+    # branches: [main]
+  schedule:
+    - cron: "0 3 * * *"
+
+
+jobs:
+  cargo-deny:
+    runs-on: ubicloud-standard-2-ubuntu-2404
+    steps:
+      - uses: actions/checkout@v6
+      - uses: EmbarkStudios/cargo-deny-action@v2
+        with:
+          command: check
+          arguments: --all-features

--- a/.github/workflows/qc.yaml
+++ b/.github/workflows/qc.yaml
@@ -64,14 +64,6 @@ jobs:
       - name: Check rp.1
         run: doc/check.sh doc/rp.1
 
-  cargo-audit:
-    runs-on: ubicloud-standard-2-ubuntu-2404
-    steps:
-      - uses: actions/checkout@v5
-      - uses: actions-rs/audit-check@v1
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-
   cargo-clippy:
     runs-on: ubicloud-standard-2-ubuntu-2404
     steps:

--- a/.github/workflows/supply-chain.yml
+++ b/.github/workflows/supply-chain.yml
@@ -9,12 +9,6 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  cargo-deny:
-    name: Deny dependencies with vulnerabilities or incompatible licenses
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v5
-      - uses: EmbarkStudios/cargo-deny-action@v2
   cargo-supply-chain:
     name: Supply Chain Report
     runs-on: ubuntu-latest

--- a/flake.nix
+++ b/flake.nix
@@ -154,6 +154,7 @@
               inputsFrom = [ pkgs.rosenpass ];
               nativeBuildInputs = with pkgs; [
                 cargo-audit
+                cargo-deny
                 cargo-msrv
                 cargo-release
                 cargo-vet


### PR DESCRIPTION
- use maintained workflow (https://github.com/actions-rs/audit-check is no longer maintained)
- use `cargo-deny` instead of `cargo-audit`
- add `cargo-deny` to Nix dev shell (`fullEnv`)
- removes old `cargo-deny` job with suboptimal settings (e.g. trigger conditions)

This PR does *not* close #779.