### PR TITLE
Upgrade `allocator-api2`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -47,15 +47,15 @@ dependencies = [
 
 [[package]]
 name = "allocator-api2"
-version = "0.2.18"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c6cb57a04249c6480766f7f7cef5467412af1490f8d1e243141daddada3264f"
+checksum = "c583acf993cf4245c4acb0a2cc2ab1f9cc097de73411bb6d3647ff6af2b1013d"
 
 [[package]]
 name = "allocator-api2-tests"
-version = "0.2.15"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f3efb93c1e2a22a828c2b16f7276bb7ae198bbf60c78d297a6f3b373f7d22e6"
+checksum = "a2277ca94b6a6fec01ae765ad46fd99a117e8ac92e10c191e2b07b4ce36c01e5"
 dependencies = [
  "allocator-api2",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,7 @@ paste = "1.0.15"
 env_logger = "0.11.10"
 toml = "1.1.2"
 static_assertions = "1.1.0"
-allocator-api2 = "0.2.14"
+allocator-api2 = "0.3"
 memsec = { git = "https://github.com/rosenpass/memsec.git", rev = "aceb9baee8aec6844125bd6612f92e9a281373df", features = [
   "alloc_ext",
 ] }
@@ -87,7 +87,7 @@ stacker = "0.1.21"
 libfuzzer-sys = "0.4"
 test_bin = "0.6"
 criterion = "0.8.2"
-allocator-api2-tests = "0.2.15"
+allocator-api2-tests = "0.3"
 procspawn = { version = "1.0.1", features = ["test-support"] }
 serde_json = { version = "1.0.140" }
 

--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -45,8 +45,12 @@ criteria = "safe-to-deploy"
 version = "1.1.3"
 criteria = "safe-to-deploy"
 
+[[exemptions.allocator-api2]]
+version = "0.3.1"
+criteria = "safe-to-deploy"
+
 [[exemptions.allocator-api2-tests]]
-version = "0.2.15"
+version = "0.3.1"
 criteria = "safe-to-run"
 
 [[exemptions.anstream]]

--- a/supply-chain/imports.lock
+++ b/supply-chain/imports.lock
@@ -1720,12 +1720,6 @@ criteria = "safe-to-deploy"
 delta = "2.0.0 -> 2.0.1"
 aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
 
-[[audits.mozilla.audits.allocator-api2]]
-who = "Nicolas Silva <nical@fastmail.com>"
-criteria = "safe-to-deploy"
-version = "0.2.18"
-aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
-
 [[audits.mozilla.audits.block-buffer]]
 who = "Mike Hommey <mh+mozilla@glandium.org>"
 criteria = "safe-to-deploy"


### PR DESCRIPTION
The newest version for `allocator-api2` is `0.4` but its corresponding `allocator-api2-tests` crate is still on `0.3`. They are incompatible, so I only upgraded to `0.3`.