### PR TITLE
fix: correct falied->failed typo in janitor error message

### DIFF
--- a/util/src/tokio/janitor.rs
+++ b/util/src/tokio/janitor.rs
@@ -475,7 +475,7 @@ impl<T, E> EnsureJanitorResult<T, E> {
             ),
             (Some(Err(jerr)), Err(cerr)) => panic!(
                 "Both the calee and the janitor or \
-                some of its deamons falied in enter_janitor()/ensure_janitor():\n\
+                some of its deamons failed in enter_janitor()/ensure_janitor():\n\
                 \n\
                 Janitor/Daemon error: {jerr:?}
                 \n\


### PR DESCRIPTION
Corrects the typo `falied` → `failed` in the janitor error message (util/src/tokio/janitor.rs).

Single-character typo fix in panic message. 1 file changed, 1 line.