### PR TITLE
Group non-critical dependabot updates into weekly PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,11 +3,21 @@ updates:
   - package-ecosystem: "cargo"
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: "weekly"
+    groups:
+      non-critical:
+        update-types:
+          - "minor"
+          - "patch"
     # open-pull-requests-limit: 0 # temporarily disable dependabot
 
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: "weekly"
+    groups:
+      non-critical:
+        update-types:
+          - "minor"
+          - "patch"
     # open-pull-requests-limit: 0 # temporarily disable dependabot


### PR DESCRIPTION
Fixes #896.

Both the cargo and github-actions dependabot configs were on a daily schedule with no grouping, so every minor or patch bump gets its own PR (e.g. #893, #895). That's a lot of near-identical noise for updates that don't need individual review.

This switches both ecosystems to a weekly schedule and adds a `non-critical` group for minor and patch updates so they get bundled into one PR per week. Major version bumps aren't in the group, so they still show up as their own PR and get separate attention.

Tested by loading the updated `.github/dependabot.yml` with a YAML parser to confirm it's still valid.