### PR TITLE
fix(nix): provide man for manual page tests

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -145,6 +145,7 @@
                 rustfmt
                 prettier
                 nushell # for the .ci/gen-workflow-files.nu script
+                man-db # renders generated manual pages in Rust integration tests
                 proverif-patched
               ];
             };
@@ -161,6 +162,7 @@
                 rustfmt
                 prettier
                 nushell # for the .ci/gen-workflow-files.nu script
+                man-db # renders generated manual pages in Rust integration tests
                 proverif-patched
                 pkgs.cargo-llvm-cov
                 pkgs.grcov

--- a/pkgs/rosenpass.nix
+++ b/pkgs/rosenpass.nix
@@ -3,6 +3,7 @@
   stdenv,
   rustPlatform,
   cmake,
+  man-db,
   mandoc,
   removeReferencesTo,
   bash,
@@ -88,6 +89,7 @@ rustPlatform.buildRustPackage {
   nativeBuildInputs = [
     stdenv.cc
     cmake # for oqs build in the oqs-sys crate
+    man-db # renders generated manual pages in integration tests
     mandoc # for the built-in manual
     removeReferencesTo
     rustPlatform.bindgenHook # for C-bindings in the crypto libs


### PR DESCRIPTION
## Summary

- add `man-db` to the default and full Nix development shells
- include `man-db` in the Rosenpass package test environment, where generated-manpage integration tests execute `man`

Fixes #840.

## Verification

- `git diff --check`
- `cargo metadata --no-deps --format-version=1`
- verified the Nix dependency declarations place `man-db` in both development shells and `nativeBuildInputs` for package tests

`RUST_MIN_STACK=8388608 cargo test -p rosenpass --test main-fn-generates-manpages --all-features` could not complete on this worker because the host lacks `libclang` (required by `oqs-sys` bindgen); the project Nix package already provides `rustPlatform.bindgenHook`, and Nix is unavailable on this worker for the corresponding Nix evaluation.