### PR TITLE
do not force KVM hardware acceleration for Nix checks

### DIFF
--- a/tests/integration/rpsc-test.nix
+++ b/tests/integration/rpsc-test.nix
@@ -123,6 +123,8 @@ let
 in
 {
   name = "rosenpass with key exchangers";
+  requiredFeatures.kvm = false; # These two lines allow us to run the check
+  qemu.forceAccel = false; # on a machine without KVM hardware acceleration.
   defaults = {
     imports = [
       ./rp-key-exchange.nix


### PR DESCRIPTION
The issue was found by @Fabian-Wilmers and I think it should be fixed: `nix flake check` does not work in a VM which has KVM hardware acceleration disabled. We should default to the emulation backend of qemu then.