### PR TITLE
docs: fix typos in docker usage, supply-chain CI, tests and whitepaper

### DIFF
--- a/docker/USAGE.md
+++ b/docker/USAGE.md
@@ -121,7 +121,7 @@ cp -r workdir-server/server.rosenpass-public workdir-client/server.rosenpass-pub
 ```
 
 Start the server container.
-Note that the `NET_ADMIN` capability is neccessary, the rp command will create and manage wireguard interfaces.
+Note that the `NET_ADMIN` capability is necessary, the rp command will create and manage wireguard interfaces.
 Also make sure the `wireguard` kernel module is loaded by the host. (`lsmod | grep wireguard`)
 
 ```bash

--- a/papers/whitepaper.md
+++ b/papers/whitepaper.md
@@ -607,7 +607,7 @@ cookie_value = lhash("cookie-value", cookie_secret, initiator_host_info)[0..16]
 cookie_encrypted = XAEAD(lhash("cookie-key", spkm), nonce, cookie_value, mac_peer)
 ```
 
-where `cookie_secret` is a secret variable that changes every two minutes to a random value. Moreover, `lhash` is always instantiated with SHAKE256 when computing `cookie_value` for compatability reasons.  `initiator_host_info` is used to identify the initiator host, and is implementation-specific for the client. This paramaters used to identify the host must be carefully chosen to ensure there is a unique mapping, especially when using IPv4 and IPv6 addresses to identify the host (such as taking care of IPv6 link-local addresses). `cookie_value` is a truncated 16 byte value from the above hash operation. `mac_peer` is the `mac` field of the peer's handshake message to which message is the reply.
+where `cookie_secret` is a secret variable that changes every two minutes to a random value. Moreover, `lhash` is always instantiated with SHAKE256 when computing `cookie_value` for compatibility reasons.  `initiator_host_info` is used to identify the initiator host, and is implementation-specific for the client. This paramaters used to identify the host must be carefully chosen to ensure there is a unique mapping, especially when using IPv4 and IPv6 addresses to identify the host (such as taking care of IPv6 link-local addresses). `cookie_value` is a truncated 16 byte value from the above hash operation. `mac_peer` is the `mac` field of the peer's handshake message to which message is the reply.
 
 #### Envelope `mac` Field {#envelope-mac-field}
 
@@ -643,7 +643,7 @@ However, when the responder is under load, it may reject InitHello messages with
 
 This whitepaper does not mandate any specific mechanism to detect responder contention (also mentioned as the under load condition) that would trigger use of the cookie mechanism.
 
-For the reference implemenation, Rosenpass has derived inspiration from the Linux implementation of WireGuard.  This implementation suggests that the receiver keep track of the number of messages it is processing at a given time.
+For the reference implementation, Rosenpass has derived inspiration from the Linux implementation of WireGuard.  This implementation suggests that the receiver keep track of the number of messages it is processing at a given time.
 
 On receiving an incoming message, if the length of the message queue to be processed exceeds a threshold `MAX_QUEUED_INCOMING_HANDSHAKES_THRESHOLD`, the client is considered under load and its state is stored as under load. In addition, the timestamp of this instant when the client was last under load is stored. When recieving subsequent messages, if the client is still in an under load state, the client will check if the time elapsed since the client was last under load has exceeded `LAST_UNDER_LOAD_WINDOW` seconds. If this is the case, the client will update its state to normal operation, and process the message in a normal fashion.
 

--- a/supply-chain-CI.md
+++ b/supply-chain-CI.md
@@ -1,7 +1,7 @@
 # Continuous Integration for supply chain protection
 
 This repository's CI uses non-standard mechanisms to harmonize the usage of `dependabot` together with [`cargo vet`](https://mozilla.github.io/cargo-vet/). Since cargo-vet audits for new versions of crates are rarely immediately available once dependabots bumps the version,
-the exemptions for `cargo vet` have to be regenerated for each push request opened by dependabot. To make this work, some setup is neccessary to setup the CI. The required steps are as follows:
+the exemptions for `cargo vet` have to be regenerated for each push request opened by dependabot. To make this work, some setup is necessary to setup the CI. The required steps are as follows:
 
 1. Create a mew user on github. For the purpose of these instructions, we will assume that its mail address is `ci@example.com` and that its username is `ci-bot`. Protect this user account as you would any other user account that you intend to gve write permissions to. For example, setup MFA or protect the email address of the user. Make sure to verify your e-mail.
 2. Add `ci-bot` as a member of your organizaton with write access to the repository.
@@ -13,7 +13,7 @@ the exemptions for `cargo vet` have to be regenerated for each push request open
 
 ## What this does
 
-For the `cargo vet` check in the CI for dependabot, the `cargo vet`-exemptions have to automatically be regenerated, because otherwise this CI job will always fail for dependabot PRs. After the exemptions have been regenerated, they need to be commited and pushed to the PR. This invalidates the CI run that pushed the commit so that it does not show up in the PR anymore but does not trigger a new CI run. This is a [protection by Github](https://docs.github.com/en/actions/security-for-github-actions/security-guides/automatic-token-authentication#using-the-github_token-in-a-workflow) to prevent infinite loops. However, in this case it prevents us from having a proper CI run for dependabot PRs. The solution to this is to execute `push` operation with a personal access token.
+For the `cargo vet` check in the CI for dependabot, the `cargo vet`-exemptions have to automatically be regenerated, because otherwise this CI job will always fail for dependabot PRs. After the exemptions have been regenerated, they need to be committed and pushed to the PR. This invalidates the CI run that pushed the commit so that it does not show up in the PR anymore but does not trigger a new CI run. This is a [protection by Github](https://docs.github.com/en/actions/security-for-github-actions/security-guides/automatic-token-authentication#using-the-github_token-in-a-workflow) to prevent infinite loops. However, in this case it prevents us from having a proper CI run for dependabot PRs. The solution to this is to execute `push` operation with a personal access token.
 
 ## Preventing infinite loops
 

--- a/tests/integration/README.md
+++ b/tests/integration/README.md
@@ -18,7 +18,7 @@ All integration tests install rosenpass on virtual machines, run the key exchang
 
 ## Testing specific versions
 
-You can specify specific versions of rosenpass to test compatability. The proper way to do so is by overriding the respective inputs to the nix flake. As an example, say you want to test the compatability of your local version of rosenpass with the branch `new-feature` on github. You can achieve this by running the following command:
+You can specify specific versions of rosenpass to test compatibility. The proper way to do so is by overriding the respective inputs to the nix flake. As an example, say you want to test the compatibility of your local version of rosenpass with the branch `new-feature` on github. You can achieve this by running the following command:
 
 ```
 nix flake check  --override-input rosenpass-old ../../ --override-input rosenpass-new github:rosenpass/rosenpass/new-feature


### PR DESCRIPTION
Typo fixes across four docs:

| File | Fix |
|---|---|
| `docker/USAGE.md:124` | `neccessary` → `necessary` |
| `supply-chain-CI.md:4` | `neccessary` → `necessary` |
| `supply-chain-CI.md:16` | `commited` → `committed` |
| `tests/integration/README.md:21` | `compatability` → `compatibility` |
| `papers/whitepaper.md:610` | `compatability` → `compatibility` |
| `papers/whitepaper.md:646` | `implemenation` → `implementation` |

### One I deliberately left alone

`papers/whitepaper.md:158` is:

```markdown
## Endianness {#endianess}
```

The heading text is spelled correctly; the misspelling is in the explicit **anchor id**. Changing `{#endianess}` would silently break any existing link to `…#endianess` — from the published paper, citations, or other docs — so I left it as-is. If you'd like it corrected, it probably wants a redirect or a retained alias rather than a bare rename, which is your call.
