### PR TITLE
upgrade memsec from own 0.6 fork to upstream 0.7

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1393,8 +1393,9 @@ dependencies = [
 
 [[package]]
 name = "memsec"
-version = "0.6.3"
-source = "git+https://github.com/rosenpass/memsec.git?rev=aceb9baee8aec6844125bd6612f92e9a281373df#aceb9baee8aec6844125bd6612f92e9a281373df"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c797b9d6bb23aab2fc369c65f871be49214f5c759af65bde26ffaaa2b646b492"
 dependencies = [
  "getrandom 0.2.17",
  "libc",

--- a/pkgs/rosenpass.nix
+++ b/pkgs/rosenpass.nix
@@ -85,7 +85,6 @@ rustPlatform.buildRustPackage {
   cargoLock = {
     lockFile = src + "/Cargo.lock";
     outputHashes = {
-      "memsec-0.6.3" = "sha256-4ri+IEqLd77cLcul3lZrmpDKj4cwuYJ8oPRAiQNGeLw=";
       "uds-0.4.2" = "sha256-qlxr/iJt2AV4WryePIvqm/8/MK/iqtzegztNliR93W8=";
       "libcrux-macros-0.0.3" = "sha256-Tb5uRirwhRhoFEK8uu1LvXl89h++40pxzZ+7kXe8RAI=";
     };

--- a/rosenpass/Cargo.toml
+++ b/rosenpass/Cargo.toml
@@ -191,9 +191,7 @@ chacha20poly1305 = { version = "0.10.1", default-features = false, features = [
 blake2 = "0.10.6"
 shake = "0.1.0"
 # dependencies of `rosenpass-secret-memory`, now `rosenpass::internal::secret_memory`
-memsec = { git = "https://github.com/rosenpass/memsec.git", rev = "aceb9baee8aec6844125bd6612f92e9a281373df", features = [
-  "alloc_ext",
-] }
+memsec = { version = "0.7.0", features = ["alloc_ext"] }
 allocator-api2 = "0.3"
 # dependencies of `rosenpass-wireguard-broker`, now moved to `rosenpass::internal::wireguard_broker`
 wireguard-uapi = { version = "3.0.0", features = ["xplatform"] }

--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -474,7 +474,7 @@ version = "0.9.1"
 criteria = "safe-to-deploy"
 
 [[exemptions.memsec]]
-version = "0.6.3@git:aceb9baee8aec6844125bd6612f92e9a281373df"
+version = "0.7.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.minimal-lexical]]


### PR DESCRIPTION
We are back to using the upstream `memsec` for now. Also, I archived the [fork](https://github.com/rosenpass/memsec).