### PR TITLE
fix `<` operator to `<=` operator in cookies doc test

### DIFF
--- a/rosenpass/Cargo.toml
+++ b/rosenpass/Cargo.toml
@@ -86,6 +86,10 @@ name = "config_Rosenpass_validate"
 required-features = ["expose_internal_modules"]
 
 [[test]]
+name = "protocol_cookies_CookieStore"
+required-features = ["expose_internal_modules"]
+
+[[test]]
 name = "gen-ipc-msg-types"
 required-features = [
   "experiment_api",

--- a/rosenpass/src/protocol/cookies.rs
+++ b/rosenpass/src/protocol/cookies.rs
@@ -50,8 +50,8 @@ use super::{constants::COOKIE_SECRET_LEN, timing::Timing};
 /// let time_before_call = timebase.now();
 /// store.update(&timebase, fixed_secret.secret());
 /// assert_eq!(store.value.secret(), fixed_secret.secret());
-/// assert!(store.created_at < timebase.now());
-/// assert!(store.created_at > time_before_call);
+/// assert!(store.created_at <= timebase.now());
+/// assert!(store.created_at >= time_before_call);
 ///
 /// // Same as new()
 /// store.erase();
@@ -62,8 +62,8 @@ use super::{constants::COOKIE_SECRET_LEN, timing::Timing};
 /// let time_before_call = timebase.now();
 /// store.randomize(&timebase);
 /// assert_ne!(store.value.secret(), secret_before_call.secret());
-/// assert!(store.created_at < timebase.now());
-/// assert!(store.created_at > time_before_call);
+/// assert!(store.created_at <= timebase.now());
+/// assert!(store.created_at >= time_before_call);
 /// ```
 #[derive(Debug)]
 pub struct CookieStore<const N: usize> {

--- a/rosenpass/src/protocol/cookies.rs
+++ b/rosenpass/src/protocol/cookies.rs
@@ -34,36 +34,8 @@ use super::{constants::COOKIE_SECRET_LEN, timing::Timing};
 ///
 /// # Examples
 ///
-/// ```
-/// use rosenpass::internal::util::time::Timebase;
-/// use rosenpass::protocol::{timing::BCE, basic_types::SymKey, cookies::CookieStore};
-///
-/// rosenpass::internal::secret_memory::secret_policy_try_use_memfd_secrets();
-///
-/// let fixed_secret = SymKey::random();
-/// let timebase = Timebase::default();
-///
-/// let mut store = CookieStore::<32>::new();
-/// assert_ne!(store.value.secret(), SymKey::zero().secret());
-/// assert_eq!(store.created_at, BCE);
-///
-/// let time_before_call = timebase.now();
-/// store.update(&timebase, fixed_secret.secret());
-/// assert_eq!(store.value.secret(), fixed_secret.secret());
-/// assert!(store.created_at <= timebase.now());
-/// assert!(store.created_at >= time_before_call);
-///
-/// // Same as new()
-/// store.erase();
-/// assert_ne!(store.value.secret(), SymKey::zero().secret());
-/// assert_eq!(store.created_at, BCE);
-///
-/// let secret_before_call = store.value.clone();
-/// let time_before_call = timebase.now();
-/// store.randomize(&timebase);
-/// assert_ne!(store.value.secret(), secret_before_call.secret());
-/// assert!(store.created_at <= timebase.now());
-/// assert!(store.created_at >= time_before_call);
+/// ```ignore
+#[doc=include_str!("../../tests/protocol_cookies_CookieStore.rs")]
 /// ```
 #[derive(Debug)]
 pub struct CookieStore<const N: usize> {

--- a/rosenpass/tests/protocol_cookies_CookieStore.rs
+++ b/rosenpass/tests/protocol_cookies_CookieStore.rs
@@ -1,0 +1,32 @@
+#[test]
+fn cookie_store_demo() {
+    use rosenpass::internal::util::time::Timebase;
+    use rosenpass::protocol::{basic_types::SymKey, cookies::CookieStore, timing::BCE};
+
+    rosenpass::internal::secret_memory::secret_policy_try_use_memfd_secrets();
+
+    let fixed_secret = SymKey::random();
+    let timebase = Timebase::default();
+
+    let mut store = CookieStore::<32>::new();
+    assert_ne!(store.value.secret(), SymKey::zero().secret());
+    assert_eq!(store.created_at, BCE);
+
+    let time_before_call = timebase.now();
+    store.update(&timebase, fixed_secret.secret());
+    assert_eq!(store.value.secret(), fixed_secret.secret());
+    assert!(store.created_at < timebase.now());
+    assert!(store.created_at > time_before_call);
+
+    // Same as new()
+    store.erase();
+    assert_ne!(store.value.secret(), SymKey::zero().secret());
+    assert_eq!(store.created_at, BCE);
+
+    let secret_before_call = store.value.clone();
+    let time_before_call = timebase.now();
+    store.randomize(&timebase);
+    assert_ne!(store.value.secret(), secret_before_call.secret());
+    assert!(store.created_at < timebase.now());
+    assert!(store.created_at > time_before_call);
+}


### PR DESCRIPTION
The previous assertion statement could lead to rare test failures, e.g. in https://github.com/rosenpass/rosenpass/actions/runs/33050859863/job/98445824160

The test was introduced in 46e855b266a45113207a732f622c191bc46f66d5.