### PR TITLE
formatter: ignore `CHANGELOG.md`

### DIFF
--- a/treefmt.nix
+++ b/treefmt.nix
@@ -16,7 +16,10 @@
       "*.yaml"
       "*.yml"
     ];
-    excludes = [ "supply-chain/*" ];
+    excludes = [
+      "supply-chain/*"
+      "CHANGELOG.md"
+    ];
   };
   programs.taplo = {
     enable = true;


### PR DESCRIPTION
The auto-formatted `CHANGELOG.md` is actually much less readable then the manually formatted one.

- closes #1035 