### PR TITLE
Fix/957 clippy warnings

### DIFF
--- a/rosenpass/benches/primitives.rs
+++ b/rosenpass/benches/primitives.rs
@@ -192,7 +192,7 @@ mod aead {
 
             bench.iter(|| {
                 scheme
-                    .decrypt(&mut ptxt_out, &key, &nonce, &ad, &mut ctxt)
+                    .decrypt(&mut ptxt_out, &key, &nonce, &ad, &ctxt)
                     .unwrap()
             })
         });
@@ -219,7 +219,7 @@ mod aead {
 
             bench.iter(|| {
                 scheme
-                    .decrypt(&mut ptxt_out, &key, &nonce, &ad, &mut ctxt)
+                    .decrypt(&mut ptxt_out, &key, &nonce, &ad, &ctxt)
                     .unwrap()
             })
         });
@@ -245,7 +245,7 @@ mod aead {
 
             bench.iter(|| {
                 scheme
-                    .decrypt(&mut ptxt_out, &key, &nonce, &ad, &mut ctxt)
+                    .decrypt(&mut ptxt_out, &key, &nonce, &ad, &ctxt)
                     .unwrap()
             })
         });

--- a/rosenpass/benches/trace_handshake.rs
+++ b/rosenpass/benches/trace_handshake.rs
@@ -145,7 +145,7 @@ fn main() {
         .map(|(label, agg_stat)| JsonAggregateStat {
             protocol_version: "V03",
             label,
-            agg_stat: &agg_stat,
+            agg_stat,
         });
 
     // Write results as JSON

--- a/rosenpass/src/api/boilerplate/payload.rs
+++ b/rosenpass/src/api/boilerplate/payload.rs
@@ -11,7 +11,7 @@ pub const MAX_RESPONSE_LEN: usize = 2500; // TODO fix this
 pub const MAX_REQUEST_FDS: usize = 2;
 
 /// Message envelope for API messages
-#[repr(packed)]
+#[repr(Rust, packed)]
 #[derive(Debug, Copy, Clone, Hash, IntoBytes, FromBytes, KnownLayout, Immutable, PartialEq, Eq)]
 pub struct Envelope<M: IntoBytes + FromBytes> {
     /// Which message this is
@@ -26,7 +26,7 @@ pub type RequestEnvelope<M> = Envelope<M>;
 pub type ResponseEnvelope<M> = Envelope<M>;
 
 #[allow(missing_docs)]
-#[repr(packed)]
+#[repr(Rust, packed)]
 #[derive(Debug, Copy, Clone, Hash, IntoBytes, FromBytes, Immutable, PartialEq, Eq)]
 pub struct PingRequestPayload {
     /// Randomly generated connection id
@@ -67,7 +67,7 @@ impl Message for PingRequest {
 }
 
 #[allow(missing_docs)]
-#[repr(packed)]
+#[repr(Rust, packed)]
 #[derive(Debug, Copy, Clone, Hash, IntoBytes, FromBytes, Immutable, PartialEq, Eq)]
 pub struct PingResponsePayload {
     /// Randomly generated connection id
@@ -108,7 +108,7 @@ impl Message for PingResponse {
 }
 
 #[allow(missing_docs)]
-#[repr(packed)]
+#[repr(Rust, packed)]
 #[derive(Debug, Copy, Clone, Hash, IntoBytes, FromBytes, Immutable, PartialEq, Eq)]
 pub struct SupplyKeypairRequestPayload {}
 
@@ -168,7 +168,7 @@ pub mod supply_keypair_response_status {
 }
 
 #[allow(missing_docs)]
-#[repr(packed)]
+#[repr(Rust, packed)]
 #[derive(Debug, Copy, Clone, Hash, IntoBytes, FromBytes, Immutable, PartialEq, Eq)]
 pub struct SupplyKeypairResponsePayload {
     #[allow(missing_docs)]
@@ -209,7 +209,7 @@ impl Message for SupplyKeypairResponse {
 }
 
 #[allow(missing_docs)]
-#[repr(packed)]
+#[repr(Rust, packed)]
 #[derive(Debug, Copy, Clone, Hash, IntoBytes, FromBytes, Immutable, PartialEq, Eq)]
 pub struct AddListenSocketRequestPayload {}
 
@@ -263,7 +263,7 @@ pub mod add_listen_socket_response_status {
 }
 
 #[allow(missing_docs)]
-#[repr(packed)]
+#[repr(Rust, packed)]
 #[derive(Debug, Copy, Clone, Hash, IntoBytes, FromBytes, Immutable, PartialEq, Eq)]
 pub struct AddListenSocketResponsePayload {
     pub status: u128,
@@ -303,7 +303,7 @@ impl Message for AddListenSocketResponse {
 }
 
 #[allow(missing_docs)]
-#[repr(packed)]
+#[repr(Rust, packed)]
 #[derive(Debug, Copy, Clone, Hash, IntoBytes, FromBytes, Immutable, PartialEq, Eq)]
 pub struct AddPskBrokerRequestPayload {}
 
@@ -358,7 +358,7 @@ pub mod add_psk_broker_response_status {
 }
 
 #[allow(missing_docs)]
-#[repr(packed)]
+#[repr(Rust, packed)]
 #[derive(Debug, Copy, Clone, Hash, IntoBytes, FromBytes, Immutable, PartialEq, Eq)]
 pub struct AddPskBrokerResponsePayload {
     pub status: u128,

--- a/rosenpass/src/api/boilerplate/server.rs
+++ b/rosenpass/src/api/boilerplate/server.rs
@@ -173,7 +173,7 @@ pub trait Server {
     ///
     /// - `req` – A buffer containing the request
     /// - `res_fds` – A list of file descriptors received during the API call (i.e. this is used
-    ///    with unix socket file descriptor passing)
+    ///   with unix socket file descriptor passing)
     /// - `res` – The buffer to store the response in.
     fn handle_message<ReqBuf, ResBuf>(
         &mut self,

--- a/rosenpass/src/cli.rs
+++ b/rosenpass/src/cli.rs
@@ -145,7 +145,6 @@ impl CliArgs {
     /// Return the WireGuard PSK broker interface configured.
     ///
     /// Returns `None` if the `experiment_api` feature is disabled.
-
     #[cfg(feature = "experiment_api")]
     pub fn get_broker_interface(&self) -> Option<BrokerInterface> {
         if let Some(path_ref) = self.psk_broker_path.as_ref() {

--- a/rosenpass/src/config.rs
+++ b/rosenpass/src/config.rs
@@ -15,7 +15,7 @@ use anyhow::{bail, ensure};
 
 use serde::{Deserialize, Serialize};
 
-use crate::internal::util::file::{LoadValue, Visibility, fopen_w};
+use crate::internal::util::file::{fopen_w, LoadValue, Visibility};
 
 use crate::protocol::basic_types::{SPk, SSk};
 use crate::protocol::osk_domain_separator::OskDomainSeparator;
@@ -865,11 +865,15 @@ mod test {
     #[test]
     fn test_protocol_version() {
         let mut rosenpass = Rosenpass::empty();
-        let mut peer_v_02 = RosenpassPeer::default();
-        peer_v_02.protocol_version = ProtocolVersion::V02;
+        let peer_v_02 = RosenpassPeer {
+            protocol_version: ProtocolVersion::V02,
+            ..RosenpassPeer::default()
+        };
         rosenpass.peers.push(peer_v_02);
-        let mut peer_v_03 = RosenpassPeer::default();
-        peer_v_03.protocol_version = ProtocolVersion::V03;
+        let peer_v_03 = RosenpassPeer {
+            protocol_version: ProtocolVersion::V03,
+            ..RosenpassPeer::default()
+        };
         rosenpass.peers.push(peer_v_03);
         #[cfg(feature = "experiment_api")]
         {

--- a/rosenpass/src/config.rs
+++ b/rosenpass/src/config.rs
@@ -984,13 +984,14 @@ pub mod util {
     #[cfg(test)]
     mod test {
         use super::*;
+        use std::path::Path;
         #[test]
         fn test_resolve_path_with_tilde() {
             let test = |path_str: &str, resolved: &str| {
                 let mut path = PathBuf::from(path_str);
                 resolve_path_with_tilde(&mut path);
                 assert!(
-                    path == PathBuf::from(resolved),
+                    path == Path::new(resolved),
                     "Path {:?} has been resolved to {:?} but should have been resolved to {:?}.",
                     path_str,
                     path,

--- a/rosenpass/src/internal/cipher_traits/primitives/aead.rs
+++ b/rosenpass/src/internal/cipher_traits/primitives/aead.rs
@@ -141,7 +141,7 @@ pub trait AeadWithNonceInCiphertext<
         let (nonce, rest) = ciphertext.split_at(NONCE_LEN);
         // We know this should be the right length (we just split it), and everything else would be
         // very unexpected.
-        let nonce = nonce.try_into().map_err(|_| Error::InternalError)?;
+        let nonce = nonce.try_into().map_err(|_| Error::Internal)?;
 
         self.decrypt(plaintext, key, nonce, ad, rest)
     }
@@ -162,12 +162,12 @@ pub enum Error {
     /// An internal error occurred. This should never be happen and indicates an error in the
     /// AEAD implementation.
     #[error("internal error")]
-    InternalError,
+    Internal,
 
     /// Could not decrypt a message because the message is not a valid ciphertext for the given
     /// key.
-    #[error("decryption error")]
-    DecryptError,
+    #[error("decryption failed")]
+    DecryptionFailed,
 
     /// The provided buffers have the wrong lengths.
     #[error("buffers have invalid length")]

--- a/rosenpass/src/internal/ciphers/hash_domain.rs
+++ b/rosenpass/src/internal/ciphers/hash_domain.rs
@@ -249,7 +249,6 @@ impl SecretHashDomain {
     ///         .into_secret()
     ///         .secret(),
     /// );
-
     /// Ok::<(), anyhow::Error>(())
     /// ```
     pub fn mix_many<I, T>(mut self, it: I) -> Result<Self>

--- a/rosenpass/src/internal/ciphers/subtle/rust_crypto/chacha20poly1305_ietf.rs
+++ b/rosenpass/src/internal/ciphers/subtle/rust_crypto/chacha20poly1305_ietf.rs
@@ -37,11 +37,11 @@ impl Aead<KEY_LEN, NONCE_LEN, TAG_LEN> for ChaCha20Poly1305 {
 
         // This only fails if the length is wrong, which really shouldn't happen and would
         // constitute an internal error.
-        let encrypter = AeadImpl::new_from_slice(key).map_err(|_| AeadError::InternalError)?;
+        let encrypter = AeadImpl::new_from_slice(key).map_err(|_| AeadError::Internal)?;
 
         let mac_value = encrypter
             .encrypt_in_place_detached(nonce, ad, ct)
-            .map_err(|_| AeadError::InternalError)?;
+            .map_err(|_| AeadError::Internal)?;
         copy_slice(&mac_value[..]).to(mac);
 
         Ok(())
@@ -68,11 +68,11 @@ impl Aead<KEY_LEN, NONCE_LEN, TAG_LEN> for ChaCha20Poly1305 {
 
         // This only fails if the length is wrong, which really shouldn't happen and would
         // constitute an internal error.
-        let decrypter = AeadImpl::new_from_slice(key).map_err(|_| AeadError::InternalError)?;
+        let decrypter = AeadImpl::new_from_slice(key).map_err(|_| AeadError::Internal)?;
 
         decrypter
             .decrypt_in_place_detached(nonce, ad, plaintext, tag)
-            .map_err(|_| AeadError::DecryptError)?;
+            .map_err(|_| AeadError::DecryptionFailed)?;
 
         Ok(())
     }

--- a/rosenpass/src/internal/ciphers/subtle/rust_crypto/xchacha20poly1305_ietf.rs
+++ b/rosenpass/src/internal/ciphers/subtle/rust_crypto/xchacha20poly1305_ietf.rs
@@ -37,11 +37,11 @@ impl Aead<KEY_LEN, NONCE_LEN, TAG_LEN> for XChaCha20Poly1305 {
 
         // This only fails if the length is wrong, which really shouldn't happen and would
         // constitute an internal error.
-        let encrypter = AeadImpl::new_from_slice(key).map_err(|_| AeadError::InternalError)?;
+        let encrypter = AeadImpl::new_from_slice(key).map_err(|_| AeadError::Internal)?;
 
         let mac_value = encrypter
             .encrypt_in_place_detached(nonce, ad, ct)
-            .map_err(|_| AeadError::InternalError)?;
+            .map_err(|_| AeadError::Internal)?;
         copy_slice(&mac_value[..]).to(mac);
         Ok(())
     }
@@ -67,11 +67,11 @@ impl Aead<KEY_LEN, NONCE_LEN, TAG_LEN> for XChaCha20Poly1305 {
 
         // This only fails if the length is wrong, which really shouldn't happen and would
         // constitute an internal error.
-        let decrypter = AeadImpl::new_from_slice(key).map_err(|_| AeadError::InternalError)?;
+        let decrypter = AeadImpl::new_from_slice(key).map_err(|_| AeadError::Internal)?;
 
         decrypter
             .decrypt_in_place_detached(nonce, ad, plaintext, tag)
-            .map_err(|_| AeadError::DecryptError)?;
+            .map_err(|_| AeadError::DecryptionFailed)?;
         Ok(())
     }
 }

--- a/rosenpass/src/internal/util/length_prefix_encoding/encoder.rs
+++ b/rosenpass/src/internal/util/length_prefix_encoding/encoder.rs
@@ -168,7 +168,6 @@ pub struct WriteToIoReturn {
 ///	    .expect_err("OOB access should fail");
 /// assert!(matches!(err, MessageLenSanityError::MessageTooLarge(_)));
 /// ```
-
 pub struct LengthPrefixEncoder<Buf: Borrow<[u8]>> {
     buf: Buf,
     header: [u8; HEADER_SIZE],

--- a/rosenpass/src/internal/util/length_prefix_encoding/encoder.rs
+++ b/rosenpass/src/internal/util/length_prefix_encoding/encoder.rs
@@ -165,7 +165,7 @@ pub struct WriteToIoReturn {
 ///
 /// // The sanity check prevents an unsafe out-of-bounds access here
 /// let err = LengthPrefixEncoder::from_short_message(message, 2 * message_size)
-///	    .expect_err("OOB access should fail");
+///     .expect_err("OOB access should fail");
 /// assert!(matches!(err, MessageLenSanityError::MessageTooLarge(_)));
 /// ```
 pub struct LengthPrefixEncoder<Buf: Borrow<[u8]>> {
@@ -211,7 +211,7 @@ impl<Buf: Borrow<[u8]>> LengthPrefixEncoder<Buf> {
 
     /// Consumes the encoder and returns the underlying buffer
     ///
-    ///	# Example
+    /// # Example
     ///
     /// ```rust
     /// use rosenpass::internal::util::length_prefix_encoding::encoder::LengthPrefixEncoder;
@@ -228,7 +228,7 @@ impl<Buf: Borrow<[u8]>> LengthPrefixEncoder<Buf> {
 
     /// Consumes the encoder and returns buffer, message length and write position
     ///
-    ///	# Example
+    /// # Example
     ///
     /// ```rust
     /// use rosenpass::internal::util::length_prefix_encoding::encoder::LengthPrefixEncoder;
@@ -270,8 +270,8 @@ impl<Buf: Borrow<[u8]>> LengthPrefixEncoder<Buf> {
     ///
     /// // Fast-forward - behaves as if the HEADER had already been written; only the message remains
     /// encoder
-    /// 	.set_header_offset(HEADER_SIZE)
-    /// 	.expect("failed to move cursor");
+    ///     .set_header_offset(HEADER_SIZE)
+    ///     .expect("failed to move cursor");
     /// let mut sink = Cursor::new(vec![0; prefixed_msg_size + 1]);
     /// encoder.write_all_to_stdio(&mut sink).expect("write failed");
     /// assert_eq!(&sink.get_ref()[0..msg.len()], msg.as_bytes());
@@ -296,40 +296,40 @@ impl<Buf: Borrow<[u8]>> LengthPrefixEncoder<Buf> {
     ///
     /// # Example
     ///
-    ///	```rust
+    /// ```rust
     /// # use std::io::Cursor;
     /// # use rosenpass::internal::util::length_prefix_encoding::encoder::{LengthPrefixEncoder, WriteToIoReturn, HEADER_SIZE};
-    ///	let msg = String::from("Hello world");
-    ///	let prefixed_msg_size = msg.len() + HEADER_SIZE;
+    /// let msg = String::from("Hello world");
+    /// let prefixed_msg_size = msg.len() + HEADER_SIZE;
     ///
-    ///	let mut encoder = LengthPrefixEncoder::from_parts(msg.as_bytes(), msg.len(), 0).unwrap();
-    ///	assert_eq!(encoder.encoded_message_bytes(), prefixed_msg_size);
-    ///	assert!(!encoder.exhausted());
+    /// let mut encoder = LengthPrefixEncoder::from_parts(msg.as_bytes(), msg.len(), 0).unwrap();
+    /// assert_eq!(encoder.encoded_message_bytes(), prefixed_msg_size);
+    /// assert!(!encoder.exhausted());
     ///
-    ///	let mut dummy_stdout = Cursor::new(vec![0; prefixed_msg_size + 1]);
+    /// let mut dummy_stdout = Cursor::new(vec![0; prefixed_msg_size + 1]);
     ///
-    ///	loop {
-    ///		let result: WriteToIoReturn = encoder
-    ///			.write_to_stdio(&mut dummy_stdout)
-    ///			.expect("write failed");
-    ///		if dummy_stdout.position() as usize >= prefixed_msg_size {
-    ///			// The entire message should've been written (and the encoder state reflect this)
-    ///			assert!(result.done);
-    ///			assert_eq!(result.bytes_written, msg.len());
-    ///			assert_eq!(encoder.header_written(), (msg.len() as u64).to_le_bytes());
-    ///			assert_eq!(encoder.message_written(), msg.as_bytes());
-    ///			break;
-    ///		}
-    ///	}
-    ///	let buffer_bytes = dummy_stdout.get_ref();
-    ///	match String::from_utf8(buffer_bytes.to_vec()) {
-    ///		Ok(buffer_str) => assert_eq!(&buffer_str[HEADER_SIZE..prefixed_msg_size], msg),
-    ///		Err(err) => println!("Error converting buffer to String: {:?}", err),
-    ///	}
-    ///	assert_eq!(
-    ///		&dummy_stdout.get_ref()[HEADER_SIZE..prefixed_msg_size],
-    ///		msg.as_bytes()
-    ///	);
+    /// loop {
+    ///     let result: WriteToIoReturn = encoder
+    ///         .write_to_stdio(&mut dummy_stdout)
+    ///         .expect("write failed");
+    ///     if dummy_stdout.position() as usize >= prefixed_msg_size {
+    ///         // The entire message should've been written (and the encoder state reflect this)
+    ///         assert!(result.done);
+    ///         assert_eq!(result.bytes_written, msg.len());
+    ///         assert_eq!(encoder.header_written(), (msg.len() as u64).to_le_bytes());
+    ///         assert_eq!(encoder.message_written(), msg.as_bytes());
+    ///         break;
+    ///     }
+    /// }
+    /// let buffer_bytes = dummy_stdout.get_ref();
+    /// match String::from_utf8(buffer_bytes.to_vec()) {
+    ///     Ok(buffer_str) => assert_eq!(&buffer_str[HEADER_SIZE..prefixed_msg_size], msg),
+    ///     Err(err) => println!("Error converting buffer to String: {:?}", err),
+    /// }
+    /// assert_eq!(
+    ///     &dummy_stdout.get_ref()[HEADER_SIZE..prefixed_msg_size],
+    ///     msg.as_bytes()
+    /// );
     /// ```
     pub fn write_to_stdio<W: io::Write>(&mut self, mut w: W) -> io::Result<WriteToIoReturn> {
         if self.exhausted() {

--- a/rosenpass/src/internal/util/mio/uds_recv_fd.rs
+++ b/rosenpass/src/internal/util/mio/uds_recv_fd.rs
@@ -36,8 +36,8 @@ use crate::internal::util::fd::{IntoStdioErr, claim_fd_inplace};
 ///
 /// // Wrap the socket to start tracking received file descriptors
 /// let mut fd_passing_sock = ReadWithFileDescriptors::<MAX_REQUEST_FDS, UnixStream, _, _>::new(
-///	&io_stream,
-///	&mut read_fd_buffer,
+///     &io_stream,
+///     &mut read_fd_buffer,
 /// );
 ///
 /// // Simulated reads; the actual operations will depend on the protocol (implementation details)

--- a/rosenpass/src/internal/util/zerocopy/ref_maker.rs
+++ b/rosenpass/src/internal/util/zerocopy/ref_maker.rs
@@ -200,6 +200,7 @@ impl<B: SplitByteSlice, T> RefMaker<B, T> {
     /// assert_eq!(prefix_rm.bytes(), &[1,2,3,4]);
     /// assert_eq!(tail, &[5,6,7,8]);
     /// ```
+    #[allow(clippy::wrong_self_convention)]
     pub fn from_prefix_with_tail(self) -> anyhow::Result<(Self, B)> {
         self.ensure_fit()?;
         let (head, tail) = self.split_at_point(Self::target_size())?;
@@ -242,6 +243,7 @@ impl<B: SplitByteSlice, T> RefMaker<B, T> {
     /// let prefix_rm = RefMaker::<_, u32>::new(bytes).from_prefix().unwrap();
     /// assert_eq!(prefix_rm.bytes(), &[1,2,3,4]);
     /// ```
+    #[allow(clippy::wrong_self_convention)]
     pub fn from_prefix(self) -> anyhow::Result<Self> {
         Ok(Self::from_prefix_with_tail(self)?.0)
     }
@@ -261,6 +263,7 @@ impl<B: SplitByteSlice, T> RefMaker<B, T> {
     /// assert_eq!(suffix_rm.bytes(), &[7,8,9,10]);
     /// assert_eq!(head, &[1,2,3,4,5,6]);
     /// ```
+    #[allow(clippy::wrong_self_convention)]
     pub fn from_suffix_with_head(self) -> anyhow::Result<(Self, B)> {
         self.ensure_fit()?;
         let point = self.bytes().len() - Self::target_size();
@@ -304,6 +307,7 @@ impl<B: SplitByteSlice, T> RefMaker<B, T> {
     /// let suffix_rm = RefMaker::<_, u32>::new(bytes).from_suffix().unwrap();
     /// assert_eq!(suffix_rm.bytes(), &[7,8,9,10]);
     /// ```
+    #[allow(clippy::wrong_self_convention)]
     pub fn from_suffix(self) -> anyhow::Result<Self> {
         Ok(Self::from_suffix_with_head(self)?.0)
     }

--- a/rosenpass/src/internal/wireguard_broker/api/msgs.rs
+++ b/rosenpass/src/internal/wireguard_broker/api/msgs.rs
@@ -14,7 +14,7 @@ pub const REQUEST_MSG_BUFFER_SIZE: usize = ENVELOPE_OVERHEAD + 32 + 32 + 1 + 255
 pub const RESPONSE_MSG_BUFFER_SIZE: usize = ENVELOPE_OVERHEAD + 1;
 
 /// Envelope for messages being passed around.
-#[repr(packed)]
+#[repr(Rust, packed)]
 #[derive(IntoBytes, FromBytes, KnownLayout, Immutable)]
 pub struct Envelope<M: IntoBytes + FromBytes + KnownLayout + Immutable> {
     /// [MsgType] of this message
@@ -28,7 +28,7 @@ pub struct Envelope<M: IntoBytes + FromBytes + KnownLayout + Immutable> {
 /// Message format for requests to set a pre-shared key.
 /// # Example
 ///
-#[repr(packed)]
+#[repr(Rust, packed)]
 #[derive(IntoBytes, FromBytes, KnownLayout, Immutable)]
 pub struct SetPskRequest {
     /// The pre-shared key.
@@ -84,7 +84,7 @@ impl SetPskRequest {
 }
 
 /// Message format for response to the set pre-shared key operation.
-#[repr(packed)]
+#[repr(Rust, packed)]
 #[derive(IntoBytes, FromBytes, KnownLayout, Immutable)]
 pub struct SetPskResponse {
     pub return_code: u8,

--- a/rosenpass/src/msgs.rs
+++ b/rosenpass/src/msgs.rs
@@ -76,7 +76,7 @@ pub type MsgEnvelopeCookie = [u8; COOKIE_SIZE];
 /// assert_ne!(ih.as_bytes(), ih3.as_bytes());
 /// assert_eq!(ih3.msg_type, 42);
 /// ```
-#[repr(packed)]
+#[repr(Rust, packed)]
 #[derive(IntoBytes, FromBytes, KnownLayout, Immutable, Clone)]
 pub struct Envelope<M: IntoBytes + FromBytes> {
     /// [MsgType] of this message
@@ -126,7 +126,7 @@ pub struct Envelope<M: IntoBytes + FromBytes> {
 /// // Check that write above on byte representation was effective
 /// assert_eq!(ih.payload.sidi, [1,2,3,4]);
 /// ```
-#[repr(packed)]
+#[repr(Rust, packed)]
 #[derive(IntoBytes, FromBytes, KnownLayout, Immutable)]
 pub struct InitHello {
     /// Randomly generated connection id
@@ -175,7 +175,7 @@ pub struct InitHello {
 /// // Check that write above on byte representation was effective
 /// assert_eq!(ih.payload.sidi, [1,2,3,4]);
 /// ```
-#[repr(packed)]
+#[repr(Rust, packed)]
 #[derive(IntoBytes, FromBytes, KnownLayout, Immutable)]
 pub struct RespHello {
     /// Randomly generated connection id
@@ -226,7 +226,7 @@ pub struct RespHello {
 /// // Check that write above on byte representation was effective
 /// assert_eq!(ih.payload.sidi, [1,2,3,4]);
 /// ```
-#[repr(packed)]
+#[repr(Rust, packed)]
 #[derive(IntoBytes, FromBytes, KnownLayout, Immutable, Debug)]
 pub struct InitConf {
     /// Copied from InitHello
@@ -284,7 +284,7 @@ pub struct InitConf {
 /// // Check that write above on byte representation was effective
 /// assert_eq!(ih.payload.sid, [1,2,3,4]);
 /// ```
-#[repr(packed)]
+#[repr(Rust, packed)]
 #[derive(IntoBytes, FromBytes, KnownLayout, Immutable, Clone, Copy)]
 pub struct EmptyData {
     /// Copied from RespHello
@@ -311,7 +311,7 @@ pub struct EmptyData {
 /// [crate::protocol::HandshakeState::load_biscuit]
 ///
 /// [Envelope] and [InitHello] contain some extra examples on how to use structures from the [::zerocopy] crate.
-#[repr(packed)]
+#[repr(Rust, packed)]
 #[derive(IntoBytes, FromBytes, KnownLayout, Immutable)]
 pub struct Biscuit {
     /// H(spki) – Ident ifies the initiator
@@ -336,7 +336,7 @@ pub struct Biscuit {
 /// [crate::protocol::CryptoServer::handle_msg_under_load].
 ///
 /// [Envelope] and [InitHello] contain some extra examples on how to use structures from the [::zerocopy] crate.
-#[repr(packed)]
+#[repr(Rust, packed)]
 #[derive(IntoBytes, FromBytes, Immutable)]
 pub struct CookieReplyInner {
     /// [MsgType] of this message
@@ -363,7 +363,7 @@ pub struct CookieReplyInner {
 /// [crate::protocol::CryptoServer::handle_msg_under_load].
 ///
 /// [Envelope] and [InitHello] contain some extra examples on how to use structures from the [::zerocopy] crate.
-#[repr(packed)]
+#[repr(Rust, packed)]
 #[derive(IntoBytes, FromBytes, KnownLayout, Immutable)]
 pub struct CookieReply {
     pub inner: CookieReplyInner,

--- a/rosenpass/src/protocol/protocol.rs
+++ b/rosenpass/src/protocol/protocol.rs
@@ -3241,7 +3241,7 @@ impl HandshakeState {
     ///   out the const generics.
     /// - By adding a value parameter of type `PhantomData<TV>`, you can choose
     ///   `TV` at the call site while allowing the compiler to infer `KEM_*`
-    ///    const generics from `ct` and `pk`.
+    ///   const generics from `ct` and `pk`.
     /// - Call like: `encaps_and_mix_with_test_vector(&StaticKem, &mut ct, pk,
     ///   PhantomData::<TestVectorActive>)?;`
     pub fn encaps_and_mix_with_test_vector<

--- a/rosenpass/tests/api-integration-tests-api-setup.rs
+++ b/rosenpass/tests/api-integration-tests-api-setup.rs
@@ -106,7 +106,7 @@ fn api_integration_api_setup(protocol_version: ProtocolVersion) -> anyhow::Resul
                 peer: format!("{}", peer_b_wg_peer_id.fmt_b64::<8129>()),
                 extra_params: vec![],
             }),
-            protocol_version: protocol_version,
+            protocol_version,
             osk_domain_separator: Default::default(),
         }],
     };
@@ -128,7 +128,7 @@ fn api_integration_api_setup(protocol_version: ProtocolVersion) -> anyhow::Resul
             endpoint: Some(peer_a_endpoint.to_owned()),
             pre_shared_key: None,
             wg: None,
-            protocol_version: protocol_version,
+            protocol_version,
             osk_domain_separator: Default::default(),
         }],
     };

--- a/rosenpass/tests/api-integration-tests.rs
+++ b/rosenpass/tests/api-integration-tests.rs
@@ -87,7 +87,7 @@ fn api_integration_test(protocol_version: ProtocolVersion) -> anyhow::Result<()>
             endpoint: None,
             pre_shared_key: None,
             wg: None,
-            protocol_version: protocol_version,
+            protocol_version,
             osk_domain_separator: Default::default(),
         }],
     };
@@ -109,7 +109,7 @@ fn api_integration_test(protocol_version: ProtocolVersion) -> anyhow::Result<()>
             endpoint: Some(peer_a_endpoint.to_owned()),
             pre_shared_key: None,
             wg: None,
-            protocol_version: protocol_version,
+            protocol_version,
             osk_domain_separator: Default::default(),
         }],
     };

--- a/rosenpass/tests/integration_test.rs
+++ b/rosenpass/tests/integration_test.rs
@@ -84,7 +84,7 @@ fn generate_key_pairs(secret_key_paths: &[PathBuf], public_key_paths: &[PathBuf]
             .arg("--public-key")
             .arg(pub_key_path)
             .output()
-            .expect(format!("failed to start {BIN}").as_str());
+            .unwrap_or_else(|_| panic!("failed to start {BIN}"));
         println!("command has finished, status: {}", output.status);
         std::io::stdout().write_all(&output.stdout).unwrap();
         std::io::stderr().write_all(&output.stderr).unwrap();

--- a/rosenpass/tests/poll_example.rs
+++ b/rosenpass/tests/poll_example.rs
@@ -149,7 +149,7 @@ fn test_successful_exchange_under_packet_loss(
         } = ev
         {
             // Drop every tenth package
-            if pkg_counter % 10 == 0 {
+            if pkg_counter.is_multiple_of(10) {
                 source.drop_outgoing_packet(&mut sim);
             }
 

--- a/rosenpass/tests/test_vector_crypto_server.rs
+++ b/rosenpass/tests/test_vector_crypto_server.rs
@@ -91,13 +91,13 @@ fn crypto_server_test_vector_1() -> anyhow::Result<()> {
     secret_policy_try_use_memfd_secrets();
 
     // initialize secret and public key for peer a ...
-    let (mut peer_a_sk, mut peer_a_pk) = gen_keypair::<TV>();
+    let (mut peer_a_sk, mut peer_a_pk) = gen_keypair();
 
     TV::expose_mut_value(&test_values.peer_a_sk, &mut peer_a_sk);
     TV::expose_mut_value(&test_values.peer_a_pk, &mut peer_a_pk);
 
     // ... and for peer b
-    let (mut peer_b_sk, mut peer_b_pk) = gen_keypair::<TV>();
+    let (mut peer_b_sk, mut peer_b_pk) = gen_keypair();
 
     TV::expose_mut_value(&test_values.peer_b_sk, &mut peer_b_sk);
     TV::expose_mut_value(&test_values.peer_b_pk, &mut peer_b_pk);
@@ -154,7 +154,7 @@ fn crypto_server_test_vector_1() -> anyhow::Result<()> {
     TV::check_value(&test_values.exchanged_key, &a_key);
     Ok(())
 }
-fn gen_keypair<TV: TestVector>() -> (SSk, SPk) {
+fn gen_keypair() -> (SSk, SPk) {
     let (mut sk, mut pk) = (SSk::zero(), SPk::zero());
     StaticKem
         .keygen(sk.secret_mut(), pk.deref_mut())

--- a/to/src/to/mod.rs
+++ b/to/src/to/mod.rs
@@ -10,11 +10,11 @@
 //!   some sized variant of
 //!   `Dst` (e.g. `[u8; 64]`).
 //! - `Ret: Sized`; (anything) – must be `CondenseBeside<_>` if condensing is to be applied. The
-//!    ordinary return value of a function with an output
+//!   ordinary return value of a function with an output
 //! - `Val: Sized + BorrowMut<Dst>`; (e.g. [u8; 16]) – Some owned storage that can be borrowed as
 //!   `Dst`
-//! - `Condensed: Sized = CondenseBeside<Val>::Condensed`; (e.g. [u8; 16], Result<[u8; 16]>)
-//! – The combiation of Val and Ret after condensing was applied
+//! - `Condensed: Sized = CondenseBeside<Val>::Condensed`; (e.g. `[u8; 16]`, `Result<[u8; 16]>`)
+//!   – The combiation of Val and Ret after condensing was applied
 //!   (`Beside<Val, Ret>::condense()`/`Ret::condense(v)` for all `v : Val`).
 
 pub mod beside;

--- a/to/src/to/with_destination.rs
+++ b/to/src/to/with_destination.rs
@@ -37,6 +37,7 @@ where
     ///
     /// # Arguments
     /// * `out` - Mutable reference to the destination
+    ///
     /// See the tutorial in [readme.md] for examples and more explanations.
     fn to(self, out: &mut Dst) -> Ret {
         (self.fun)(out)


### PR DESCRIPTION
Issue [#957](https://github.com/rosenpass/rosenpass/issues/957)

Addresses a lot of the warnings when running `cargo clippy --all-features --all-targets`.

Not done:
* There are a lot of warnings for `missing_docs_in_private_items` which I don't feel qualified to address right now
* There is one warning for `missing_safety_doc` which, again, I don't feel qualified to address right now