### PR TITLE
re-apply 68e571c32c650d95c772f990b4c20ee9c1589d94 (was overwritten in be5082ca1ff8f93d6a284b64c8e7e4e6e1190f06): fix `<` operator to `<=` operator in cookies doc test

### DIFF
--- a/rosenpass/tests/protocol_cookies_CookieStore.rs
+++ b/rosenpass/tests/protocol_cookies_CookieStore.rs
@@ -15,8 +15,8 @@ fn cookie_store_demo() {
     let time_before_call = timebase.now();
     store.update(&timebase, fixed_secret.secret());
     assert_eq!(store.value.secret(), fixed_secret.secret());
-    assert!(store.created_at < timebase.now());
-    assert!(store.created_at > time_before_call);
+    assert!(store.created_at <= timebase.now());
+    assert!(store.created_at >= time_before_call);
 
     // Same as new()
     store.erase();
@@ -27,6 +27,6 @@ fn cookie_store_demo() {
     let time_before_call = timebase.now();
     store.randomize(&timebase);
     assert_ne!(store.value.secret(), secret_before_call.secret());
-    assert!(store.created_at < timebase.now());
-    assert!(store.created_at > time_before_call);
+    assert!(store.created_at <= timebase.now());
+    assert!(store.created_at >= time_before_call);
 }


### PR DESCRIPTION
- re-applys #1017
- closes #1059

`std::time::Instant` uses CLOCK_MONOTONIC (https://doc.rust-lang.org/nightly/std/time/struct.Instant.html#underlying-system-calls) which can yield identical time stamps for consecutive calls: https://www.man7.org/linux/man-pages/man2/clock_getres.2.html

This seems to occur very rarely (once in CI, not reproducible on my laptop through 10 000 runs).