### PR TITLE
clean up CI integration test

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -62,6 +62,9 @@ jobs:
             exit 1
           fi
           REF_BEFORE="github:rosenpass/rosenpass/$TARGET_REF"
+          echo "INFO: running integration test:"
+          echo "    - against  rosenpass-old=\"$REF_BEFORE\""
+          echo "    - with new rosenpass-new=\"$REF_AFTER\""
           echo "REF_BEFORE=$REF_BEFORE" >> $GITHUB_ENV
           echo "REF_AFTER=$REF_AFTER" >> $GITHUB_ENV
       - name: Check

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -12,54 +12,26 @@ concurrency:
 
 jobs:
   integration-tests-x86_64-linux:
-    name: Integration tests x86_64-linux
-    runs-on: ubicloud-standard-2
-    steps:
-      - uses: actions/checkout@v7
-      - uses: cachix/install-nix-action@v31
-        with:
-          nix_path: nixpkgs=channel:nixos-unstable
-      - uses: cachix/cachix-action@v17
-        with:
-          name: rosenpass
-          authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
-      - name: Extract the reference of before and after for the integration tests.
-        run: |
-          EVENT_NAME="${{ github.event_name }}"
-          REF_BEFORE=""
-          REF_AFTER="path:../../"
-          if [[ "$EVENT_NAME" == "pull_request" ]]; then
-            echo "This CI run was triggered in the context of a pull request."
-            REF_BEFORE="github:rosenpass/rosenpass/${{ github.event.pull_request.base.ref }}"
-            git checkout -B pr-${{ github.event.pull_request.number }}
-            REF_AFTER="git+file://../../../?ref=pr-${{ github.event.pull_request.number }}"
-          elif [[ "$EVENT_NAME" == "push" ]]; then
-            echo "This CI run was triggered in the context of a push."
-            REF_BEFORE="github:rosenpass/rosenpass/${{ github.event.before }}"
-            REF_AFTER="github:rosenpass/rosenpass/${{ github.event.after }}"
-          else
-            echo "ERROR: This CI run was not triggered in the context of a pull request or a push. Exiting with error."
-            exit 1
-          fi
-          echo "REF_BEFORE=$REF_BEFORE" >> $GITHUB_ENV
-          echo "REF_AFTER=$REF_AFTER" >> $GITHUB_ENV
-      - name: Check
-        run: |
-          cd ./tests/integration
-          nix flake check --print-build-logs --system x86_64-linux --override-input rosenpass-old $REF_BEFORE --override-input rosenpass-new $REF_AFTER
-  integration-tests-against-targets-x86_64-linux:
-    name: Integration tests x86_64-linux against ${{ matrix.target }}
+    name: Integration tests x86_64-linux against ${{ matrix.target.name }}
     runs-on: ubicloud-standard-2
     strategy:
       # necessary to continue running the other matrix target(s) when one matrix target fails
       # docs: https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#jobsjob_idstrategyfail-fast
       fail-fast: false
       matrix:
-        # Targets (branches or tags of rosenpass/rosenpass) to test the current code against.
+        # the targets to run the integration tests against
+        #
         # To test against an additional target, simply add it to this list.
+        # - an entry without a `ref` tests against the previous state of this
+        #   repository: the base branch for pull requests, the commit before a
+        #   push for pushes.
+        # - an entry with a `ref` tests against that branch or tag
         target:
-          - main
-          - v0.2.3
+          - name: previous state
+          - name: main branch
+            ref: main
+          - name: tag v0.2.3
+            ref: v0.2.3
     steps:
       - uses: actions/checkout@v7
       - uses: cachix/install-nix-action@v31
@@ -72,19 +44,24 @@ jobs:
       - name: Extract the reference of before and after for the integration tests.
         run: |
           EVENT_NAME="${{ github.event_name }}"
-          REF_BEFORE="github:rosenpass/rosenpass/${{ matrix.target }}"
+          # An empty target ref means: test against the previous state of this
+          # repository (see the comment on the matrix above).
+          TARGET_REF="${{ matrix.target.ref }}"
           REF_AFTER="path:../../"
           if [[ "$EVENT_NAME" == "pull_request" ]]; then
             echo "This CI run was triggered in the context of a pull request."
+            TARGET_REF="${TARGET_REF:-${{ github.event.pull_request.base.ref }}}"
             git checkout -B pr-${{ github.event.pull_request.number }}
             REF_AFTER="git+file://../../../?ref=pr-${{ github.event.pull_request.number }}"
           elif [[ "$EVENT_NAME" == "push" ]]; then
             echo "This CI run was triggered in the context of a push."
+            TARGET_REF="${TARGET_REF:-${{ github.event.before }}}"
             REF_AFTER="github:rosenpass/rosenpass/${{ github.event.after }}"
           else
             echo "ERROR: This CI run was not triggered in the context of a pull request or a push. Exiting with error."
             exit 1
           fi
+          REF_BEFORE="github:rosenpass/rosenpass/$TARGET_REF"
           echo "REF_BEFORE=$REF_BEFORE" >> $GITHUB_ENV
           echo "REF_AFTER=$REF_AFTER" >> $GITHUB_ENV
       - name: Check

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -11,27 +11,49 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  integration-tests-x86_64-linux:
-    name: Integration tests x86_64-linux against ${{ matrix.target.name }}
-    runs-on: ubicloud-standard-2
+  integration-tests:
+    name: Integration tests ${{ matrix.arch.system }} against ${{ matrix.target.name }}
+    runs-on: ${{ matrix.arch.runs-on }}
+    timeout-minutes: ${{ matrix.arch.timeout-minutes }}
     strategy:
-      # necessary to continue running the other matrix target(s) when one matrix target fails
-      # docs: https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#jobsjob_idstrategyfail-fast
       fail-fast: false
       matrix:
-        # the targets to run the integration tests against
-        #
-        # To test against an additional target, simply add it to this list.
-        # - an entry without a `ref` tests against the previous state of this
+        # The targets to run the integration tests against. To test against an
+        # additional target, simply add it to this list.
+        # - An entry without a `ref` tests against the previous state of this
         #   repository: the base branch for pull requests, the commit before a
         #   push for pushes.
-        # - an entry with a `ref` tests against that branch or tag
+        # - An entry with a `ref` tests against that branch or tag of
+        #   rosenpass/rosenpass.
         target:
           - name: previous state
           - name: main branch
             ref: main
           - name: tag v0.2.3
             ref: v0.2.3
+        # list of architectures to run the integration tests on
+        # - `system`: Nix `system` to use
+        # - `runs-on`: GitHub runner option
+        arch:
+          - system: x86_64-linux
+            runs-on: ubicloud-standard-2
+            timeout-minutes: 360
+
+          # disabled until we get an arm64 runner that supports KVM
+          # - system: aarch64-linux
+          #   runs-on: ubicloud-standard-2-arm
+          #   timeout-minutes: 360
+
+          # disabled because it runs too slow for the regular CI
+          # - system: i686-linux
+          #   runs-on: ubicloud-standard-8
+          #   timeout-minutes: 144000
+
+          # disabled until this issue with NixOS tests on Darwin gets
+          # resolved: https://github.com/NixOS/nixpkgs/issues/294725
+          # - system: aarch64-darwin
+          #   runs-on: warp-macos-26-arm64-6x
+          #   timeout-minutes: 360
     steps:
       - uses: actions/checkout@v7
       - uses: cachix/install-nix-action@v31
@@ -62,125 +84,9 @@ jobs:
             exit 1
           fi
           REF_BEFORE="github:rosenpass/rosenpass/$TARGET_REF"
-          echo "INFO: running integration test:"
-          echo "    - against  rosenpass-old=\"$REF_BEFORE\""
-          echo "    - with new rosenpass-new=\"$REF_AFTER\""
           echo "REF_BEFORE=$REF_BEFORE" >> $GITHUB_ENV
           echo "REF_AFTER=$REF_AFTER" >> $GITHUB_ENV
       - name: Check
         run: |
           cd ./tests/integration
-          nix flake check --print-build-logs --system x86_64-linux --override-input rosenpass-old $REF_BEFORE --override-input rosenpass-new $REF_AFTER
-  # THE FOLLOWING TEST IS DISABLED FOR THE TIME BENG UNTIL WE GET AN ARM64 RUNNER THAT SUPPORTS KVM
-  #integration-tests-aarch64-linux:
-  #  name: Integration tests aarch64-linux
-  #  runs-on: ubicloud-standard-2-arm
-  #  steps:
-  #    - uses: actions/checkout@v7
-  #    - uses: cachix/install-nix-action@v31
-  #      with:
-  #        nix_path: nixpkgs=channel:nixos-unstable
-  #    - uses: cachix/cachix-action@v17
-  #      with:
-  #        name: rosenpass
-  #        authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
-  #    - name: Extract the reference of before and after for the integration tests.
-  #      run: |
-  #        EVENT_NAME="${{ github.event_name }}"
-  #        REF_BEFORE=""
-  #        REF_AFTER="path:../../"
-  #        if [[ "$EVENT_NAME" == "pull_request" ]]; then
-  #          echo "This CI run was triggered in the context of a pull request."
-  #          REF_BEFORE="github:rosenpass/rosenpass/${{ github.event.pull_request.base.ref }}"
-  #          #git checkout -B pr-${{ github.event.pull_request.number }}
-  #          REF_AFTER="git+file://../../../?ref=pr-${{ github.event.pull_request.number }}"
-  #        elif [[ "$EVENT_NAME" == "push" ]]; then
-  #          echo "This CI run was triggered in the context of a push."
-  #          REF_BEFORE="github:rosenpass/rosenpass/${{ github.event.before }}"
-  #          REF_AFTER="github:rosenpass/rosenpass/${{ github.event.after }}"
-  #          #git checkout -B ${{ github.ref_name }}
-  #        else
-  #          echo "ERROR: This CI run was not triggered in the context of a pull request or a push. Exiting with error."
-  #          exit 1
-  #        fi
-  #        echo "REF_BEFORE=$REF_BEFORE" >> $GITHUB_ENV
-  #        echo "REF_AFTER=$REF_AFTER" >> $GITHUB_ENV
-  #    - name: Check
-  #      run: |
-  #        cd ./tests/integration
-  #        # export QEMU_OPTS="-machine virt -cpu cortex-a57"
-  #        nix flake check --print-build-logs --system aarch64-linux --override-input rosenpass-old $REF_BEFORE --override-input rosenpass-new $REF_AFTER
-  #integration-tests-i686-linux:
-  #  name: Integration tests i686-linux
-  #  timeout-minutes: 144000
-  #  runs-on: ubicloud-standard-8
-  #  steps:
-  #    - uses: actions/checkout@v7
-  #    - uses: cachix/install-nix-action@v31
-  #      with:
-  #        nix_path: nixpkgs=channel:nixos-unstable
-  #    - uses: cachix/cachix-action@v17
-  #      with:
-  #        name: rosenpass
-  #        authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
-  #    - name: Extract the reference of before and after for the integration tests.
-  #      run: |
-  #        EVENT_NAME="${{ github.event_name }}"
-  #        REF_BEFORE=""
-  #        REF_AFTER="path:../../"
-  #        if [[ "$EVENT_NAME" == "pull_request" ]]; then
-  #          echo "This CI run was triggered in the context of a pull request."
-  #          REF_BEFORE="github:rosenpass/rosenpass/${{ github.event.pull_request.base.ref }}"
-  #          git checkout -B pr-${{ github.event.pull_request.number }}
-  #          REF_AFTER="git+file://../../../?ref=pr-${{ github.event.pull_request.number }}"
-  #        elif [[ "$EVENT_NAME" == "push" ]]; then
-  #          echo "This CI run was triggered in the context of a push."
-  #          REF_BEFORE="github:rosenpass/rosenpass/${{ github.event.before }}"
-  #          REF_AFTER="github:rosenpass/rosenpass/${{ github.event.after }}"
-  #        else
-  #          echo "ERROR: This CI run was not triggered in the context of a pull request or a push. Exiting with error."
-  #          exit 1
-  #        fi
-  #        echo "REF_BEFORE=$REF_BEFORE" >> $GITHUB_ENV
-  #        echo "REF_AFTER=$REF_AFTER" >> $GITHUB_ENV
-  #    - name: Check
-  #      run: |
-  #        cd ./tests/integration
-  #        nix flake check --print-build-logs --system i686-linux --override-input rosenpass-old $REF_BEFORE --override-input rosenpass-new $REF_AFTER
-  # THE FOLLOWING TEST IS DISABLED FOR THE TIME BENG UNTIL THIS ISSUE WITH NIXOS TESTS ON DARWIN GETS RESOLVED: https://github.com/NixOS/nixpkgs/issues/294725
-  #integration-tests-aarch64-darwin:
-  #  name: Integration tests aarch64-darwin
-  #  runs-on: warp-macos-26-arm64-6x
-  #  steps:
-  #    - uses: actions/checkout@v7
-  #    - uses: cachix/install-nix-action@v31
-  #      with:
-  #        nix_path: nixpkgs=channel:nixos-unstable
-  #    - uses: cachix/cachix-action@v17
-  #      with:
-  #        name: rosenpass
-  #        authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
-  #    - name: Extract the reference of before and after for the integration tests.
-  #      run: |
-  #        EVENT_NAME="${{ github.event_name }}"
-  #        REF_BEFORE=""
-  #        REF_AFTER="path:../../"
-  #        if [[ "$EVENT_NAME" == "pull_request" ]]; then
-  #          echo "This CI run was triggered in the context of a pull request."
-  #          REF_BEFORE="github:rosenpass/rosenpass/${{ github.event.pull_request.base.ref }}"
-  #          git checkout -B pr-${{ github.event.pull_request.number }}
-  #          REF_AFTER="git+file://../../../?ref=pr-${{ github.event.pull_request.number }}"
-  #        elif [[ "$EVENT_NAME" == "push" ]]; then
-  #          echo "This CI run was triggered in the context of a push."
-  #          REF_BEFORE="github:rosenpass/rosenpass/${{ github.event.before }}"
-  #          REF_AFTER="github:rosenpass/rosenpass/${{ github.event.after }}"
-  #        else
-  #          echo "ERROR: This CI run was not triggered in the context of a pull request or a push. Exiting with error."
-  #          exit 1
-  #        fi
-  #        echo "REF_BEFORE=$REF_BEFORE" >> $GITHUB_ENV
-  #        echo "REF_AFTER=$REF_AFTER" >> $GITHUB_ENV
-  #    - name: Check
-  #      run: |
-  #        cd ./tests/integration
-  #        nix flake check --print-build-logs --system aarch64-darwin --override-input rosenpass-old $REF_BEFORE --override-input rosenpass-new $REF_AFTER
+          nix flake check --print-build-logs --system ${{ matrix.arch.system }} --override-input rosenpass-old $REF_BEFORE --override-input rosenpass-new $REF_AFTER

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -47,6 +47,50 @@ jobs:
         run: |
           cd ./tests/integration
           nix flake check --print-build-logs --system x86_64-linux --override-input rosenpass-old $REF_BEFORE --override-input rosenpass-new $REF_AFTER
+  integration-tests-against-targets-x86_64-linux:
+    name: Integration tests x86_64-linux against ${{ matrix.target }}
+    runs-on: ubicloud-standard-2
+    strategy:
+      # necessary to continue running the other matrix target(s) when one matrix target fails
+      # docs: https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#jobsjob_idstrategyfail-fast
+      fail-fast: false
+      matrix:
+        # Targets (branches or tags of rosenpass/rosenpass) to test the current code against.
+        # To test against an additional target, simply add it to this list.
+        target:
+          - main
+          - v0.2.3
+    steps:
+      - uses: actions/checkout@v7
+      - uses: cachix/install-nix-action@v31
+        with:
+          nix_path: nixpkgs=channel:nixos-unstable
+      - uses: cachix/cachix-action@v17
+        with:
+          name: rosenpass
+          authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
+      - name: Extract the reference of before and after for the integration tests.
+        run: |
+          EVENT_NAME="${{ github.event_name }}"
+          REF_BEFORE="github:rosenpass/rosenpass/${{ matrix.target }}"
+          REF_AFTER="path:../../"
+          if [[ "$EVENT_NAME" == "pull_request" ]]; then
+            echo "This CI run was triggered in the context of a pull request."
+            git checkout -B pr-${{ github.event.pull_request.number }}
+            REF_AFTER="git+file://../../../?ref=pr-${{ github.event.pull_request.number }}"
+          elif [[ "$EVENT_NAME" == "push" ]]; then
+            echo "This CI run was triggered in the context of a push."
+            REF_AFTER="github:rosenpass/rosenpass/${{ github.event.after }}"
+          else
+            echo "ERROR: This CI run was not triggered in the context of a pull request or a push. Exiting with error."
+            exit 1
+          fi
+          echo "REF_BEFORE=$REF_BEFORE" >> $GITHUB_ENV
+          echo "REF_AFTER=$REF_AFTER" >> $GITHUB_ENV
+      - name: Check
+        run: |
+          cd ./tests/integration
+          nix flake check --print-build-logs --system x86_64-linux --override-input rosenpass-old $REF_BEFORE --override-input rosenpass-new $REF_AFTER
   # THE FOLLOWING TEST IS DISABLED FOR THE TIME BENG UNTIL WE GET AN ARM64 RUNNER THAT SUPPORTS KVM
   #integration-tests-aarch64-linux:
   #  name: Integration tests aarch64-linux

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -30,7 +30,7 @@ jobs:
           REF_AFTER="path:../../"
           if [[ "$EVENT_NAME" == "pull_request" ]]; then
             echo "This CI run was triggered in the context of a pull request."
-            REF_BEFORE="github:rosenpass/rosenpass/main"
+            REF_BEFORE="github:rosenpass/rosenpass/${{ github.event.pull_request.base.ref }}"
             git checkout -B pr-${{ github.event.pull_request.number }}
             REF_AFTER="git+file://../../../?ref=pr-${{ github.event.pull_request.number }}"
           elif [[ "$EVENT_NAME" == "push" ]]; then
@@ -67,7 +67,7 @@ jobs:
   #        REF_AFTER="path:../../"
   #        if [[ "$EVENT_NAME" == "pull_request" ]]; then
   #          echo "This CI run was triggered in the context of a pull request."
-  #          REF_BEFORE="github:rosenpass/rosenpass/main"
+  #          REF_BEFORE="github:rosenpass/rosenpass/${{ github.event.pull_request.base.ref }}"
   #          #git checkout -B pr-${{ github.event.pull_request.number }}
   #          REF_AFTER="git+file://../../../?ref=pr-${{ github.event.pull_request.number }}"
   #        elif [[ "$EVENT_NAME" == "push" ]]; then
@@ -106,7 +106,7 @@ jobs:
   #        REF_AFTER="path:../../"
   #        if [[ "$EVENT_NAME" == "pull_request" ]]; then
   #          echo "This CI run was triggered in the context of a pull request."
-  #          REF_BEFORE="github:rosenpass/rosenpass/main"
+  #          REF_BEFORE="github:rosenpass/rosenpass/${{ github.event.pull_request.base.ref }}"
   #          git checkout -B pr-${{ github.event.pull_request.number }}
   #          REF_AFTER="git+file://../../../?ref=pr-${{ github.event.pull_request.number }}"
   #        elif [[ "$EVENT_NAME" == "push" ]]; then
@@ -143,7 +143,7 @@ jobs:
   #        REF_AFTER="path:../../"
   #        if [[ "$EVENT_NAME" == "pull_request" ]]; then
   #          echo "This CI run was triggered in the context of a pull request."
-  #          REF_BEFORE="github:rosenpass/rosenpass/main"
+  #          REF_BEFORE="github:rosenpass/rosenpass/${{ github.event.pull_request.base.ref }}"
   #          git checkout -B pr-${{ github.event.pull_request.number }}
   #          REF_AFTER="git+file://../../../?ref=pr-${{ github.event.pull_request.number }}"
   #        elif [[ "$EVENT_NAME" == "push" ]]; then


### PR DESCRIPTION
- closes #1067 
- fix: CI integration test now checks against the PR base branch and not against hard-coded `main`
- feature: CI integreation test now always runs agains `main` and `v0.2.3` (and still also against the PR base branch / previous commit)
- merge various CI integration tests with different targets and different architectures into one matrix CI job
- ❌️ failing against `v0.2.3` is expected, see #1068
- ❌️ potentially failing protocol benchmark is probably fine (mid-ns range anyways, so definitely hard to benchmark); this has also happened many times before and is generally quite flakey.