### PR TITLE
Fix cargo deny warnings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1324,7 +1324,8 @@ checksum = "3eaf3ede3fee6db1a4c2ee091bf8a8b4dccdc6d17f656fb07896ee72867612f2"
 [[package]]
 name = "libcrux-macros"
 version = "0.0.3"
-source = "git+https://github.com/cryspen/libcrux.git?rev=0ab6d2dd9c1f#0ab6d2dd9c1f39c82b1125a566d6befb38feea28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffd6aa2dcd5be681662001b81d493f1569c6d49a32361f470b0c955465cd0338"
 dependencies = [
  "quote",
  "syn 2.0.119",
@@ -1332,8 +1333,9 @@ dependencies = [
 
 [[package]]
 name = "libcrux-test-utils"
-version = "0.0.2"
-source = "git+https://github.com/cryspen/libcrux.git?rev=0ab6d2dd9c1f#0ab6d2dd9c1f39c82b1125a566d6befb38feea28"
+version = "0.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4ea567a8e29e573dd745e7c53ca2828482b91ef74ed836b1433210ec3511026"
 dependencies = [
  "libcrux-macros",
 ]

--- a/deny.toml
+++ b/deny.toml
@@ -110,7 +110,7 @@ unknown-git = "warn"
 # if not specified. If it is specified but empty, no registries are allowed.
 allow-registry = ["https://github.com/rust-lang/crates.io-index"]
 # List of URLs for allowed Git repositories
-allow-git = ["git+https://github.com/rosenpass/memsec.git?branch=master"]
+allow-git = []
 
 [sources.allow-org]
 # github.com organizations to allow git sources for

--- a/deny.toml
+++ b/deny.toml
@@ -110,7 +110,7 @@ unknown-git = "warn"
 # if not specified. If it is specified but empty, no registries are allowed.
 allow-registry = ["https://github.com/rust-lang/crates.io-index"]
 # List of URLs for allowed Git repositories
-allow-git = []
+allow-git = ["git+https://github.com/rosenpass/uds"]
 
 [sources.allow-org]
 # github.com organizations to allow git sources for

--- a/pkgs/rosenpass.nix
+++ b/pkgs/rosenpass.nix
@@ -86,7 +86,6 @@ rustPlatform.buildRustPackage {
     lockFile = src + "/Cargo.lock";
     outputHashes = {
       "uds-0.4.2" = "sha256-qlxr/iJt2AV4WryePIvqm/8/MK/iqtzegztNliR93W8=";
-      "libcrux-macros-0.0.3" = "sha256-Tb5uRirwhRhoFEK8uu1LvXl89h++40pxzZ+7kXe8RAI=";
     };
   };
 

--- a/rosenpass/Cargo.toml
+++ b/rosenpass/Cargo.toml
@@ -172,7 +172,7 @@ rustix = { version = "1.1.4", features = [
 uds = { git = "https://github.com/rosenpass/uds", optional = true, features = [
   "mio_1xx",
 ] }
-libcrux-test-utils = { git = "https://github.com/cryspen/libcrux.git", rev = "0ab6d2dd9c1f", optional = true }
+libcrux-test-utils = { version = "0.0.3", optional = true }
 assert_tv = { version = "0.6" } #Dev dependencies
 base64 = { version = "0.23.0" }
 serde_json = { version = "1.0.140" }

--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -449,6 +449,10 @@ criteria = "safe-to-deploy"
 version = "0.2.189"
 criteria = "safe-to-deploy"
 
+[[exemptions.libcrux-test-utils]]
+version = "0.0.3"
+criteria = "safe-to-deploy"
+
 [[exemptions.libfuzzer-sys]]
 version = "0.4.13"
 criteria = "safe-to-deploy"

--- a/supply-chain/imports.lock
+++ b/supply-chain/imports.lock
@@ -1099,6 +1099,12 @@ criteria = "safe-to-deploy"
 version = "0.4.3"
 aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
 
+[[audits.mozilla.audits.libcrux-macros]]
+who = "Dana Keeler <dkeeler@mozilla.com>"
+criteria = "safe-to-deploy"
+version = "0.0.3"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
 [[audits.mozilla.audits.nix]]
 who = "Alex Franchuk <afranchuk@mozilla.com>"
 criteria = "safe-to-deploy"


### PR DESCRIPTION
- removes/adds proper exceptions for `memsec` and `uds` to `deny.toml` for using git sources instead of crates.io
- uses `libcrux-test-utils` from crates.io instead of old hard-coded commit.