### PR TITLE
upgrade `tests/integration/flake.nix` to NixOS 26.05 and `nix flake update`

### DIFF
--- a/tests/integration/flake.lock
+++ b/tests/integration/flake.lock
@@ -7,11 +7,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1751413152,
-        "narHash": "sha256-Tyw1RjYEsp5scoigs1384gIg6e0GoBVjms4aXFfRssQ=",
+        "lastModified": 1788450739,
+        "narHash": "sha256-glZLQlzIn1fXH6PazR2iUmTo7kzzyYSshrWhLS9TqCU=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "77826244401ea9de6e3bac47c2db46005e1f30b5",
+        "rev": "31729ca8cbdb4fa927b34e5f4353e6a83f39e993",
         "type": "github"
       },
       "original": {
@@ -25,11 +25,11 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1726560853,
-        "narHash": "sha256-X6rJYSESBVr3hBoH0WbKE5KvhPU5bloyZ2L4K60/fPQ=",
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "c1dfcf08411b08f6b8615f7d8971a2bfa81d5e8a",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
         "type": "github"
       },
       "original": {
@@ -56,10 +56,68 @@
         "type": "github"
       }
     },
+    "flake-utils_3": {
+      "inputs": {
+        "systems": "systems_3"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "flake-utils_4": {
+      "inputs": {
+        "systems": "systems_4"
+      },
+      "locked": {
+        "lastModified": 1726560853,
+        "narHash": "sha256-X6rJYSESBVr3hBoH0WbKE5KvhPU5bloyZ2L4K60/fPQ=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "c1dfcf08411b08f6b8615f7d8971a2bfa81d5e8a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
     "nix-vm-test": {
       "inputs": {
         "nixpkgs": [
           "rosenpass-new",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1779799925,
+        "narHash": "sha256-kMBQRZjb2A+qVpuNCiRoqMhDElkP/jR2m9Lu7PAt7M4=",
+        "owner": "numtide",
+        "repo": "nix-vm-test",
+        "rev": "d41d806a5c9699ab9cbac5a698aac889c83fa57e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "nix-vm-test",
+        "type": "github"
+      }
+    },
+    "nix-vm-test_2": {
+      "inputs": {
+        "nixpkgs": [
+          "rosenpass-new",
+          "rosenpassOld",
           "nixpkgs"
         ]
       },
@@ -77,10 +135,32 @@
         "type": "github"
       }
     },
-    "nix-vm-test_2": {
+    "nix-vm-test_3": {
       "inputs": {
         "nixpkgs": [
           "rosenpass-old",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1779799925,
+        "narHash": "sha256-kMBQRZjb2A+qVpuNCiRoqMhDElkP/jR2m9Lu7PAt7M4=",
+        "owner": "numtide",
+        "repo": "nix-vm-test",
+        "rev": "d41d806a5c9699ab9cbac5a698aac889c83fa57e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "nix-vm-test",
+        "type": "github"
+      }
+    },
+    "nix-vm-test_4": {
+      "inputs": {
+        "nixpkgs": [
+          "rosenpass-old",
+          "rosenpassOld",
           "nixpkgs"
         ]
       },
@@ -100,48 +180,48 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1735563628,
-        "narHash": "sha256-OnSAY7XDSx7CtDoqNh8jwVwh4xNL/2HaJxGjryLWzX8=",
+        "lastModified": 1788405554,
+        "narHash": "sha256-r2f1oUwixlgq9zOdYLqJLfS/lWBT60/IITjhTKI59JU=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "b134951a4c9f3c995fd7be05f3243f8ecd65d798",
+        "rev": "a5cc6f2c37bf518436dc8d1c288ccd0c43c2f4c4",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixos-24.05",
+        "ref": "nixos-26.05",
         "repo": "nixpkgs",
         "type": "github"
       }
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1728193676,
-        "narHash": "sha256-PbDWAIjKJdlVg+qQRhzdSor04bAPApDqIv2DofTyynk=",
+        "lastModified": 1780453794,
+        "narHash": "sha256-bXMRa9VTsHSPXL4Cw8R6JJLQeY3Y/IP4+YJCYVmQ7FY=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "ecbc1ca8ffd6aea8372ad16be9ebbb39889e55b6",
+        "rev": "6b316287bae2ee04c9b93c8c858d930fd07d7338",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixos-24.05",
+        "ref": "nixos-26.05",
         "repo": "nixpkgs",
         "type": "github"
       }
     },
     "nixpkgs_3": {
       "locked": {
-        "lastModified": 1728193676,
-        "narHash": "sha256-PbDWAIjKJdlVg+qQRhzdSor04bAPApDqIv2DofTyynk=",
+        "lastModified": 1780453794,
+        "narHash": "sha256-bXMRa9VTsHSPXL4Cw8R6JJLQeY3Y/IP4+YJCYVmQ7FY=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "ecbc1ca8ffd6aea8372ad16be9ebbb39889e55b6",
+        "rev": "6b316287bae2ee04c9b93c8c858d930fd07d7338",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixos-24.05",
+        "ref": "nixos-26.05",
         "repo": "nixpkgs",
         "type": "github"
       }
@@ -159,15 +239,16 @@
         "flake-utils": "flake-utils",
         "nix-vm-test": "nix-vm-test",
         "nixpkgs": "nixpkgs_2",
-        "rust-overlay": "rust-overlay",
-        "treefmt-nix": "treefmt-nix"
+        "rosenpassOld": "rosenpassOld",
+        "rust-overlay": "rust-overlay_2",
+        "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1752081615,
-        "narHash": "sha256-g9jC1HNCMSMPzArA8RCPGaxCCFH6dzQuq20RDsRwRT8=",
+        "lastModified": 1788447081,
+        "narHash": "sha256-EEVXB2lOFvTjyA6mN4oav2XLCMApfcfDwzRH6EMVPe4=",
         "owner": "rosenpass",
         "repo": "rosenpass",
-        "rev": "3e03e479350551d11b81bde1bb55f5fdf8246f7c",
+        "rev": "b1f029dda2db3d104aa689fe1fdabcab485c3ec0",
         "type": "github"
       },
       "original": {
@@ -179,18 +260,19 @@
     },
     "rosenpass-old": {
       "inputs": {
-        "flake-utils": "flake-utils_2",
-        "nix-vm-test": "nix-vm-test_2",
+        "flake-utils": "flake-utils_3",
+        "nix-vm-test": "nix-vm-test_3",
         "nixpkgs": "nixpkgs_3",
-        "rust-overlay": "rust-overlay_2",
-        "treefmt-nix": "treefmt-nix_2"
+        "rosenpassOld": "rosenpassOld_2",
+        "rust-overlay": "rust-overlay_4",
+        "treefmt-nix": "treefmt-nix_4"
       },
       "locked": {
-        "lastModified": 1752081615,
-        "narHash": "sha256-g9jC1HNCMSMPzArA8RCPGaxCCFH6dzQuq20RDsRwRT8=",
+        "lastModified": 1788447081,
+        "narHash": "sha256-EEVXB2lOFvTjyA6mN4oav2XLCMApfcfDwzRH6EMVPe4=",
         "owner": "rosenpass",
         "repo": "rosenpass",
-        "rev": "3e03e479350551d11b81bde1bb55f5fdf8246f7c",
+        "rev": "b1f029dda2db3d104aa689fe1fdabcab485c3ec0",
         "type": "github"
       },
       "original": {
@@ -200,10 +282,63 @@
         "type": "github"
       }
     },
+    "rosenpassOld": {
+      "inputs": {
+        "flake-utils": "flake-utils_2",
+        "nix-vm-test": "nix-vm-test_2",
+        "nixpkgs": [
+          "rosenpass-new",
+          "nixpkgs"
+        ],
+        "rust-overlay": "rust-overlay",
+        "treefmt-nix": "treefmt-nix"
+      },
+      "locked": {
+        "lastModified": 1754748821,
+        "narHash": "sha256-mMggTZDC97lLvKNOLtDz3GBjjxXFD++e1s0RZsVH/vI=",
+        "owner": "rosenpass",
+        "repo": "rosenpass",
+        "rev": "916a9ebb7133f0b22057fb097a473217f261928a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "rosenpass",
+        "repo": "rosenpass",
+        "rev": "916a9ebb7133f0b22057fb097a473217f261928a",
+        "type": "github"
+      }
+    },
+    "rosenpassOld_2": {
+      "inputs": {
+        "flake-utils": "flake-utils_4",
+        "nix-vm-test": "nix-vm-test_4",
+        "nixpkgs": [
+          "rosenpass-old",
+          "nixpkgs"
+        ],
+        "rust-overlay": "rust-overlay_3",
+        "treefmt-nix": "treefmt-nix_3"
+      },
+      "locked": {
+        "lastModified": 1754748821,
+        "narHash": "sha256-mMggTZDC97lLvKNOLtDz3GBjjxXFD++e1s0RZsVH/vI=",
+        "owner": "rosenpass",
+        "repo": "rosenpass",
+        "rev": "916a9ebb7133f0b22057fb097a473217f261928a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "rosenpass",
+        "repo": "rosenpass",
+        "rev": "916a9ebb7133f0b22057fb097a473217f261928a",
+        "type": "github"
+      }
+    },
     "rust-overlay": {
       "inputs": {
         "nixpkgs": [
           "rosenpass-new",
+          "rosenpassOld",
           "nixpkgs"
         ]
       },
@@ -224,7 +359,29 @@
     "rust-overlay_2": {
       "inputs": {
         "nixpkgs": [
+          "rosenpass-new",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1780629589,
+        "narHash": "sha256-oHysjxZdaEqkmyDpN8G1bl3V+r9uyRD1O66bH0bq0Cs=",
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "rev": "7a5a1c0a5cb86a28224304309b68f050835fd1f6",
+        "type": "github"
+      },
+      "original": {
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "type": "github"
+      }
+    },
+    "rust-overlay_3": {
+      "inputs": {
+        "nixpkgs": [
           "rosenpass-old",
+          "rosenpassOld",
           "nixpkgs"
         ]
       },
@@ -234,6 +391,27 @@
         "owner": "oxalica",
         "repo": "rust-overlay",
         "rev": "730fd8e82799219754418483fabe1844262fd1e2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "type": "github"
+      }
+    },
+    "rust-overlay_4": {
+      "inputs": {
+        "nixpkgs": [
+          "rosenpass-old",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1780629589,
+        "narHash": "sha256-oHysjxZdaEqkmyDpN8G1bl3V+r9uyRD1O66bH0bq0Cs=",
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "rev": "7a5a1c0a5cb86a28224304309b68f050835fd1f6",
         "type": "github"
       },
       "original": {
@@ -272,10 +450,41 @@
         "type": "github"
       }
     },
+    "systems_3": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "systems_4": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
     "treefmt-nix": {
       "inputs": {
         "nixpkgs": [
           "rosenpass-new",
+          "rosenpassOld",
           "nixpkgs"
         ]
       },
@@ -296,7 +505,29 @@
     "treefmt-nix_2": {
       "inputs": {
         "nixpkgs": [
+          "rosenpass-new",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1780220602,
+        "narHash": "sha256-eynAfOmbmxJnkp7YewvCEbShNnnYJ9gLLqkzsYtBPeM=",
+        "owner": "numtide",
+        "repo": "treefmt-nix",
+        "rev": "db947814a175b7ca6ded66e21383d938df01c227",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "treefmt-nix",
+        "type": "github"
+      }
+    },
+    "treefmt-nix_3": {
+      "inputs": {
+        "nixpkgs": [
           "rosenpass-old",
+          "rosenpassOld",
           "nixpkgs"
         ]
       },
@@ -306,6 +537,27 @@
         "owner": "numtide",
         "repo": "treefmt-nix",
         "rev": "815e4121d6a5d504c0f96e5be2dd7f871e4fd99d",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "treefmt-nix",
+        "type": "github"
+      }
+    },
+    "treefmt-nix_4": {
+      "inputs": {
+        "nixpkgs": [
+          "rosenpass-old",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1780220602,
+        "narHash": "sha256-eynAfOmbmxJnkp7YewvCEbShNnnYJ9gLLqkzsYtBPeM=",
+        "owner": "numtide",
+        "repo": "treefmt-nix",
+        "rev": "db947814a175b7ca6ded66e21383d938df01c227",
         "type": "github"
       },
       "original": {

--- a/tests/integration/flake.nix
+++ b/tests/integration/flake.nix
@@ -4,7 +4,7 @@
   inputs = {
     flake-parts.url = "github:hercules-ci/flake-parts";
     flake-parts.inputs.nixpkgs-lib.follows = "nixpkgs";
-    nixpkgs.url = "github:NixOS/nixpkgs/nixos-24.05";
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-26.05";
     # Override or change these inputs for testing new Integrations. They are overriden automatically when run in the CI
     rosenpass-old.url = "github:rosenpass/rosenpass/main";
     rosenpass-new.url = "github:rosenpass/rosenpass/main";


### PR DESCRIPTION
- closes #1073
- :x: flickering McEliece keygen time causes benchmark CI test to fail – this is probably fine:
  - new time is roughly similar to `main` again
  - this time is simply not important for the protocol