### PR TITLE
Begin work on highly secure transports for the API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2010,6 +2010,7 @@ dependencies = [
  "assert_tv",
  "base64 0.23.1",
  "base64ct",
+ "bitflags 2.13.1",
  "blake2",
  "chacha20poly1305",
  "clap",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2036,6 +2036,7 @@ dependencies = [
  "netlink-packet-core",
  "netlink-packet-generic",
  "netlink-packet-wireguard",
+ "num-traits",
  "num_enum",
  "oqs-sys",
  "paste",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2058,6 +2058,7 @@ dependencies = [
  "tempfile",
  "test_bin",
  "thiserror 2.0.20",
+ "tinyvec",
  "tokio",
  "toml",
  "typenum",
@@ -2512,6 +2513,12 @@ dependencies = [
  "serde",
  "serde_json",
 ]
+
+[[package]]
+name = "tinyvec"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa5fdc3bce6191a1dbc8c02d5c8bffcf557bafa17c124c5264a458f1b0613fa"
 
 [[package]]
 name = "tokio"

--- a/rosenpass/Cargo.toml
+++ b/rosenpass/Cargo.toml
@@ -168,6 +168,7 @@ rustix = { version = "1.1.4", features = [
   "net",
   "fs",
   "process",
+  "mm",
 ] } # Broker dependencies (might need cleanup or changes)
 uds = { git = "https://github.com/rosenpass/uds", optional = true, features = [
   "mio_1xx",
@@ -234,11 +235,6 @@ test_bin = "0.6"
 stacker = "0.1.21"
 serial_test = "4.0"
 tempfile = "3"
-rustix = { version = "1.1.4", features = [
-  "net",
-  "fs",
-  "process",
-] } # Broker dependencies (might need cleanup or changes)
 serde_json = { version = "1.0.140" }
 # dependencies of `rosenpass-ciphers`, now `rosenpass::internal::ciphers`
 rand = "0.10"

--- a/rosenpass/Cargo.toml
+++ b/rosenpass/Cargo.toml
@@ -203,7 +203,7 @@ wireguard-uapi = { version = "3.0.0", features = ["xplatform"] }
 postcard = { version = "1.1.1", default-features = false, features = [
   "alloc",
 ] } # Socket handler only
-libc = { version = "0.2", optional = true } # Problem in CI, unknown reasons: dependency (libc) specified without providing a local path, Git repository, version, or workspace dependency to use # Maybe something about the combination of features and optional crates?
+libc = { version = "0.2" } # Always required for some features missing in rustix
 # dependencies of `rosenpass-oqs`, now moved to `rosenpass::internal::oqs`:
 oqs-sys = { version = "0.8", default-features = false, features = [
   'classic_mceliece',
@@ -252,7 +252,6 @@ experiment_api = [
   "dep:hex-literal",
   "dep:uds",
   "dep:command-fds",
-  "dep:libc",                           # From `rosenpass-wireguard-broker`
   "dep:tokio",                          # From `rosenpass-wireguard-broker-socket-handler`
   "experiment_file_descriptor_passing",
 ]
@@ -272,7 +271,6 @@ rp = [
   "dep:netlink-packet-core",
   "dep:netlink-packet-generic",
   "dep:netlink-packet-wireguard",
-  "dep:libc",
 ]
 # features of `rosenpass_util`:
 experiment_file_descriptor_passing = ["dep:uds"]

--- a/rosenpass/Cargo.toml
+++ b/rosenpass/Cargo.toml
@@ -189,6 +189,7 @@ tokio = { version = "1.46", optional = true, features = [
 base64ct = { version = "1.6.0", default-features = false }
 typenum = { version = "1.17.0" }
 bitflags = { version = "2.9.3" }
+tinyvec = { version = "1.10.0" }
 num-traits = { version = "0.2.19" }
 # dependencies of `rosenpass-ciphers`, now `rosenpass::internal::ciphers`
 chacha20poly1305 = { version = "0.10.1", default-features = false, features = [

--- a/rosenpass/Cargo.toml
+++ b/rosenpass/Cargo.toml
@@ -188,6 +188,7 @@ tokio = { version = "1.46", optional = true, features = [
 ] }
 base64ct = { version = "1.6.0", default-features = false }
 typenum = { version = "1.17.0" }
+num-traits = { version = "0.2.19" }
 # dependencies of `rosenpass-ciphers`, now `rosenpass::internal::ciphers`
 chacha20poly1305 = { version = "0.10.1", default-features = false, features = [
   "std",

--- a/rosenpass/Cargo.toml
+++ b/rosenpass/Cargo.toml
@@ -188,6 +188,7 @@ tokio = { version = "1.46", optional = true, features = [
 ] }
 base64ct = { version = "1.6.0", default-features = false }
 typenum = { version = "1.17.0" }
+bitflags = { version = "2.9.3" }
 num-traits = { version = "0.2.19" }
 # dependencies of `rosenpass-ciphers`, now `rosenpass::internal::ciphers`
 chacha20poly1305 = { version = "0.10.1", default-features = false, features = [

--- a/rosenpass/src/api/boilerplate/request_ref.rs
+++ b/rosenpass/src/api/boilerplate/request_ref.rs
@@ -44,13 +44,13 @@ impl<B: SplitByteSlice> RequestRef<B> {
         RequestRefMaker::new(buf)?.parse()
     }
 
-    /// Produce a [ResponseRef] from the prefix of a raw message buffer,
+    /// Produce a [ResponseRef](crate::api::ResponseRef) from the prefix of a raw message buffer,
     /// reading the type from the buffer.
     pub fn parse_from_prefix(buf: B) -> anyhow::Result<Self> {
         RequestRefMaker::new(buf)?.from_prefix()?.parse()
     }
 
-    /// Produce a [ResponseRef] from the suffix of a raw message buffer,
+    /// Produce a [ResponseRef](crate::api::ResponseRef) from the suffix of a raw message buffer,
     /// reading the type from the buffer.
     pub fn parse_from_suffix(buf: B) -> anyhow::Result<Self> {
         RequestRefMaker::new(buf)?.from_suffix()?.parse()

--- a/rosenpass/src/api/boilerplate/server.rs
+++ b/rosenpass/src/api/boilerplate/server.rs
@@ -87,7 +87,7 @@ pub trait Server {
     /// # API Return Status
     ///
     /// 1. [crate::api::add_listen_socket_response_status::OK] - Indicates success
-    /// 2. [add_listen_socket_response_status::INVALID_REQUEST] – Malformed request; could be:
+    /// 2. [crate::api::add_listen_socket_response_status::INVALID_REQUEST] – Malformed request; could be:
     ///     - Missing file descriptors for public key
     ///     - Invalid file descriptor type
     /// 3. [crate::api::add_listen_socket_response_status::INTERNAL_ERROR] – Some other, non-fatal error

--- a/rosenpass/src/internal/ciphers/hash_domain.rs
+++ b/rosenpass/src/internal/ciphers/hash_domain.rs
@@ -78,7 +78,7 @@ impl HashDomain {
     /// it evaluates
     #[cfg_attr(
         feature = "expose_internal_modules",
-        doc = "[`KeyedHashInstance::keyed_hash`](crate::internal::ciphers_traits::primitives::keyed_hash::KeyedHashInstance::keyed_hash)"
+        doc = "[`KeyedHashInstance::keyed_hash`](crate::internal::cipher_traits::primitives::keyed_hash::KeyedHashInstance::keyed_hash)"
     )]
     #[cfg_attr(
         not(feature = "expose_internal_modules"),
@@ -139,7 +139,7 @@ impl HashDomainNamespace {
     /// it evaluates
     #[cfg_attr(
         feature = "expose_internal_modules",
-        doc = "[`KeyedHashInstance::keyed_hash`](crate::internal::ciphers_traits::primitives::keyed_hash::KeyedHashInstance::keyed_hash)"
+        doc = "[`KeyedHashInstance::keyed_hash`](crate::internal::cipher_traits::primitives::keyed_hash::KeyedHashInstance::keyed_hash)"
     )]
     #[cfg_attr(
         not(feature = "expose_internal_modules"),
@@ -167,7 +167,7 @@ impl SecretHashDomain {
     /// Create a new [SecretHashDomain] with the given key `k` and data `d` by calling
     #[cfg_attr(
         feature = "expose_internal_modules",
-        doc = "[`KeyedHashInstance::keyed_hash`](crate::internal::ciphers_traits::primitives::keyed_hash::KeyedHashInstance::keyed_hash)"
+        doc = "[`KeyedHashInstance::keyed_hash`](crate::internal::cipher_traits::primitives::keyed_hash::KeyedHashInstance::keyed_hash)"
     )]
     #[cfg_attr(
         not(feature = "expose_internal_modules"),
@@ -211,7 +211,7 @@ impl SecretHashDomain {
     /// it evaluates
     #[cfg_attr(
         feature = "expose_internal_modules",
-        doc = "[`KeyedHashInstance::keyed_hash`](crate::internal::ciphers_traits::primitives::keyed_hash::KeyedHashInstance::keyed_hash)"
+        doc = "[`KeyedHashInstance::keyed_hash`](crate::internal::cipher_traits::primitives::keyed_hash::KeyedHashInstance::keyed_hash)"
     )]
     #[cfg_attr(
         not(feature = "expose_internal_modules"),
@@ -286,7 +286,7 @@ impl SecretHashDomainNamespace {
     /// it evaluates
     #[cfg_attr(
         feature = "expose_internal_modules",
-        doc = "[`KeyedHashInstance::keyed_hash`](crate::internal::ciphers_traits::primitives::keyed_hash::KeyedHashInstance::keyed_hash)"
+        doc = "[`KeyedHashInstance::keyed_hash`](crate::internal::cipher_traits::primitives::keyed_hash::KeyedHashInstance::keyed_hash)"
     )]
     #[cfg_attr(
         not(feature = "expose_internal_modules"),

--- a/rosenpass/src/internal/util/convert.rs
+++ b/rosenpass/src/internal/util/convert.rs
@@ -1,0 +1,85 @@
+//! Additional helpers to [std::convert]: Traits for conversions between types.
+
+/// Variant of [std::convert::Into] with an explicitly specified type.
+///
+/// This facilitates method chaining.
+///
+/// # Examples
+///
+/// We can create a nicer implementation of the following function using this extension trait
+///
+/// ```
+/// use rosenpass::internal::util::convert::IntoTypeExt;
+///
+/// fn encode_char_u32_be_1(c: char) -> [u8; 4] {
+///     let i : u32 = c.into();
+///     i.to_be_bytes()
+/// }
+///
+/// fn encode_char_u32_be_2(c: char) -> [u8; 4] {
+///     c.into_type::<u32>().to_be_bytes()
+/// }
+///
+/// assert_eq!(encode_char_u32_be_1('X'), [0x00, 0x00, 0x00, 0x58]);
+/// assert_eq!(encode_char_u32_be_1('X'), encode_char_u32_be_2('X'));
+///
+/// ```
+pub trait IntoTypeExt {
+    /// Variant of [std::convert::Into] with explicitly specified type.
+    ///
+    /// # Examples
+    ///
+    /// See [IntoTypeExt].
+    fn into_type<T>(self) -> T
+    where
+        Self: Into<T>,
+    {
+        self.into()
+    }
+}
+
+impl<T> IntoTypeExt for T {}
+
+/// Variant of [std::convert::TryInto] with an explicitly specified type.
+///
+/// This facilitates method chaining.
+///
+/// # Examples
+///
+/// We can create a nicer implementation of the following function using this extension trait
+///
+/// ```
+/// use rosenpass::internal::util::convert::TryIntoTypeExt;
+/// use rosenpass::internal::util::result::OkExt;
+///
+/// fn encode_char_u16_be_1(c: char) -> Result<[u8; 2], <char as TryInto<u16>>::Error> {
+///     let i : u16 = c.try_into()?;
+///     Ok(i.to_be_bytes())
+/// }
+///
+/// fn encode_char_u16_be_2(c: char) -> Result<[u8; 2], <char as TryInto<u16>>::Error> {
+///     c.try_into_type::<u16>()?.to_be_bytes().ok()
+/// }
+///
+/// assert_eq!(encode_char_u16_be_1('X'), Ok([0x00, 0x58]));
+/// assert_eq!(encode_char_u16_be_1('X'), encode_char_u16_be_2('X'));
+///
+/// const HEART_CAT : char = '😻'; // 1F63B
+/// assert!(encode_char_u16_be_1(HEART_CAT).is_err());
+/// assert_eq!(encode_char_u16_be_1(HEART_CAT), encode_char_u16_be_2(HEART_CAT));
+/// ```
+pub trait TryIntoTypeExt {
+    /// Variant of [std::convert::TryInto] with explicitly specified type.
+    ///
+    /// # Examples
+    ///
+    /// See [TryIntoTypeExt].
+    fn try_into_type<T>(self) -> Result<T, <Self as TryInto<T>>::Error>
+    where
+        Self: TryInto<T>,
+    {
+        self.try_into()
+    }
+}
+
+impl<T> TryIntoTypeExt for T {}

--- a/rosenpass/src/internal/util/int/mod.rs
+++ b/rosenpass/src/internal/util/int/mod.rs
@@ -1,0 +1,3 @@
+//! Helpers for working with integer types
+
+pub mod modular;

--- a/rosenpass/src/internal/util/int/mod.rs
+++ b/rosenpass/src/internal/util/int/mod.rs
@@ -1,3 +1,4 @@
 //! Helpers for working with integer types
 
 pub mod modular;
+pub mod u64uint;

--- a/rosenpass/src/internal/util/int/modular.rs
+++ b/rosenpass/src/internal/util/int/modular.rs
@@ -1,0 +1,276 @@
+//! Numeric types for modular arithmetic
+
+use num_traits::{
+    CheckedMul, Euclid, Num, Unsigned, WrappingNeg, Zero, ops::overflowing::OverflowingAdd,
+};
+
+/// Summary-trait for numeric types that can serve as the basis for ModuleBase
+pub trait ModuleBase: Num + Ord + Copy + Unsigned + OverflowingAdd + Zero {}
+impl<T> ModuleBase for T where T: Num + Ord + Copy + Unsigned + OverflowingAdd + Zero {}
+
+/// Represents a modulus; i.e. the range of values some number type is allowed to use.
+///
+/// This is based on some inner representation.
+///
+/// This is not just a value of the underlying representation, because it also supports the modulus
+/// [Self::new_full_range()], which indicates that the full range of the underlying type is to be
+/// supported.
+///
+/// Note that zero is not a valid modulus
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub struct Modulus<T: ModuleBase> {
+    /// Inner representation of the type
+    modulus: T,
+}
+
+impl<T: ModuleBase> Modulus<T> {
+    /// Create a new [Self] without any checks
+    fn raw_new(modulus: T) -> Self {
+        Self { modulus }
+    }
+
+    /// Create a new [Self] that indicates that the full range of the underlying type is to be used
+    pub fn new_full_range() -> Self {
+        Self::raw_new(T::zero())
+    }
+
+    /// Try to create a new [Self]. Will return None only if `modulus == 0`
+    pub fn try_new(modulus: T) -> Option<Self> {
+        match modulus == T::zero() {
+            true => None,
+            false => Some(Self::raw_new(modulus)),
+        }
+    }
+
+    /// Like [Self::try_new] but will panic if `modulus == 0`
+    ///
+    /// # Panic
+    ///
+    /// Will panic if `modulus == 0`
+    pub fn new_or_panic(modulus: T) -> Self {
+        match Self::try_new(modulus) {
+            None => panic!("Can not create Module with modulus zero!"),
+            Some(me) => me,
+        }
+    }
+
+    /// Check if this [Self] represents the full range of the underlying type
+    pub fn is_full_range(&self) -> bool {
+        self.modulus == T::zero()
+    }
+
+    /// Get the raw modulus. I.e. the value of the underlying type that can be given to
+    /// a modulo operation to implement modular arithmetic.
+    ///
+    /// Will return None if [Self::is_full_range].
+    pub fn modulus(&self) -> Option<T> {
+        match self.is_full_range() {
+            true => None,
+            false => Some(self.modulus),
+        }
+    }
+
+    /// Check if the given type is contained in the range represented by this [Self]
+    pub fn contains(&self, v: T) -> bool {
+        match self.is_full_range() {
+            true => true,
+            false => v < self.modulus,
+        }
+    }
+    /// Double the modulus.
+    ///
+    /// Correctly handles the case that `v.double().is_full_range()`.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use rosenpass::internal::util::int::modular::Modulus;
+    ///
+    /// fn m(v: u8) -> Modulus<u8> {
+    ///   Modulus::new_or_panic(v)
+    /// }
+    ///
+    /// assert_eq!(m(100).double(), Some(m(200)));
+    /// assert_eq!(m(128).double(), Some(Modulus::new_full_range()));
+    /// assert_eq!(m(129).double(), None);
+    /// ```
+    pub fn double(&self) -> Option<Self> {
+        let s = self.modulus()?;
+        match s.overflowing_add(&s) {
+            (d, true) if d > T::zero() => None,
+            (d, _) => Some(Self::raw_new(d)),
+        }
+    }
+
+    /// Create a new [ModularArithmetic] by taking the value modulo the modulus
+    pub fn new_number<U: Into<T>>(self, value: U) -> ModularArithmetic<T>
+    where
+        T: ModularArithmeticBase,
+    {
+        ModularArithmetic::modular_new(value.into(), self)
+    }
+
+    /// Apply [Self::new_number] to each of the parameters, return whatever result the closure
+    /// produces
+    pub fn with_converted<U, const N: usize, R, F>(&self, params: [U; N], f: F) -> R
+    where
+        Self: Copy,
+        T: std::fmt::Debug + ModularArithmeticBase,
+        U: Into<T>,
+        F: FnOnce([ModularArithmetic<T>; N]) -> R,
+    {
+        let params = params.map(|v| self.new_number(v));
+        f(params)
+    }
+
+    /// Apply [Self::new_number] to each of the parameters, converting the result to the underlying
+    /// representation
+    pub fn formula<U, const N: usize, F>(&self, params: [U; N], f: F) -> T
+    where
+        Self: Copy,
+        T: std::fmt::Debug + ModularArithmeticBase,
+        U: Into<T>,
+        F: FnOnce([ModularArithmetic<T>; N]) -> ModularArithmetic<T>,
+    {
+        self.with_converted(params, f).value()
+    }
+}
+
+/// Summary trait for types that can serve as the basis for [ModularArithmetic]
+pub trait ModularArithmeticBase:
+    ModuleBase
+    + std::fmt::Debug
+    + Num
+    + PartialOrd
+    + Ord
+    + Copy
+    + Unsigned
+    + CheckedMul
+    + Euclid
+    + WrappingNeg
+{
+}
+impl<T> ModularArithmeticBase for T where
+    T: ModuleBase
+        + std::fmt::Debug
+        + Num
+        + PartialOrd
+        + Ord
+        + Copy
+        + Unsigned
+        + CheckedMul
+        + Euclid
+        + WrappingNeg
+{
+}
+
+/// Modular arithmetic with an arbitrary modulus
+#[derive(Debug, Copy, Clone)]
+pub struct ModularArithmetic<T: ModularArithmeticBase> {
+    /// The modulus
+    modulus: Modulus<T>,
+    /// The value inside the modulus
+    ///
+    /// Note that `self.modulus.contains(self.value)` must always hold.
+    value: T,
+}
+
+impl<T: ModularArithmeticBase> ModularArithmetic<T> {
+    /// Construct a new [Self].
+    ///
+    /// Will return none unless `module.`[contains](Modulus::contains)`(value)`.
+    pub fn try_new(value: T, module: Modulus<T>) -> Option<Self> {
+        module.contains(value).then_some(Self {
+            value,
+            modulus: module,
+        })
+    }
+
+    /// Construct a new [Self].
+    ///
+    /// # Panic
+    ///
+    /// Will punic unless `module.`[contains](Modulus::contains)`(value)`.
+    pub fn modular_new(value: T, module: Modulus<T>) -> Self {
+        let value = match module.modulus() {
+            Some(m) => value.rem_euclid(&m),
+            None => value,
+        };
+
+        Self {
+            modulus: module,
+            value,
+        }
+    }
+
+    /// Return the modulus
+    pub fn modulus(&self) -> &Modulus<T> {
+        &self.modulus
+    }
+
+    /// The inner value
+    pub fn value(&self) -> T {
+        self.value
+    }
+}
+
+impl<T: ModularArithmeticBase> PartialEq for ModularArithmetic<T> {
+    fn eq(&self, other: &Self) -> bool {
+        self.value == other.value
+    }
+}
+
+impl<T: ModularArithmeticBase> Eq for ModularArithmetic<T> {}
+
+impl<T: ModularArithmeticBase> PartialOrd for ModularArithmetic<T> {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl<T: ModularArithmeticBase> Ord for ModularArithmetic<T> {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        self.value.cmp(&other.value)
+    }
+}
+
+impl<T: ModularArithmeticBase> std::ops::Neg for ModularArithmetic<T> {
+    type Output = Self;
+
+    fn neg(self) -> Self::Output {
+        let ret = match self.modulus().modulus() {
+            None => self.value().wrapping_neg(),
+            Some(modulus) => modulus - self.value(),
+        };
+
+        Self {
+            value: ret,
+            modulus: self.modulus,
+        }
+    }
+}
+
+impl<T: ModularArithmeticBase> std::ops::Sub for ModularArithmetic<T> {
+    type Output = Self;
+
+    fn sub(self, rhs: Self) -> Self::Output {
+        assert_eq!(self.modulus(), rhs.modulus());
+
+        if self < rhs {
+            return -(rhs - self);
+        }
+
+        Self {
+            value: self.value() - rhs.value(),
+            modulus: self.modulus,
+        }
+    }
+}
+
+impl<T: ModularArithmeticBase> std::ops::Add for ModularArithmetic<T> {
+    type Output = Self;
+
+    fn add(self, rhs: Self) -> Self::Output {
+        self - (-rhs)
+    }
+}

--- a/rosenpass/src/internal/util/int/u64uint/constants.rs
+++ b/rosenpass/src/internal/util/int/u64uint/constants.rs
@@ -1,0 +1,12 @@
+//! Constants for u64 <-> usize conversion
+
+/// Largest numeric value that can be safely represented both as
+/// a u64 and usize
+pub const MAX_USIZE_IN_U64: usize = match u64::BITS >= usize::BITS {
+    true => usize::MAX,
+    false => u64::MAX as usize,
+};
+
+/// Largest numeric value that can be safely represented both as
+/// a u64 and usize
+pub const MAX_U64_IN_USIZE: u64 = MAX_USIZE_IN_U64 as u64;

--- a/rosenpass/src/internal/util/int/u64uint/mod.rs
+++ b/rosenpass/src/internal/util/int/u64uint/mod.rs
@@ -1,0 +1,21 @@
+//! Making sure size representations fit both into [usize] and [u64]
+
+use static_assertions::const_assert;
+
+mod constants;
+pub use constants::*;
+
+#[allow(clippy::module_inception)]
+mod u64uint;
+pub use u64uint::*;
+
+mod range;
+pub use range::*;
+
+/// Safe conversion from usize to u64
+///
+/// TODO: Deprecate this
+pub const fn usize_to_u64(v: usize) -> u64 {
+    const_assert!(u64::BITS >= usize::BITS);
+    v as u64
+}

--- a/rosenpass/src/internal/util/int/u64uint/range.rs
+++ b/rosenpass/src/internal/util/int/u64uint/range.rs
@@ -1,0 +1,29 @@
+//! Working with ranges of [super::U64USize]
+
+use std::ops::Range;
+
+use super::U64USize;
+
+/// Extensions for working with [std::ops::Range] of [U64USize]
+pub trait U64USizeRangeExt {
+    /// Convert to a usize based range
+    fn usize(self) -> Range<usize>;
+    /// Convert to a u64 based range
+    fn u64(self) -> Range<u64>;
+}
+
+impl U64USizeRangeExt for Range<U64USize> {
+    fn usize(self) -> Range<usize> {
+        Range {
+            start: self.start.usize(),
+            end: self.end.usize(),
+        }
+    }
+
+    fn u64(self) -> Range<u64> {
+        Range {
+            start: self.start.u64(),
+            end: self.end.u64(),
+        }
+    }
+}

--- a/rosenpass/src/internal/util/int/u64uint/u64uint.rs
+++ b/rosenpass/src/internal/util/int/u64uint/u64uint.rs
@@ -1,0 +1,192 @@
+//! The [U64UInt type]
+
+use super::MAX_U64_IN_USIZE;
+
+/// Error produced by [U64USize::try_new]
+#[derive(Debug, thiserror::Error)]
+pub enum U64USizeConversionError<T: std::fmt::Debug> {
+    /// Value can not be represented as u64
+    #[error("Value can not be represented as a u64 (max = {}) value: {:?}", u64::MAX, .0)]
+    NoU64Repr(T),
+    /// Value can not be represented as usize
+    #[error("Value can not be represented as a usize (max = {}) value: {:?}", usize::MAX, .0)]
+    NoUSizeRepr(T),
+    /// Value can not be represented as usize or u64
+    #[error("Value can not be represented as a u64 (max = {}) or usize (max = {}) value: {:?}", u64::MAX, usize::MAX, .0)]
+    NoU64OrUSizeRepr(T),
+}
+
+/// A number that can be represented as both a usize and a u64.
+#[derive(Default, Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub struct U64USize {
+    /// Enclosed data
+    storage: u64,
+}
+
+impl U64USize {
+    /// Cast another number to a number that can be represented as usize and u64;
+    ///
+    /// This is the internal version which does not use [TryInto]; we use this to implement
+    /// [TryInto].
+    fn try_new_internal<T>(v: T) -> Result<Self, U64USizeConversionError<T>>
+    where
+        T: Copy + TryInto<usize> + TryInto<u64> + std::fmt::Debug,
+    {
+        use U64USizeConversionError as E;
+
+        let v_u64: Result<u64, _> = v.try_into();
+        let v_usize: Result<usize, _> = v.try_into();
+        match (v_u64, v_usize) {
+            (Ok(storage), Ok(_)) => Ok(Self { storage }),
+            (Err(_), Ok(_)) => Err(E::NoU64Repr(v)),
+            (Ok(_), Err(_)) => Err(E::NoUSizeRepr(v)),
+            (Err(_), Err(_)) => Err(E::NoU64OrUSizeRepr(v)),
+        }
+    }
+
+    /// Cast another number to a number that can be represented as usize and u64
+    pub fn try_new<T>(v: T) -> Result<U64USize, <T as TryInto<Self>>::Error>
+    where
+        T: TryInto<Self>,
+    {
+        v.try_into()
+    }
+
+    /// Like [Self::try_new], but panics
+    pub fn new_or_panic<T>(v: T) -> Self
+    where
+        T: TryInto<Self>,
+        <T as TryInto<Self>>::Error: std::fmt::Debug,
+    {
+        match Self::try_new(v) {
+            Ok(v) => v,
+            Err(e) => panic!(
+                "Could not construct {}: {e:?}",
+                std::any::type_name::<Self>()
+            ),
+        }
+    }
+
+    /// Return this value as a usize
+    pub fn usize(&self) -> usize {
+        self.storage as usize
+    }
+
+    /// Return this value as a u64
+    pub fn u64(&self) -> u64 {
+        self.storage
+    }
+}
+
+impl std::ops::Sub for U64USize {
+    type Output = Self;
+
+    fn sub(self, rhs: Self) -> Self::Output {
+        Self::new_or_panic(self.u64() - rhs.u64())
+    }
+}
+
+impl std::ops::Add for U64USize {
+    type Output = Self;
+
+    fn add(self, rhs: Self) -> Self::Output {
+        Self::new_or_panic(self.u64() + rhs.u64())
+    }
+}
+
+/// Facilitates creation of [U64USize] in cases where truncation to the largest representable value is permissible
+pub trait TruncateIntoU64USize {
+    /// Check whether calling [TruncateIntoU64USize::truncate_to_u64usize] would truncate or return
+    /// the value as-is
+    fn fits_into_u64usize(&self) -> bool;
+
+    /// Turn [Self] into a [U64USize]. If the value is representable as a usize and a u64, then
+    /// the value will be returned as is. Otherwise, the maximum representable value [MAX_U64_IN_USIZE]
+    /// will be returned.
+    fn truncate_to_u64usize(&self) -> U64USize;
+}
+
+/// Create instances of From for SafeUSize
+macro_rules! derive_TruncateIntoU64Usize {
+    ($($T:ty),*) => {
+        $(
+            impl TruncateIntoU64USize for $T {
+                fn fits_into_u64usize(&self) -> bool {
+                    U64USize::try_new(*self).is_ok()
+                }
+
+                fn truncate_to_u64usize(&self) -> U64USize {
+                    U64USize::try_new(*self).unwrap_or(U64USize::new_or_panic(MAX_U64_IN_USIZE))
+                }
+            }
+        )*
+    }
+}
+
+derive_TruncateIntoU64Usize!(
+    U64USize, usize, isize, bool, u8, u16, u32, u64, u128, i8, i16, i32, i64, i128
+);
+
+/// Create instances of From for SafeUSize
+macro_rules! U64USize_derive_from {
+    ($($T:ty),*) => {
+        $(
+            impl From<$T> for U64USize {
+                fn from(value: $T) -> Self {
+                    U64USize::try_new_internal::<$T>(value).unwrap()
+                }
+            }
+        )*
+    }
+}
+
+U64USize_derive_from!(bool, u8, u16);
+
+/// Create instances of TryFrom for SafeUSize
+macro_rules! U64USize_derive_try_from {
+    ($($T:ty),*) => {
+        $(
+            impl TryFrom<$T> for U64USize {
+                type Error = U64USizeConversionError<$T>;
+
+                fn try_from(value: $T) -> Result<Self, Self::Error> {
+                    U64USize::try_new_internal::<$T>(value)
+                }
+            }
+        )*
+    }
+}
+
+U64USize_derive_try_from!(usize, isize, u32, u64, u128, i8, i16, i32, i64, i128);
+
+/// Create instances of Into for SafeUSize
+macro_rules! U64USize_derive_into {
+    ($($T:ty),*) => {
+        $(
+            impl From<U64USize> for $T {
+                fn from(val: U64USize) -> Self {
+                    val.u64() as $T
+                }
+            }
+        )*
+    }
+}
+
+U64USize_derive_into!(usize, u64, u128, i128);
+
+/// Create instances of TryInto for SafeUSize
+macro_rules! U64USize_derive_try_into {
+    ($($T:ty),*) => {
+        $(
+            impl TryFrom<U64USize> for $T {
+                type Error = <$T as TryFrom<u64>>::Error;
+
+                fn try_from(val: U64USize) -> Result<Self, Self::Error> {
+                    val.u64().try_into()
+                }
+            }
+        )*
+    }
+}
+
+U64USize_derive_try_into!(isize, u8, u16, u32, i8, i16, i32, i64);

--- a/rosenpass/src/internal/util/ipc/mod.rs
+++ b/rosenpass/src/internal/util/ipc/mod.rs
@@ -1,0 +1,3 @@
+//! Inter-process communication related resources
+
+pub mod shm;

--- a/rosenpass/src/internal/util/ipc/shm/mod.rs
+++ b/rosenpass/src/internal/util/ipc/shm/mod.rs
@@ -1,0 +1,4 @@
+//! Resources for working with shared-memory
+
+mod shared_memory_segment;
+pub use shared_memory_segment::*;

--- a/rosenpass/src/internal/util/ipc/shm/mod.rs
+++ b/rosenpass/src/internal/util/ipc/shm/mod.rs
@@ -2,3 +2,5 @@
 
 mod shared_memory_segment;
 pub use shared_memory_segment::*;
+
+pub mod ringbuf;

--- a/rosenpass/src/internal/util/ipc/shm/ringbuf/local.rs
+++ b/rosenpass/src/internal/util/ipc/shm/ringbuf/local.rs
@@ -1,0 +1,103 @@
+//! Local shared memory ring buffers – mostly for testing
+
+use std::sync::Arc;
+
+use crate::internal::util::ipc::shm::SharedMemorySegment;
+use crate::internal::util::ringbuf::concurrent::framework::{
+    ConcurrentPipeReader, ConcurrentPipeWriter,
+};
+
+use super::{ShmPipeCore, ShmPipeVariables};
+
+/// A process-local shared memory pipe reader
+///
+/// See [shm_pipe()].
+pub type LocalShmPipeReader = ConcurrentPipeReader<ShmPipeCore<Arc<ShmPipeVariables>>>;
+
+/// A process-local shared memory pipe writer
+///
+/// See [shm_pipe()].
+pub type LocalShmPipeWriter = ConcurrentPipeWriter<ShmPipeCore<Arc<ShmPipeVariables>>>;
+
+/// Creates a process-local shared-memory pipe.
+///
+/// See [ConcurrentPipeWriter]/[ConcurrentPipeReader]. The types [LocalShmPipeWriter]/[LocalShmPipeReader] are just aliases for these.
+///
+/// # Safety
+///
+/// Mind the comments in the safety section of [super::super::SharedMemorySegment]; the issues
+/// described in there *exactly* affect this implementation.
+pub fn shm_pipe(len: usize) -> anyhow::Result<(LocalShmPipeWriter, LocalShmPipeReader)> {
+    let shared = Arc::new(ShmPipeVariables::new());
+    let (seg_fd, seg_buf_1) = SharedMemorySegment::create(len)?;
+    let seg_buf_2 = unsafe { SharedMemorySegment::from_fd(seg_fd, len) }?;
+
+    let writer = ShmPipeCore::new(shared.clone(), seg_buf_1);
+    let reader = ShmPipeCore::new(shared, seg_buf_2);
+
+    Ok((
+        ConcurrentPipeWriter::from_core(writer),
+        ConcurrentPipeReader::from_core(reader),
+    ))
+}
+
+#[test]
+fn test_shm_pipe() -> anyhow::Result<()> {
+    let (mut writer, mut reader) = shm_pipe(1024)?;
+
+    const MSG: &[u8] = b"Hello World\0";
+    const MSG_COUNT: usize = 100000;
+
+    let t = std::thread::spawn(move || {
+        for _ in 0..MSG_COUNT {
+            let mut buf = MSG;
+            while !buf.is_empty() {
+                let n = writer.write(buf).unwrap();
+                buf = &buf[n..];
+            }
+        }
+    });
+
+    let mut buf = [0u8; 1000];
+    let mut buf_off = 0;
+    let mut msg_no = 0usize;
+
+    'read_data: while msg_no < MSG_COUNT {
+        let mut old_off = buf_off;
+
+        // Read the data from the shared memory buffer
+        buf_off += reader.read(&mut buf[buf_off..])?;
+
+        loop {
+            // Scan the available data for the zero terminator
+            let msg_len = &buf[old_off..buf_off]
+                .iter()
+                .copied()
+                .enumerate()
+                .find(|(_off, c)| *c == 0x0)
+                .map(|(off, _c)| off + old_off + 1);
+
+            // Next iteration, unless the terminator was found
+            let msg_len = match *msg_len {
+                Some(l) => l,
+                None => continue 'read_data,
+            };
+
+            // Register the newly read message
+            msg_no += 1;
+
+            // Check that the message is correctly transferred
+            let msg = &buf[0..msg_len];
+            assert_eq!(msg, MSG);
+
+            // Move any extra data to the beginning of the buffer and adjust the offsets accordingly
+            buf.copy_within(msg_len..buf_off, 0);
+            old_off = 0;
+            buf_off -= msg_len;
+        }
+    }
+
+    t.join().unwrap();
+
+    Ok(())
+}

--- a/rosenpass/src/internal/util/ipc/shm/ringbuf/main.rs
+++ b/rosenpass/src/internal/util/ipc/shm/ringbuf/main.rs
@@ -1,0 +1,81 @@
+//! Shared-memory ring buffer implementations (main part of the enclosing module)
+
+use std::{borrow::Borrow, sync::atomic::AtomicU64};
+
+use zerocopy::{FromBytes, IntoBytes};
+
+use crate::internal::util::{
+    ipc::shm::SharedMemorySegment,
+    ringbuf::concurrent::framework::{
+        ConcurrentPipeCore, ConcurrentPipeReader, ConcurrentPipeWriter,
+    },
+};
+
+/// Synchronization variables for a [ShmPipeWriter]/[ShmPipeReader].
+///
+/// These values must be shared between the reader/writer in such a way that access to the inner
+/// variables is synchronized and atomic between the two parties.
+#[repr(C)]
+#[derive(Debug, Default, IntoBytes, FromBytes)]
+pub struct ShmPipeVariables {
+    /// See [crate::internal::util::ringbuf::sched::RingBufferScheduler::items_read()]
+    pub items_read: AtomicU64,
+    /// See [crate::internal::util::ringbuf::sched::RingBufferScheduler::items_written()]
+    pub items_written: AtomicU64,
+}
+
+impl ShmPipeVariables {
+    /// Constructor
+    pub fn new() -> Self {
+        Self {
+            items_read: 0.into(),
+            items_written: 0.into(),
+        }
+    }
+}
+
+/// The [ConcurrentPipeCore] for a shared memory pipe.
+#[derive(Debug)]
+pub struct ShmPipeCore<Variables: Borrow<ShmPipeVariables>> {
+    /// The synchronization variables
+    variables: Variables,
+    /// The memory buffer
+    buf: SharedMemorySegment,
+}
+
+impl<Variables: Borrow<ShmPipeVariables>> ShmPipeCore<Variables> {
+    /// Constructor
+    pub fn new(variables: Variables, buf: SharedMemorySegment) -> Self {
+        Self { variables, buf }
+    }
+}
+
+/// A shared memory pipe reader
+pub type ShmPipeReader<Variables> = ConcurrentPipeReader<ShmPipeCore<Variables>>;
+
+/// A shared memory pipe reader
+pub type ShmPipeWriter<Variables> = ConcurrentPipeWriter<ShmPipeCore<Variables>>;
+
+impl<Variables: Borrow<ShmPipeVariables>> ConcurrentPipeCore for ShmPipeCore<Variables> {
+    type AtomicType = AtomicU64;
+
+    fn buf_len(&self) -> u64 {
+        self.buf.len() as u64
+    }
+
+    fn items_read(&self) -> &AtomicU64 {
+        &self.variables.borrow().items_read
+    }
+
+    fn items_written(&self) -> &AtomicU64 {
+        &self.variables.borrow().items_written
+    }
+
+    fn read_from_buffer(&mut self, dst: &mut [u8], off: u64) {
+        self.buf.volatile_read(dst, off as usize)
+    }
+
+    fn write_to_buffer(&mut self, off: u64, src: &[u8]) {
+        self.buf.volatile_write(off as usize, src);
+    }
+}

--- a/rosenpass/src/internal/util/ipc/shm/ringbuf/mod.rs
+++ b/rosenpass/src/internal/util/ipc/shm/ringbuf/mod.rs
@@ -1,0 +1,7 @@
+//! Shared-memory ring buffers
+
+mod main;
+pub use main::*;
+
+mod local;
+pub use local::*;

--- a/rosenpass/src/internal/util/ipc/shm/shared_memory_segment.rs
+++ b/rosenpass/src/internal/util/ipc/shm/shared_memory_segment.rs
@@ -1,0 +1,399 @@
+//! Accessing data in a shared memory segment
+
+use std::{
+    borrow::Borrow,
+    os::fd::{AsFd, OwnedFd},
+};
+
+use crate::internal::util::{
+    int::u64uint::usize_to_u64,
+    ptr::{ReadMemVolatile, WriteMemVolatile},
+    result::OkExt,
+    secret_memory::{
+        fd::SecretMemfdConfig,
+        mmap::{MMapError, MapFdConfig, MappedSegment},
+    },
+};
+
+/// Safe creation of shared memory segments
+///
+/// This is a slightly more convenient API than using [MapFdConfig] directly.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct SharedMemorySegmentBuilder {
+    /// Configuration for allocating memory file descriptors and their secrecy level
+    pub secret_memfd_cfg: SecretMemfdConfig,
+    /// Configuration for mapping file descriptors into memory
+    pub map_fd_cfg: MapFdConfig,
+}
+
+impl SharedMemorySegmentBuilder {
+    /// Create a new secret memory segment builder.
+    ///
+    /// Note that this always sets [MapFdConfig::set_shared()], but you can overwrite this behavior
+    /// by un-setting the flag again.
+    ///
+    /// # Safety & panic
+    ///
+    /// This function can panic when [u64] is unable to represent the given size
+    /// value. This might be the case in future computers impressing me with their excessive size.
+    pub const fn new(len: usize) -> Self {
+        let secret_memfd_cfg = SecretMemfdConfig::new();
+        let map_fd_cfg = MapFdConfig::new()
+            .set_shared()
+            .resize_on_mmap(usize_to_u64(len));
+        Self {
+            secret_memfd_cfg,
+            map_fd_cfg,
+        }
+    }
+
+    /// Create a secret memory segment using the configuration stored here
+    pub fn create_segment(&self) -> anyhow::Result<(OwnedFd, SharedMemorySegment)> {
+        let fd = self.secret_memfd_cfg.create()?;
+        let seg = self.map_fd_cfg.mappable_fd(&fd).mmap()?;
+        let seg = unsafe { SharedMemorySegment::from_mapped_segment(seg) };
+
+        Ok((fd, seg))
+    }
+}
+
+/// Safe creation of and access to shared memory segments
+///
+/// # Safety
+///
+/// Any means to create a [Self] must guarantee, that further calls to [Self::volatile_write] and
+/// [Self::volatile_read] are also safe.
+///
+/// The API of this struct is specifically designed so creating multiple memory mappings of the same
+/// shared memory segment is impossible without unsafe code.
+///
+/// We recognize that the sole purpose of shared memory segments is that multiple mappings of them
+/// are created, there just is no way to do so using safe rust.
+///
+/// The reason for this is – that by the Rust documentation – any concurrent memory access leads to
+/// undefined behavior, even volatile accesses caused solely by an adversarial application on the
+/// other end of a shared memory communication channel.
+///
+/// For this reason, we force users to use unsafe code to create shared memory mappings from an
+/// existing file descriptor, as this could potentially lead to adversarial data races (and thus to
+/// undefined behavior).
+///
+/// In practice, we believe using concurrent memory access using volatile operations is going to
+/// lead to nothing worse than garbled data being transferred. The user should treat any data
+/// received through a shared-memory ring buffer as untrusted and validate this data any way, so
+/// garbled data should be caught.
+///
+/// This means that [Self::from_fd()] is unsafe in theory, but most likely safe in practice.
+///
+/// ## Concurrent, untrusted shared memory is technically undefined behavior
+///
+/// Its even worse than having to use unsafe: technically speaking, it may be impossible to
+/// use shared memory soundly in rust unless all parties with access to the segment are
+/// *trusted*. If these parties are not trusted (or buggy) they can always cause undefined
+/// behavior:
+///
+/// From the [std::sync::atomic] documentation:
+///
+/// > **The most important aspect of this model is that data races are undefined behavior.** A data race
+/// > is defined as conflicting non-synchronized accesses where at least one of the accesses is non-atomic.
+/// > Here, accesses are conflicting if they affect overlapping regions of memory and at least one of them
+/// > is a write. (A compare_exchange or compare_exchange_weak that does not succeed is not considered a
+/// > write.) They are non-synchronized if neither of them happens-before the other, according to the
+/// > happens-before order of the memory model.
+///
+/// The fact that this API uses volatile [reads](Self::volatile_read) and [writes](Self::volatile_write),
+/// and the the fact that we use mmap(2) for allocation does not mitigate this issue; from the
+/// documentation of [std::ptr::write_volatile()]:
+///
+/// > When a volatile operation is used for memory inside an allocation, it behaves exactly like write,
+/// > except for the additional guarantee that it won’t be elided or reordered (see above). This implies
+/// > that the operation will actually access memory and not e.g. be lowered to a register access. Other
+/// > than that, all the usual rules for memory accesses apply (including provenance). In particular, just
+/// > like in C, whether an operation is volatile has no bearing whatsoever on questions involving concurrent
+/// > access from multiple threads. Volatile accesses behave exactly like non-atomic accesses in that regard.
+///
+/// An allocation is defined as follows (taken from [std::ptr]):
+///
+/// > An allocation is a subset of program memory which is addressable from Rust, and within which pointer
+/// > arithmetic is possible. Examples of allocations include heap allocations, stack-allocated variables,
+/// > statics, and consts. The safety preconditions of some Rust operations - such as offset and field
+/// > projections (expr.field) - are defined in terms of the allocations on which they operate.
+///
+/// This definition clearly applies to mmap(2) allocated regions.
+///
+/// What might mitigate this issue is mapping the region just once per process:
+///
+/// > In particular, just
+/// > like in C, whether an operation is volatile has no bearing whatsoever on questions involving concurrent
+/// > access from **multiple threads**.
+///
+/// We could argue that a process is not a thread, and thus concurrent access from two processes is
+/// fine, but concurrent access from two threads is not (unless guarded by an atomic value or a
+/// mutex or some primitive actually designed for synchronization).
+///
+/// There is no wording in the spec explicitly allowing raceful, concurrent access from multiple processes.
+///
+/// The problem with basing our safety-argument on the claim that "processes are not threads" is
+/// that the line between processes and threads is drawn in the sand. For linux, read the man page
+/// of clone(2):
+///
+/// > By contrast with fork(2), these [clone, __clone2, clone3] system calls provide more precise control over what pieces of execution
+/// > context are shared between the calling process and the child process.  For example, using  these  system
+/// > calls,  the caller can control whether or not the two processes share the virtual address space, the ta‐
+/// > ble of file descriptors, and the table of signal handlers.  These system calls also allow the new  child
+/// > process to be placed in separate namespaces(7).
+/// >
+/// > […]
+/// >
+/// > ## CLONE_THREAD (since Linux 2.4.0)
+/// >
+/// > If  CLONE_THREAD is set, the child is placed in the same thread group as the calling process.  To
+/// > make the remainder of the discussion of CLONE_THREAD more readable, the term "thread" is used  to
+/// > refer to the processes within a thread group.
+///
+/// According to the man page, "the term 'thread' is used  to refer to the processes within a thread group.".
+///
+/// The Rust (transitively, from the C++11 Atomic) specification tells us that there must be no
+/// concurrent memory access between threads whether this access is volatile or not. The linux man
+/// pages tell us that "thread" is just a special type of "process".
+///
+/// **The most robust interpretation of these specifications is that shared memory must not be used for
+/// communication with an untrusted party across thread or process boundaries, or else the other
+/// process/thread can cause undefined behavior in our process.**
+///
+/// ## In practice
+///
+/// Realistically, using volatile reads/writes on valid, mapped memory might cause garbled values in
+/// case of a data race, but it should crash the program or do anything worse than create garbled
+/// values.
+///
+/// Mind that we do not mind garbled values here; we are implementing a shared memory communication
+/// interface, so our application must always assume, that the data it receives may be garbled. It
+/// has to be validated. We just don't want the other application to be able to do anything worse
+/// that garble the data it is sending (or receiving), so lets estimate what can *realistically*
+/// happen here if the other application maliciously causes a race.
+///
+/// The worst any of the assembly sequences below should do is cause tearing in case of a data
+/// race.
+///
+/// This leads me to the conclusion that what what we are dealing here with is not an
+/// implementation that is faulty/insecure, instead it is a definition-gap in the compiler
+/// semantics for volatile memory access for use in security-critical applications.
+///
+/// Godbolt link: <https://rust.godbolt.org/z/GGjsGsc33>
+/// Compiler: `rustc 1.90.0`
+///
+/// Rust code:
+///
+/// ```rust
+/// #[unsafe(no_mangle)]
+/// pub fn read_volatile(num: &[u128]) -> u128 {
+///     let ptr = num.as_ptr();
+///     unsafe { ptr.read_volatile() }
+/// }
+///
+/// #[unsafe(no_mangle)]
+/// pub fn write_volatile(num: &mut [u128]) {
+///     let ptr = num.as_mut_ptr();
+///     unsafe { ptr.write_volatile(42u128) };
+/// }
+/// ```
+///
+/// x86_64 (`--target=x86_64-unknown-linux-gnu -O`):
+///
+/// ```asm
+/// read_volatile:
+///         mov     rax, qword ptr [rdi]
+///         mov     rdx, qword ptr [rdi + 8]
+///         ret
+///
+/// write_volatile:
+///         mov     qword ptr [rdi + 8], 0
+///         mov     qword ptr [rdi], 42
+///         ret
+/// ```
+///
+/// arm64 (`--target=aarch64-unknown-linux-gnu -O`):
+///
+/// ```asm
+/// read_volatile:
+///         ldp     x0, x1, [x0]
+///         ret
+///
+/// write_volatile:
+///         mov     w8, #42
+///         stp     x8, xzr, [x0]
+///         ret
+/// ```
+///
+/// armv7 (`--target=armv7-unknown-linux-gnueabihf -O`)
+///
+/// ```asm
+/// read_volatile:
+///         push    {r4, r5, r11, lr}
+///         ldrd    r2, r3, [r1]
+///         ldrd    r4, r5, [r1, #8]
+///         stm     r0, {r2, r3, r4, r5}
+///         pop     {r4, r5, r11, pc}
+///
+/// write_volatile:
+///         push    {r4, r5, r11, lr}
+///         mov     r2, #0
+///         mov     r4, #42
+///         mov     r3, r2
+///         mov     r5, r2
+///         strd    r2, r3, [r0, #8]
+///         strd    r4, r5, [r0]
+///         pop     {r4, r5, r11, pc}
+/// ```
+///
+/// risc64 (`--target=riscv64gc-unknown-linux-gnu`):
+///
+/// ```asm
+/// read_volatile:
+///         ld      a1, 8(a0)
+///         ld      a0, 0(a0)
+///         ret
+///
+/// write_volatile:
+///         sd      zero, 8(a0)
+///         li      a1, 42
+///         sd      a1, 0(a0)
+///         ret
+/// ```
+///
+#[derive(Debug)]
+pub struct SharedMemorySegment {
+    /// The underlying mapped segment
+    inner: MappedSegment,
+}
+
+impl SharedMemorySegment {
+    /// Create a new shared memory segment.
+    pub fn create(len: usize) -> anyhow::Result<(OwnedFd, Self)> {
+        SharedMemorySegmentBuilder::new(len).create_segment()
+    }
+
+    /// Create a shared memory segment from a file descriptor
+    ///
+    /// # Safety
+    ///
+    /// See the comments in [Self].
+    pub unsafe fn from_fd<Fd: AsFd>(fd: Fd, size: usize) -> Result<Self, MMapError> {
+        let cfg = MapFdConfig::new()
+            .set_shared()
+            .expected_size(usize_to_u64(size));
+        unsafe { Self::from_fd_with_config(fd, cfg) }
+    }
+
+    /// Create a shared memory segment from a file descriptor
+    ///
+    /// # Safety
+    ///
+    /// See the comments in [Self].
+    pub unsafe fn from_fd_with_config<Fd: AsFd>(
+        fd: Fd,
+        cfg: MapFdConfig,
+    ) -> Result<Self, MMapError> {
+        let segment = cfg.mappable_fd(&fd).mmap()?;
+        unsafe { Self::from_mapped_segment(segment).ok() }
+    }
+
+    /// Create a shared memory segment from an existing mapped segment
+    ///
+    /// # Safety
+    ///
+    /// See the comments in [Self].
+    pub unsafe fn from_mapped_segment(inner: MappedSegment) -> Self {
+        Self { inner }
+    }
+
+    /// The underlying mapped segment
+    pub fn mapped_segment(&self) -> &MappedSegment {
+        self.inner.borrow()
+    }
+
+    /// A pointer to the underlying mapped segment
+    pub fn ptr(&self) -> *mut u8 {
+        self.mapped_segment().ptr()
+    }
+
+    /// The length of the underlying mapped segment
+    pub fn len(&self) -> usize {
+        self.mapped_segment().len()
+    }
+
+    /// Whether `self.`[len()](Self::len)` == 0`
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
+    /// Read data from the ring buffer
+    ///
+    /// # Safety
+    ///
+    /// See comments in [Self].
+    pub fn volatile_read(&self, dst: &mut [u8], off: usize) {
+        let end = off + dst.len();
+        assert!(end <= self.len());
+
+        unsafe { self.ptr().add(off).read_mem_volatile(dst) }
+    }
+
+    /// Read data from the ring buffer
+    ///
+    /// # Safety
+    ///
+    /// See comments in [Self].
+    pub fn volatile_write(&self, off: usize, src: &[u8]) {
+        let end = off + src.len();
+        assert!(end <= self.len());
+
+        unsafe { self.ptr().add(off).write_mem_volatile(src) }
+    }
+}
+
+impl From<SharedMemorySegment> for MappedSegment {
+    fn from(val: SharedMemorySegment) -> Self {
+        val.inner
+    }
+}
+
+impl Borrow<MappedSegment> for SharedMemorySegment {
+    fn borrow(&self) -> &MappedSegment {
+        self.mapped_segment()
+    }
+}
+
+#[test]
+fn test_shared_memory_segment() -> anyhow::Result<()> {
+    let underscore = [b'_'; 38];
+    let zero = [0u8; 38];
+    let test_string = b"Hello World";
+
+    let mut after_write = zero.to_owned();
+    crate::internal::util::mem::cpy_min(test_string, &mut after_write);
+
+    let (fd, reg1) = SharedMemorySegment::create(1024)?;
+    let reg2 = unsafe { SharedMemorySegment::from_fd(fd, 1024) }?;
+
+    let mut buf = underscore.to_owned();
+    reg1.volatile_read(&mut buf, 0);
+    assert_eq!(&buf, &zero);
+
+    let mut buf = underscore.to_owned();
+    reg2.volatile_read(&mut buf, 0);
+    assert_eq!(&buf, &zero);
+
+    reg1.volatile_write(0, test_string);
+
+    let mut buf = underscore.to_owned();
+    reg1.volatile_read(&mut buf, 0);
+    assert_eq!(&buf, &after_write);
+
+    let mut buf = underscore.to_owned();
+    reg2.volatile_read(&mut buf, 0);
+    assert_eq!(&buf, &after_write);
+
+    Ok(())
+}

--- a/rosenpass/src/internal/util/mem.rs
+++ b/rosenpass/src/internal/util/mem.rs
@@ -290,6 +290,110 @@ impl<T: Sized> MoveExt for T {
     }
 }
 
+/// Explicitly copy a value
+///
+/// This is sometimes useful as an alternative to the deref operator
+/// (`x.copy()` instead of `*x`) to achieve neater method chains.
+///
+/// # Examples
+///
+/// ```
+/// use rosenpass::internal::util::mem::CopyExt;
+/// use rosenpass::internal::util::result::OkExt;
+///
+/// // Without CopyExt
+/// fn boilerplate_1<T: Copy>(v: &T) -> Result<T, ()> {
+///     (*v).ok()
+/// }
+///
+/// // With CopyExt
+/// fn boilerplate_2<T: Copy>(v: &T) -> Result<T, ()> {
+///     v.copy().ok()
+/// }
+///
+/// assert_eq!(boilerplate_1(&32), Ok(32));
+/// assert_eq!(boilerplate_1(&32), boilerplate_2(&32));
+/// ```
+pub trait CopyExt: Copy {
+    /// Copy a value
+    fn copy(&self) -> Self {
+        *self
+    }
+}
+
+impl<T: Copy> CopyExt for T {}
+
+/// Helper trait for applying a mutating closure/function to a mutable reference
+///
+/// # Examples
+///
+/// ```rust
+/// use rosenpass::internal::util::mem::MutateRefExt;
+///
+/// fn plus_two_mul_three(v: u64) -> u64 {
+///     (v + 2) * 3
+/// }
+///
+/// fn inconvenient_example(v: &mut u64) {
+///     *v = plus_two_mul_three(*v);
+/// }
+///
+/// fn convenient_example(v: &mut u64) {
+///     v.mutate(plus_two_mul_three);
+/// }
+///
+/// let mut x = 0;
+/// inconvenient_example(&mut x);
+/// assert_eq!(x, 6);
+/// convenient_example(&mut x);
+/// assert_eq!(x, 24);
+///
+/// x = 0;
+///
+/// x.mutate(plus_two_mul_three);
+/// assert_eq!(x, 6);
+/// x.mutate(|v| (v + 2) * 3);
+/// assert_eq!(x, 24);
+///
+/// x = 0;
+///
+/// let y = &mut x;
+/// y.mutate(plus_two_mul_three);
+/// assert_eq!(x, 6);
+///
+/// struct Cont {
+///     x: u64,
+/// }
+///
+/// impl Cont {
+///     fn x_mut(&mut self) -> &mut u64 {
+///         &mut self.x
+///     }
+/// }
+///
+/// let mut s = Cont { x: 0 };
+/// s.x_mut().mutate(|v| (v + 2) * 3);
+/// ```
+pub trait MutateRefExt: DerefMut
+where
+    Self::Target: Sized,
+{
+    /// Directly mutate a reference
+    fn mutate<F: FnOnce(Self::Target) -> Self::Target>(self, f: F) -> Self;
+}
+
+impl<T> MutateRefExt for T
+where
+    T: DerefMut,
+    <T as Deref>::Target: Copy,
+{
+    fn mutate<F: FnOnce(Self::Target) -> Self::Target>(mut self, f: F) -> Self {
+        let v = self.deref_mut();
+        *v = f(*v);
+        self
+    }
+}
+
 #[cfg(test)]
 mod test_forgetting {
     use crate::internal::util::mem::Forgetting;

--- a/rosenpass/src/internal/util/mod.rs
+++ b/rosenpass/src/internal/util/mod.rs
@@ -28,6 +28,7 @@ pub mod ptr;
 /// Extended Result type functionality.
 pub mod result;
 pub mod rustix;
+pub mod sync;
 /// Time and duration utilities.
 pub mod time;
 #[cfg(feature = "tokio")]

--- a/rosenpass/src/internal/util/mod.rs
+++ b/rosenpass/src/internal/util/mod.rs
@@ -24,6 +24,7 @@ pub mod mem;
 pub mod mio;
 /// Extended Option type functionality.
 pub mod option;
+pub mod ptr;
 /// Extended Result type functionality.
 pub mod result;
 pub mod rustix;

--- a/rosenpass/src/internal/util/mod.rs
+++ b/rosenpass/src/internal/util/mod.rs
@@ -31,6 +31,7 @@ pub mod ptr;
 pub mod result;
 pub mod ringbuf;
 pub mod rustix;
+pub mod secret_memory;
 pub mod sync;
 /// Time and duration utilities.
 pub mod time;

--- a/rosenpass/src/internal/util/mod.rs
+++ b/rosenpass/src/internal/util/mod.rs
@@ -29,6 +29,7 @@ pub mod option;
 pub mod ptr;
 /// Extended Result type functionality.
 pub mod result;
+pub mod ringbuf;
 pub mod rustix;
 pub mod sync;
 /// Time and duration utilities.

--- a/rosenpass/src/internal/util/mod.rs
+++ b/rosenpass/src/internal/util/mod.rs
@@ -18,6 +18,7 @@ pub mod functional;
 pub mod int;
 /// Input/output operations.
 pub mod io;
+pub mod ipc;
 /// Length prefix encoding schemes implementation.
 pub mod length_prefix_encoding;
 /// Memory manipulation and allocation utilities.

--- a/rosenpass/src/internal/util/mod.rs
+++ b/rosenpass/src/internal/util/mod.rs
@@ -15,6 +15,7 @@ pub mod file;
 pub mod fmt;
 /// Functional programming utilities.
 pub mod functional;
+pub mod int;
 /// Input/output operations.
 pub mod io;
 /// Length prefix encoding schemes implementation.

--- a/rosenpass/src/internal/util/mod.rs
+++ b/rosenpass/src/internal/util/mod.rs
@@ -9,6 +9,7 @@ pub mod b64;
 pub mod build;
 /// Control flow abstractions and utilities.
 pub mod controlflow;
+pub mod convert;
 /// File system operations and handling.
 pub mod file;
 pub mod fmt;

--- a/rosenpass/src/internal/util/ptr/mod.rs
+++ b/rosenpass/src/internal/util/ptr/mod.rs
@@ -1,0 +1,4 @@
+//! Utilities for working with pointers
+
+mod volatile;
+pub use volatile::*;

--- a/rosenpass/src/internal/util/ptr/volatile.rs
+++ b/rosenpass/src/internal/util/ptr/volatile.rs
@@ -1,0 +1,51 @@
+//! Utilities relating to volatile reads/writes on pointers
+
+/// Read from a memory location using
+/// `pointer::read_volatile` in a loop and store the
+/// results in the given slice
+pub trait ReadMemVolatile<T> {
+    /// Read from a memory location using
+    /// `pointer::read_volatile` in a loop and store the
+    /// results in an array
+    ///
+    /// # Safety
+    ///
+    /// Refer to `pointer::read_volatile`
+    unsafe fn read_mem_volatile(self, dst: &mut [T]);
+}
+
+impl<T> ReadMemVolatile<T> for *const T {
+    unsafe fn read_mem_volatile(self, dst: &mut [T]) {
+        for (idx, dst) in dst.iter_mut().enumerate() {
+            *dst = unsafe { self.add(idx).read_volatile() };
+        }
+    }
+}
+
+impl<T> ReadMemVolatile<T> for *mut T {
+    unsafe fn read_mem_volatile(self, dst: &mut [T]) {
+        unsafe { self.cast_const().read_mem_volatile(dst) }
+    }
+}
+
+/// Write to a memory location using
+/// `pointer::write_volatile` in a loop
+/// and store the resulting values in the given slice
+pub trait WriteMemVolatile<T>: ReadMemVolatile<T> {
+    /// Write to a memory location using
+    /// `pointer::write_volatile` in a loop
+    /// and store the resulting values in the given slice
+    ///
+    /// # Safety
+    ///
+    /// Refer to `pointer::write_volatile`
+    unsafe fn write_mem_volatile(self, src: &[T]);
+}
+
+impl<T: Copy> WriteMemVolatile<T> for *mut T {
+    unsafe fn write_mem_volatile(self, src: &[T]) {
+        for (idx, src) in src.iter().enumerate() {
+            unsafe { self.add(idx).write_volatile(*src) }
+        }
+    }
+}

--- a/rosenpass/src/internal/util/ringbuf/concurrent/framework.rs
+++ b/rosenpass/src/internal/util/ringbuf/concurrent/framework.rs
@@ -1,0 +1,243 @@
+//! An implementation of a concurrent ring buffer with the
+//! core (IO/memory access) operations in a detached trait. Everything around the core is
+//! implemented but before being able to use this, callers must implement an appropriate IO core.
+
+use crate::internal::util::int::u64uint::U64USizeRangeExt;
+use crate::internal::util::result::OkExt;
+use crate::internal::util::ringbuf::sched::{
+    Diff, OperationType, RingBufferFromCountersError, RingBufferScheduler, ScheduledOperations,
+};
+use crate::internal::util::sync::atomic::abstract_atomic::AbstractAtomic;
+
+/// Core trait used by [ConcurrentPipeReader] and [ConcurrentPipeWriter] to implement
+/// a concurrent pipe based on a ring buffer
+pub trait ConcurrentPipeCore {
+    /// The type used for the atomics; i.e. the values returned by
+    /// [Self::items_read] and [Self.:items_written].
+    type AtomicType: AbstractAtomic<u64>;
+
+    /// Length of the underlying memory buffer
+    fn buf_len(&self) -> u64;
+
+    /// Number of items read
+    fn items_read(&self) -> &Self::AtomicType;
+    /// Number of items written
+    fn items_written(&self) -> &Self::AtomicType;
+    /// Copy data from the underlying memory buffer into the destination
+    fn read_from_buffer(&mut self, dst: &mut [u8], off: u64);
+    /// Write data from src into the underlying memory buffer
+    fn write_to_buffer(&mut self, off: u64, src: &[u8]);
+}
+
+/// Raised by [ConcurrentPipeReader::read()]/[ConcurrentPipeWriter::write()] if the underlying
+/// ring buffer is in an inconsistent state.
+///
+/// When used in shared memory applications, this error may have been locally caused, but it may
+/// also be caused by **the other threads or processes** putting the ring buffer into an
+/// inconsistent state.
+///
+/// For this reason, you must treat this error as an unrecoverable breakdown of the communication channel. You
+/// must close and no longer use ring buffer after receiving this error, but you can handle it
+/// gracefully by reopening a new ring buffer in its place.
+///
+/// # API Stability
+///
+/// Treat this error type as opaque; do not rely on the enum values remaining the same
+#[derive(Debug, thiserror::Error, Clone)]
+pub enum InconsistentRingBufferStateError {
+    /// Failed to update an inner counter; this probably indicates a data race (forbidden
+    /// concurrent read/write)
+    #[error("Concurrent access to the ring buffer {:?}", self)]
+    ConcurrrentAccess {
+        /// Whether this was a read or write
+        operation_type: OperationType,
+        /// Operations performed before updaing the ring buffer state
+        scheduled_ops: ScheduledOperations,
+        /// The scheduler that scheduled our operation
+        scheduler_state: RingBufferScheduler,
+        /// The counter value before compare and exchange
+        expected_counter_value: u64,
+        /// The counter value we actually found in the counter
+        actual_counter_value: u64,
+        /// The counter value we tried to set
+        new_counter_value_tried_to_set: u64,
+    },
+    /// Could not construct ring buffer scheduler
+    #[error("Inconsistent ring buffer state: {:?}", .0)]
+    InconsistentCounterState(#[from] RingBufferFromCountersError),
+}
+
+/// Indicator for [ConcurrentPipeImpl::read_or_write] about which operation
+/// is being executed
+#[derive(Debug)]
+enum ConcurrentPipeOperation<'a> {
+    /// This call implements [ConcurrentPipeReader::read]
+    Read(&'a mut [u8]),
+    /// This call implements [ConcurrentPipeWriter::write]
+    Write(&'a [u8]),
+}
+
+impl<'a> ConcurrentPipeOperation<'a> {
+    /// Read-only access to the operation buffer
+    pub fn inner_buf(&'a self) -> &'a [u8] {
+        match self {
+            ConcurrentPipeOperation::Read(items) => items,
+            ConcurrentPipeOperation::Write(items) => items,
+        }
+    }
+
+    /// Length of [Self::inner_buf]
+    pub fn len(&self) -> usize {
+        self.inner_buf().len()
+    }
+
+    /// Decides which type of operation, in terms of [OperationType] [Self] represents
+    pub fn scheduler_op(&self) -> OperationType {
+        match self {
+            ConcurrentPipeOperation::Read(_) => OperationType::Read,
+            ConcurrentPipeOperation::Write(_) => OperationType::Write,
+        }
+    }
+}
+
+/// The implementations of [ConcurrentPipeReader] and [ConcurrentPipeWriter]
+/// happen to be extremely similar. This struct forms the basis of both.
+struct ConcurrentPipeImpl<Core: ConcurrentPipeCore> {
+    /// Core trait
+    core: Core,
+}
+
+impl<Core: ConcurrentPipeCore> ConcurrentPipeImpl<Core> {
+    /// Like [ConcurrentPipeReader::from_core] and [ConcurrentPipeWriter::from_core]
+    fn from_core(core: Core) -> Self {
+        Self { core }
+    }
+
+    /// The implementations of [ConcurrentPipeReader::read] and [ConcurrentPipeWriter::write]
+    /// happen to be extremely similar. This function implements both.
+    fn read_or_write(
+        &mut self,
+        mut op: ConcurrentPipeOperation,
+    ) -> Result<usize, InconsistentRingBufferStateError> {
+        use std::sync::atomic::Ordering as O;
+
+        // Figure out which counter to store the result of the operation in and the orderings to
+        // use for load/store operations
+        let (ord_r, ord_w, ord_store_succ, ord_store_fail) = match op {
+            ConcurrentPipeOperation::Read(_) => (O::Relaxed, O::Acquire, O::Relaxed, O::Relaxed),
+            ConcurrentPipeOperation::Write(_) => (O::Relaxed, O::Relaxed, O::Release, O::Relaxed),
+        };
+
+        // Construct a ring buffer scheduler from the current state
+        let sched = RingBufferScheduler::try_from_counters(
+            self.core.buf_len(),
+            self.core.items_written().load(ord_w),
+            self.core.items_read().load(ord_r),
+        )?;
+
+        // Have the scheduler schedule the operations
+        let ops = sched.schedule_contigous_operations(op.scheduler_op(), op.len());
+
+        // Actually perform the operations
+        for (buf_slice, ring_op) in ops.with_outside_buffer_range() {
+            match &mut op {
+                ConcurrentPipeOperation::Read(dst) => self
+                    .core
+                    .read_from_buffer(&mut dst[buf_slice.usize()], ring_op.off),
+                ConcurrentPipeOperation::Write(src) => self
+                    .core
+                    .write_to_buffer(ring_op.off, &src[buf_slice.usize()]),
+            }
+        }
+
+        // Take a differential between the scheduler and the scheduler after the operations where
+        // applied. Make sure only one counter was updated
+        let diff = sched
+            .register_operation(&ops)
+            .diff_old(&sched)
+            .expect_op_only(op.scheduler_op())
+            .unwrap();
+
+        let store_to_ctr = match op {
+            ConcurrentPipeOperation::Read(_) => self.core.items_read(),
+            ConcurrentPipeOperation::Write(_) => self.core.items_written(),
+        };
+
+        // Update the counters, assuming there was any change at all
+        if let Diff::Different(old, new) = diff {
+            store_to_ctr
+                .compare_exchange(old, new, ord_store_succ, ord_store_fail)
+                .map_err(
+                    |actual| InconsistentRingBufferStateError::ConcurrrentAccess {
+                        operation_type: op.scheduler_op(),
+                        scheduled_ops: ops,
+                        scheduler_state: sched,
+                        expected_counter_value: old,
+                        actual_counter_value: actual,
+                        new_counter_value_tried_to_set: new,
+                    },
+                )?;
+        }
+
+        ops.cumulative_operation_length().usize().ok()
+    }
+}
+
+/// Provides the necessary boilerplate around [ConcurrentPipeCore] to implement
+/// reading from the pipe
+pub struct ConcurrentPipeReader<Core: ConcurrentPipeCore> {
+    /// The implementations of [ConcurrentPipeReader::read] and [ConcurrentPipeWriter::write]
+    /// happen to be extremely similar. We use [ConcurrentPipeImpl] to implement both.
+    inner: ConcurrentPipeImpl<Core>,
+}
+
+impl<Core: ConcurrentPipeCore> ConcurrentPipeWriter<Core> {
+    /// Create a [Self] from a [ConcurrentPipeCore]
+    pub fn from_core(core: Core) -> Self {
+        Self {
+            inner: ConcurrentPipeImpl::from_core(core),
+        }
+    }
+
+    /// Determine the length of the underlying ring buffer
+    pub fn buf_len(&self) -> u64 {
+        self.inner.core.buf_len()
+    }
+
+    /// Write data into the concurrent pipe.
+    ///
+    /// Returns the number of bytes actually written.
+    pub fn write(&mut self, src: &[u8]) -> Result<usize, InconsistentRingBufferStateError> {
+        self.inner
+            .read_or_write(ConcurrentPipeOperation::Write(src))
+    }
+}
+
+/// Provides the necessary boilerplate around [ConcurrentPipeCore] to implement
+/// writing to the pipe
+pub struct ConcurrentPipeWriter<Core: ConcurrentPipeCore> {
+    /// The implementations of [ConcurrentPipeReader::read] and [ConcurrentPipeWriter::write]
+    /// happen to be extremely similar. We use [ConcurrentPipeImpl] to implement both.
+    inner: ConcurrentPipeImpl<Core>,
+}
+
+impl<Core: ConcurrentPipeCore> ConcurrentPipeReader<Core> {
+    /// Create a [Self] from a [ConcurrentPipeCore]
+    pub fn from_core(core: Core) -> Self {
+        Self {
+            inner: ConcurrentPipeImpl::from_core(core),
+        }
+    }
+
+    /// Determine the length of the underlying ring buffer
+    pub fn buf_len(&self) -> u64 {
+        self.inner.core.buf_len()
+    }
+
+    /// Read data from the concurrent pipe.
+    ///
+    /// Returns the number of bytes read.
+    pub fn read(&mut self, dst: &mut [u8]) -> Result<usize, InconsistentRingBufferStateError> {
+        self.inner.read_or_write(ConcurrentPipeOperation::Read(dst))
+    }
+}

--- a/rosenpass/src/internal/util/ringbuf/concurrent/mod.rs
+++ b/rosenpass/src/internal/util/ringbuf/concurrent/mod.rs
@@ -1,0 +1,3 @@
+//! Concurrent ring buffers
+
+pub mod framework;

--- a/rosenpass/src/internal/util/ringbuf/mod.rs
+++ b/rosenpass/src/internal/util/ringbuf/mod.rs
@@ -1,3 +1,4 @@
 //! Ring buffers and utilities for working with them
 
+pub mod concurrent;
 pub mod sched;

--- a/rosenpass/src/internal/util/ringbuf/mod.rs
+++ b/rosenpass/src/internal/util/ringbuf/mod.rs
@@ -1,0 +1,3 @@
+//! Ring buffers and utilities for working with them
+
+pub mod sched;

--- a/rosenpass/src/internal/util/ringbuf/sched.rs
+++ b/rosenpass/src/internal/util/ringbuf/sched.rs
@@ -1,0 +1,1418 @@
+//! Contains [RingBufferScheduler], which does not actually implement a ring buffer, but which
+//! handles the complicated math involved in writing/reading to a ring buffer backed by a linear
+//! memory array
+
+use std::borrow::Borrow;
+
+use crate::internal::util::{
+    functional::{ApplyExt, MutatingExt},
+    int::modular::Modulus,
+    int::u64uint::{TruncateIntoU64USize, U64USize, U64USizeConversionError},
+    mem::{CopyExt, MutateRefExt},
+    result::OkExt,
+};
+
+/// Boolean numbers, named "Zero" and "One" for clarity
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Bit {
+    /// Zero <=> False
+    Zero,
+    /// One <=> True
+    One,
+}
+
+/// Type of a block in a ring buffer. Can either be occupied or not.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BlockType {
+    /// The block does not contain data
+    Free,
+    /// The block does contain data
+    Data,
+}
+
+/// Distinguishes Read & Write operations
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum OperationType {
+    /// Read from the ring buffer
+    Read,
+    /// Write to the ring buffer
+    Write,
+}
+
+/// Identifying information about a block in a ring buffer
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Block {
+    /// What sort of block this is
+    pub typ: BlockType,
+    /// The index; together with `typ` this uniquely identifies a block.
+    /// A block `no = Zero, typ = Free` would be the first empty block in
+    /// a ring buffer. `no = One, typ = Data` would be the second data-filled block
+    pub no: Bit,
+    /// Where the block begins
+    pub off: u64,
+    /// How long the block is
+    pub len: u64,
+}
+
+impl Block {
+    /// Constructor
+    pub fn new(typ: BlockType, no: Bit, off: u64, len: u64) -> Self {
+        Self { typ, no, off, len }
+    }
+}
+
+/// According to the write/read offsets, a buffer can use one of two layouts
+///
+/// Layout 1:
+///
+/// ```txt
+/// Data | Free | Data
+/// ```
+///
+/// Layout 2:
+///
+/// ```txt
+/// Free | Data | Free
+/// ```
+///
+/// For details about how the layout is determined, please
+/// see the source code of [RingBufferScheduler::layout].
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub enum BufferLayout {
+    /// Layout is `Data | Free | Data`
+    DataFreeData,
+    /// Layout is `Free | Data | Free`
+    FreeDataFree,
+}
+
+/// Fill state of the ring buffer
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub enum BufferFillState {
+    /// Entirely empty
+    Empty,
+    /// Part empty, part filled
+    Partial,
+    /// Entirely filled
+    Full,
+}
+
+/// Operations that can be passed to [RingBufferScheduler::try_register_operation]
+pub trait RegisterableOperation {
+    /// Error type returned in case of failure
+    type Error: std::fmt::Debug;
+    /// Register this operation with a ring buffer
+    fn register(&self, ring: RingBufferScheduler) -> Result<RingBufferScheduler, Self::Error>;
+}
+
+/// A scheduled operation on the ring buffer.
+///
+/// This is returned by [RingBufferScheduler::schedule_reads]/[RingBufferScheduler::schedule_writes]
+/// in an array and essentially just represents a slice in the ring buffer.
+///
+/// Also see [ScheduledOperations] which offers operations on the whole array of
+/// operations returned by the ring buffer.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ScheduledOperation {
+    /// A hint, about whether this operation is a read or a write
+    pub typ: OperationType,
+    /// Ring buffer offset, where the operation should start
+    pub off: u64,
+    /// After how many items the operation should end
+    pub len: U64USize,
+}
+
+/// We need default for [tinyvec::ArrayVec] to work
+impl Default for ScheduledOperation {
+    fn default() -> Self {
+        Self::new(OperationType::Read, Default::default(), Default::default())
+    }
+}
+
+impl ScheduledOperation {
+    /// Constructor
+    pub fn new(typ: OperationType, off: u64, len: U64USize) -> Self {
+        Self { typ, off, len }
+    }
+}
+
+impl RegisterableOperation for ScheduledOperation {
+    type Error = RingBufferRegisterOpError;
+
+    fn register(&self, ring: RingBufferScheduler) -> Result<RingBufferScheduler, Self::Error> {
+        ring.try_register_operation_manually(self.typ, self.len.u64())
+    }
+}
+
+/// Error returned by [ScheduledOperations::try_new]
+#[derive(thiserror::Error, Debug)]
+pub enum ScheduledOperationCreationError {
+    /// Cause of this error
+    #[error("Could not create ScheduledOperations (list of ScheduledOperation); cumulative operation length too long: {:?}", .0)]
+    SizeConversionError(#[from] U64USizeConversionError<u64>),
+    /// The operations are not all of the same type
+    #[error(
+        "Could not create ScheduledOperations (list of ScheduledOperation); inconsistent operation type (read/write)"
+    )]
+    InconsistentOperationType,
+}
+
+/// The type returned by [RingBufferScheduler::schedule_contigous_operations()] and sister
+/// functions.
+pub type ScheduledOperations =
+    AbstractScheduledOperations<tinyvec::ArrayVec<[ScheduledOperation; 2]>>;
+
+/// Represents a list of [ScheduledOperation]s, while enforcing that the total operation
+/// length can be represented both as a u64 and as a usize and that all the operation types
+/// (read/write) are the same.
+///
+/// This is the abstract type that supports many different containers. The concrete type
+/// represented by [RingBufferScheduler::schedule_contigous_operations()] and sister methods
+/// is [ScheduledOperations].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct AbstractScheduledOperations<Cont>
+where
+    Cont: IntoIterator<Item = ScheduledOperation>,
+    for<'a> &'a Cont: IntoIterator<Item = &'a ScheduledOperation>,
+    for<'a> &'a mut Cont: IntoIterator<Item = &'a mut ScheduledOperation>,
+{
+    /// Inner range
+    cont: Cont,
+}
+
+impl<Cont> RegisterableOperation for AbstractScheduledOperations<Cont>
+where
+    Cont: IntoIterator<Item = ScheduledOperation>,
+    for<'a> &'a Cont: IntoIterator<Item = &'a ScheduledOperation>,
+    for<'a> &'a mut Cont: IntoIterator<Item = &'a mut ScheduledOperation>,
+{
+    type Error = RingBufferRegisterOpError;
+
+    fn register(&self, ring: RingBufferScheduler) -> Result<RingBufferScheduler, Self::Error> {
+        self.container()
+            .into_iter()
+            .try_fold(ring, |ring, op| ring.try_register_operation(op))
+    }
+}
+
+impl<Cont> AbstractScheduledOperations<Cont>
+where
+    Cont: IntoIterator<Item = ScheduledOperation>,
+    for<'a> &'a Cont: IntoIterator<Item = &'a ScheduledOperation>,
+    for<'a> &'a mut Cont: IntoIterator<Item = &'a mut ScheduledOperation>,
+{
+    /// Ensure this ScheduledOperations is in a sound in a sound state
+    fn demand_soundness(&self) -> Result<(), ScheduledOperationCreationError> {
+        use ScheduledOperationCreationError as E;
+
+        // Ensure that the operation length is representable as usize & u64
+        U64USize::try_new(self.cumulative_operation_length_u64())?;
+
+        // Ensure that the operation type is the same across all operations
+        self.container()
+            .into_iter()
+            .map(|op| op.typ)
+            .map(Some)
+            .reduce(|acc, elm| (acc == elm).then_some(()).and(acc))
+            .map(|v| v.is_some())
+            .unwrap_or(true)
+            .then_some(())
+            .ok_or(E::InconsistentOperationType)?;
+
+        Ok(())
+    }
+
+    /// Create a new list of scheduled operations
+    pub fn try_new(cont: Cont) -> Result<Self, ScheduledOperationCreationError> {
+        let me = Self { cont };
+        me.demand_soundness()?;
+        Ok(me)
+    }
+
+    /// Like [Self::try_new], but panics on error
+    pub fn new_or_panic(cont: Cont) -> Self {
+        match Self::try_new(cont) {
+            Ok(v) => v,
+            Err(e) => panic!("{e:?}"),
+        }
+    }
+
+    /// Access to the inner container
+    pub fn container(&self) -> &Cont {
+        self.cont.borrow()
+    }
+
+    /// Extract the inner container
+    pub fn into_container(self) -> Cont {
+        self.cont
+    }
+
+    /// Used by [Self::try_new] and [Self::cumulative_operation_length]
+    fn cumulative_operation_length_u64(&self) -> u64 {
+        // Won't panic, because we ensure that the cumulative length is short enough
+        // upon creation of Self
+        self.cont
+            .borrow()
+            .into_iter()
+            .map(|op| op.len.u64())
+            .fold(0u64, std::ops::Add::add)
+    }
+
+    /// Sum of all the operation lengths in the list.
+    ///
+    /// This would be the total number of bytes written/read if all of the operations where
+    /// applied.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use rosenpass::internal::util::ringbuf::sched::{AbstractScheduledOperations, ScheduledOperation, OperationType};
+    ///
+    /// use OperationType::Read as R;
+    ///
+    /// let inp = AbstractScheduledOperations::new_or_panic(vec![
+    ///     ScheduledOperation::new(R, 8, 1u8.into()),
+    ///     ScheduledOperation::new(R, 22, 10u8.into()),
+    ///     ScheduledOperation::new(R, 1000, 100u8.into()),
+    /// ]);
+    ///
+    /// assert_eq!(inp.cumulative_operation_length(), 111u8.into());
+    /// ```
+    pub fn cumulative_operation_length(&self) -> U64USize {
+        // Won't panic, because we ensure that the cumulative length is short enough
+        // upon creation of Self
+        self.cumulative_operation_length_u64()
+            .apply(U64USize::new_or_panic)
+    }
+
+    /// Sum of the operation lengths before an operation, for each operation.
+    ///
+    /// In an operation between a linear buffer and a ring buffer, this represents offset in
+    /// the linear buffer where the operation would start.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use rosenpass::internal::util::ringbuf::sched::{AbstractScheduledOperations, ScheduledOperation, OperationType};
+    ///
+    /// use OperationType::Read as R;
+    ///
+    /// let inp = AbstractScheduledOperations::new_or_panic(vec![
+    ///     ScheduledOperation::new(R, 8, 1u8.into()),
+    ///     ScheduledOperation::new(R, 22, 10u8.into()),
+    ///     ScheduledOperation::new(R, 1000, 100u8.into()),
+    /// ]);
+    ///
+    /// let cor = vec![
+    ///     (0,  ScheduledOperation::new(R, 8, 1u8.into())),
+    ///     (1,  ScheduledOperation::new(R, 22, 10u8.into())),
+    ///     (11, ScheduledOperation::new(R, 1000, 100u8.into())),
+    /// ];
+    ///
+    /// let out : Vec<(u64, ScheduledOperation)> = inp.with_cumulative_offset()
+    ///     .into_iter()
+    ///     .map(|(off, op)| (off.u64(), *op))
+    ///     .collect();
+    ///
+    /// assert_eq!(cor, out);
+    /// ```
+    pub fn with_cumulative_offset(
+        &self,
+    ) -> impl IntoIterator<Item = (U64USize, &ScheduledOperation)> {
+        // Won't panic, because we ensure that the cumulative length is short enough
+        // upon creation of Self
+        let mut cumulative_offset = 0;
+        self.cont.borrow().into_iter().map(move |op| {
+            let result = (U64USize::new_or_panic(cumulative_offset), op);
+            cumulative_offset += op.len.u64();
+            result
+        })
+    }
+
+    /// Prepares operations between a ring buffer and a linear slice of memory.
+    ///
+    /// Returns tuples where
+    ///
+    /// 1. the first element represents the subslice of the linear memory slice
+    /// 2. the second element represents the subslice of the ring buffer
+    ///
+    /// You can work with the `std::ops::Range<`[U64USize]`>` ranges easily by utilizing
+    /// [crate::internal::util::int::u64uint::U64USizeRangeExt].
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use rosenpass::internal::util::int::u64uint::U64USize;
+    /// use rosenpass::internal::util::ringbuf::sched::{OperationType, ScheduledOperation, ScheduledOperations};
+    ///
+    /// use tinyvec::ArrayVec;
+    ///
+    /// use std::ops::Range;
+    ///
+    /// fn op(off: u64, len: u64) -> ScheduledOperation {
+    ///     ScheduledOperation::new(OperationType::Read, off, len.try_into().unwrap())
+    /// }
+    ///
+    /// fn range(start: u64, end: u64) -> Range<U64USize> {
+    ///     Range {
+    ///         start: start.try_into().unwrap(),
+    ///         end: end.try_into().unwrap(),
+    ///     }
+    /// }
+    ///
+    /// let inp =
+    ///     ScheduledOperations::new_or_panic(ArrayVec::from([op(8, 1), op(22, 10)]));
+    ///
+    /// let outp: Vec<(Range<U64USize>, ScheduledOperation)> = vec![
+    ///     (range(0, 1), op(8, 1)),
+    ///     (range(1, 11), op(22, 10)),
+    /// ];
+    ///
+    /// let out: Vec<(Range<U64USize>, ScheduledOperation)> = inp
+    ///     .with_outside_buffer_range()
+    ///     .into_iter()
+    ///     .map(|(range, op)| (range, *op))
+    ///     .collect();
+    ///
+    /// assert_eq!(outp, out);
+    /// ```
+    pub fn with_outside_buffer_range(
+        &self,
+    ) -> impl IntoIterator<Item = (std::ops::Range<U64USize>, &ScheduledOperation)> {
+        self.with_cumulative_offset()
+            .into_iter()
+            .map(|(cumul_off, op)| {
+                let range = std::ops::Range::<U64USize> {
+                    start: cumul_off,
+                    // Can not panic, because we checked that the value is
+                    // representable in [Self::demand_soundness]
+                    end: cumul_off + op.len,
+                };
+                (range, op)
+            })
+    }
+}
+
+/// Represent the information of whether two values are the same or different
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Diff<T: PartialEq> {
+    /// The two values are the same
+    Same(T),
+    /// The two values are different
+    Different(T, T),
+}
+
+impl<T: PartialEq> Diff<T> {
+    /// Constructor
+    pub fn new(old: T, new: T) -> Self {
+        match old == new {
+            true => Self::Same(old),
+            false => Self::Different(old, new),
+        }
+    }
+
+    /// Whether this enum is [Diff::Same]
+    pub fn is_same(&self) -> bool {
+        matches!(self, Self::Same(_))
+    }
+
+    /// Whether this enum is [Diff::Different]
+    pub fn is_different(&self) -> bool {
+        matches!(self, Self::Different(_, _))
+    }
+
+    /// Return the old value
+    pub fn old_value(self) -> T {
+        match self {
+            Diff::Same(v) => v,
+            Diff::Different(old, _) => old,
+        }
+    }
+
+    /// Return the new value
+    pub fn new_value(self) -> T {
+        match self {
+            Diff::Same(v) => v,
+            Diff::Different(_, new) => new,
+        }
+    }
+}
+
+/// Represents a differential over two [RingBufferScheduler]s
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct RingBufferSchedulerDiff {
+    /// How [RingBufferScheduler::buf_len()] changed
+    pub buf_len: Diff<u64>,
+    /// How [RingBufferScheduler::items_read()] changed
+    pub items_read: Diff<u64>,
+    /// How [RingBufferScheduler::items_written()] changed
+    pub items_written: Diff<u64>,
+}
+
+/// Returned by [RingBufferSchedulerDiff::expect_read_only()]
+#[derive(thiserror::Error, Debug)]
+#[error(
+    "Expected ring buffer scheduler diff to only contain a change in the number of items read, but the actual diff is: {diff:?}"
+)]
+pub struct RingBufferSchedulerDiffExpectReadOnlyError {
+    /// Full differential
+    pub diff: RingBufferSchedulerDiff,
+}
+
+/// Returned by [RingBufferSchedulerDiff::expect_write_only()]
+#[derive(thiserror::Error, Debug)]
+#[error(
+    "Expected ring buffer scheduler diff to only contain a change in the number of items read, but the actual diff is: {diff:?}"
+)]
+pub struct RingBufferSchedulerDiffExpectWriteOnlyError {
+    /// Full differential
+    pub diff: RingBufferSchedulerDiff,
+}
+
+/// Returned by [RingBufferSchedulerDiff::expect_op_only()]
+#[derive(thiserror::Error, Debug)]
+pub enum RingBufferSchedulerDiffExpectOpOnlyError {
+    /// Expands into [RingBufferSchedulerDiffExpectReadOnlyError]
+    #[error("{:?}", 0)]
+    ReadOnlyError(#[from] RingBufferSchedulerDiffExpectReadOnlyError),
+    /// Expands into [RingBufferSchedulerDiffExpectWriteOnlyError]
+    #[error("{:?}", 0)]
+    WriteOnlyError(#[from] RingBufferSchedulerDiffExpectWriteOnlyError),
+}
+
+impl RingBufferSchedulerDiff {
+    /// Constructor
+    pub fn new(a: RingBufferScheduler, b: RingBufferScheduler) -> Self {
+        Self {
+            buf_len: Diff::new(a.buf_len(), b.buf_len()),
+            items_read: Diff::new(a.items_read(), b.items_read()),
+            items_written: Diff::new(a.items_written(), b.items_written()),
+        }
+    }
+
+    /// Ensure that only the number of items read has changed and return the value
+    pub fn expect_read_only(self) -> Result<Diff<u64>, RingBufferSchedulerDiffExpectReadOnlyError> {
+        (self.buf_len.is_same() && self.items_written.is_same())
+            .then_some(())
+            .ok_or(RingBufferSchedulerDiffExpectReadOnlyError { diff: self })?;
+        Ok(self.items_read)
+    }
+
+    /// Ensure that only the number of items written has changed and return the value
+    pub fn expect_write_only(
+        self,
+    ) -> Result<Diff<u64>, RingBufferSchedulerDiffExpectWriteOnlyError> {
+        (self.buf_len.is_same() && self.items_read.is_same())
+            .then_some(())
+            .ok_or(RingBufferSchedulerDiffExpectWriteOnlyError { diff: self })?;
+        Ok(self.items_written)
+    }
+
+    /// Call [Self::expect_read_only]/[Self::expect_write_only] as indicated by the operation type
+    pub fn expect_op_only(
+        self,
+        op: OperationType,
+    ) -> Result<Diff<u64>, RingBufferSchedulerDiffExpectOpOnlyError> {
+        match op {
+            OperationType::Read => self.expect_read_only()?.ok(),
+            OperationType::Write => self.expect_write_only()?.ok(),
+        }
+    }
+}
+
+/// Handles the math involved in treating a linear slice of memory as a ring buffer.
+///
+/// The implementation supports buffers up to [Self::MAX_BUF_LEN] in size and handles arbitrarily
+/// sized buffers (there is no need to have the buffer size be a multiple of two). We are making no
+/// assumption about what sort of items are being transported. It could be bytes, could also be
+/// something else.
+///
+/// This is not necessarily a long-lived structure. There is nothing incorrect about constructing
+/// a scheduler on every function call (or read or write) operation in your ring buffer. The
+/// structure is completely defined by the values passed to [Self::new].
+///
+/// Most of the functions provided are used internally and may be of use to the users of the
+/// scheduler. The following operations are essential:
+///
+/// - [Self::new] – Create a new scheduler
+/// - [Self::register_write] – Call after actually performing a write to inform the scheduler
+///   about how much data was written
+/// - [Self::register_read] – Call after actually performing a read to inform the scheduler
+///   about how much data has bean read
+/// - [Self::schedule_next_read] – Schedule a single, contiguous read from the buffer
+/// - [Self::schedule_next_write] – Schedule a single, contiguous write to the buffer
+/// - [Self::schedule_reads]/[Self::schedule_writes] – Schedule multiple contiguous reads/writes;
+///   as many as are possible
+///
+/// Internally, the ring buffer stores three values:
+///
+/// - [Self::buf_len()] – The buffer length
+/// - [Self::items_read()] – Number of items read (read offset)
+/// - [Self::items_written()] – Number of items written (write offset)
+///
+/// ## Size Representation
+///
+/// For the sake of simplicity, [Self] represents all sizes as u64 internally and expects counters
+/// to be managed as u64 values.
+///
+/// To make sure, that the scheduler is still usable on systems where usize is not 64 bit long,
+/// the functions scheduling operations (e.g. [Self::schedule_contigous_operations]) never schedule
+/// any operations which are too long to be represented as both [u64] and [usize]; this limits
+/// operation size to around 4GB on 32 bit systems.
+///
+/// [Self] agressively uses [U64USize] in various APIs, to make the size requirements and behavior
+/// explicit. E.g. [ScheduledOperation::off] is u64, since it refers to positions in the linear
+/// buffer underlying the ring buffer while [ScheduledOperation::len] uses [U64USize], because it
+/// refers to the operation length, which must always fit into [usize] and [u64].
+///
+/// Note that [ScheduledOperation::off] being a [u64] is a minor issue. Users of this scheduler can
+/// make sure that this offset always fits into a [usize] by choosing a buffer length that fits
+/// into [usize].
+///
+/// ## Counter representations
+///
+/// The counters ([Self::items_read], [Self::items_written]) are elements of $ℤ_{2 \cdot \texttt{buf_len}}$ (i.e. the
+/// integers modulo `2 * buf_len` such that
+///
+/// ```rust,ignore
+/// items_written - items_read <= buf_len
+/// ```
+///
+/// , but they are represented as u64 internally.
+///
+/// This representation is quite convenient for concurrent ring buffers, as it makes sure that
+/// read operations and write operations never need to update the same values. Write operations
+/// just update items_written and read operations update items_read through modular addition each.
+///
+/// In this representation, all possible fill states have a clear representation
+///
+/// ```rust,ignore
+/// data_avail = items_written - items_read
+/// space_avail = buf_len - (data_avail)
+/// is_empty => data_avail = 0, space_avail = buf_len
+/// is_full  => data_avail = buf_len, space_avail = 0
+/// ```
+///
+/// These counters are monotonically increasing; although because we are
+/// using modular addition the values often decrease when viewed as plain integers. When using these numbers
+/// to derive buffer offsets ([Self::read_off], [Self::write_off]), the scheduler just takes the
+/// number of items written/read modulo the buffer length:
+///
+/// ```rust,ignore
+/// read_off = items_read % buf_len
+/// write_off = items_written % buf_len
+/// ```
+///
+/// This representation als makes sure we can handle all allowed buffer sizes with ease.
+///
+/// ## Contiguous data blocks
+///
+/// The scheduler separates the ring buffer into three regions we call blocks:
+///
+/// ```txt
+/// Block 0 | Block 1 | Block 2
+/// ```
+///
+/// Depending on the number of items written/read, there are four layouts:
+///
+/// Layout 1 (Partially filled, `read_off < write_off`):
+///
+/// ```txt
+///       Block 0       |       Block 1       |       Block 2
+/// Write/Free Block 1  | Read/Filled Block 0 | Write/Free Block 0
+/// POSSIBLY ZERO SIZED |                    |  NEVER ZERO SIZED
+///                   read_off            write_off
+/// ```
+///
+/// Layout 2 (Partially filled, `write_off < read_off`):
+///
+/// ```txt
+///       Block 0       |       Block 1      |       Block 2
+/// Read/Filled Block 1 | Write/Free Block 0 | Read/Filled Block 0
+/// POSSIBLY ZERO SIZED |                    |  NEVER ZERO SIZED
+///                   write_off           read_off
+/// ```
+///
+/// Layout 3 (Filled):
+///
+/// ```txt
+///       Block 0       |       Block 1        |       Block 2
+/// Read/Filled Block 1 |  Write/Empty Block 0 | Read/Filled Block 0
+/// POSSIBLY ZERO SIZED |     ZERO SIZED       |  NEVER ZERO SIZED
+///                   write_off             read_off
+/// ```
+///
+/// Layout 3 (Empty):
+///
+/// ```txt
+///       Block 0       |       Block 1        |       Block 2
+/// Write/Empty Block 1 |  Read/Filled Block 0 | Write/Empty Block 0
+/// POSSIBLY ZERO SIZED |     ZERO SIZED       |  NEVER ZERO SIZED
+///                   read_off             write_off
+/// ```
+///
+/// The layout used can be determined with [Self::layout()].
+///
+/// Note that Block 0, i.e. Empty Block 1 or Filled Block 1 is never actually used for any
+/// operations. This is not a problem, because filling up Block 2 will just flip the entire
+/// ring buffer into the other layout: Block 1 becomes Block 2, Block 0 becomes Block 1 and
+/// Block 2 becomes Block 0 which is not zero-sized. Take this example:
+///
+/// ```txt
+/// buf_len = 100
+/// items_read = 120
+/// items_written = 180
+///
+/// read_off  = items_read    % buf_len = 120 % 100 = 20
+/// write_off = items_written % buf_len = 180 % 100 = 80
+///
+/// layout = FreeDataFree
+///
+/// |       Block 0       |       Block 1        |       Block 2    |
+/// |        Free         |        Data          |        Free      |
+/// |      (20 items)     |      (60 items)      |      (20 items)  |
+///
+///               read_off = 20             write_off = 80
+/// ```
+///
+/// Block 2 can now be filled by writing 20 items. After this write, the buffer
+/// will be in the following state:
+///
+/// ```txt
+/// buf_len = 100
+/// items_read = 120
+/// items_written = 200
+///
+/// read_off  = items_read    % buf_len = 120 % 100 = 20
+/// write_off = items_written % buf_len = 200 % 100 = 0
+///
+/// layout = DataFreeData
+///
+/// |       Block 0       |       Block 1        |       Block 2    |
+/// |        Data         |        Free          |        Data      |
+/// |      (0 items)      |      (20 items)      |      (60 items)  |
+///
+///               write_off = 0             read_off = 20
+/// ```
+#[derive(Copy, Clone, PartialEq, Eq)]
+pub struct RingBufferScheduler {
+    /// Length of the ring buffer
+    buf_len: u64,
+    /// Read offset (is not reset and can be bigger than the buffer length)
+    items_read: u64,
+    /// Write offset (is not reset; routinely bigger than the buffer length and reduced through
+    /// modulo)
+    items_written: u64,
+}
+/// Error produced by [RingBufferScheduler::try_new]
+#[derive(Debug, thiserror::Error, Clone, Copy, PartialEq, Eq)]
+pub enum RingBufferNewError {
+    /// The buffer size is too large. This means an extremely large buffer (> 1<<63) is being
+    /// managed. What year is this? :)
+    #[error("Requested buffer size ({}) is too large. Maximum supported buffer size is (1<<63 = {})", .0, RingBufferScheduler::MAX_BUF_LEN)]
+    BufferTooLarge(u64),
+}
+
+/// Error produced by [RingBufferScheduler::try_from_counters]
+#[derive(Debug, thiserror::Error, Clone, Copy, PartialEq, Eq)]
+pub enum RingBufferFromCountersError {
+    /// The buffer size is too large. This means an extremely large buffer (> 1<<63) is being
+    /// managed. What year is this? :)
+    #[error("{:0}", .0)]
+    RingBufferNewError(#[from] RingBufferNewError),
+    /// items_written >= 2*buf_len
+    #[error("For a ring buffer of length {buf_len}, \
+        items_written must be < {bl2}, but the actual value is {items_written}",
+        bl2 = buf_len*2)]
+    ItemsWrittenOutOfBounds {
+        /// buf_len parameter
+        buf_len: u64,
+        /// items_written parameter
+        items_written: u64,
+    },
+    /// items_read >= 2*buf_len
+    #[error("For a ring buffer of length {buf_len}, \
+        items_read must be < {bl2}, but the actual value is {items_read}",
+        bl2 = buf_len*2)]
+    ItemsReadOutofBounds {
+        /// buf_len parameter
+        buf_len: u64,
+        /// items_read parameter
+        items_read: u64,
+    },
+    /// Counters are larger than allowed
+    #[error("For a ring buffer of length {buf_len}, \
+        items_read must be <= {buf_len}, but the actual value is {data_avail}: \
+        data_avail = items_written - items_read = {items_written} - {items_read} \
+        = {data_avail} (mod 2 * buf_len = {bl2})",
+        data_avail = Modulus::<u64>::new_or_panic(buf_len.wrapping_mul(2)).formula([*items_written, *items_read], |[w, r]| {
+            w - r
+        }),
+        bl2 = buf_len.wrapping_mul(2))]
+    DataAvailOutOfBounds {
+        /// buf_len parameter
+        buf_len: u64,
+        /// items_written parameter
+        items_written: u64,
+        /// items_read parameter
+        items_read: u64,
+    },
+}
+
+/// Error produced by [RingBufferScheduler::try_register_read]/[RingBufferScheduler::try_register_write]
+#[derive(Debug, thiserror::Error, Clone, Copy, PartialEq, Eq)]
+pub enum RingBufferRegisterOpError {
+    /// Operation out of bounds given current buffer
+    /// [RingBufferScheduler::data_avail]/[RingBufferScheduler::space_avail]
+    #[error(
+        "Requested operation size ({op_type:?} of len {op_len}) is too large. \
+        Given the current ring buffer state, the maximum supported {op_type:?} length is {max_len}. \
+        This usually indicates a developer error."
+    )]
+    OperationTooLarge {
+        /// Operation type
+        op_type: OperationType,
+        /// Operation length
+        op_len: u64,
+        /// Maximum allowed operation length
+        max_len: u64,
+    },
+}
+
+impl RingBufferScheduler {
+    /// Maximum supported buffer size
+    pub const MAX_BUF_LEN: u64 = 1 << (u64::BITS - 1);
+
+    /// Construct a new [Self] from its components
+    fn new_raw(buf_len: u64, items_written: u64, items_read: u64) -> Self {
+        Self {
+            buf_len,
+            items_read,
+            items_written,
+        }
+    }
+
+    /// Ensure this ring buffer is in a sound in a sound state
+    fn demand_soundness(&self) -> Result<(), RingBufferFromCountersError> {
+        let Self {
+            buf_len,
+            items_written,
+            items_read,
+        } = *self;
+
+        // There is exactly one valid zero-size buffer representation
+        if *self == Self::new_raw(0, 0, 0) {
+            return Ok(());
+        };
+
+        // Double-check that self.buf_modulus() won't panic
+        self.buf_modulus().unwrap();
+
+        // Ensure the buffer length is small enough
+        let bm2 = self
+            .buf_double_modulus()
+            .ok_or(RingBufferNewError::BufferTooLarge(buf_len))?;
+
+        use RingBufferFromCountersError as E;
+        bm2.contains(items_written)
+            .then_some(())
+            .ok_or(E::ItemsWrittenOutOfBounds {
+                buf_len,
+                items_written,
+            })?;
+        bm2.contains(items_read)
+            .then_some(())
+            .ok_or(E::ItemsReadOutofBounds {
+                buf_len,
+                items_read,
+            })?;
+        (self.data_avail() <= self.buf_len())
+            .then_some(())
+            .ok_or(E::DataAvailOutOfBounds {
+                buf_len,
+                items_written,
+                items_read,
+            })?;
+
+        Ok(())
+    }
+
+    /// Non-panicking variant of [Self::new]
+    pub fn try_new(buf_len: u64) -> Result<Self, RingBufferNewError> {
+        match Self::try_from_counters(buf_len, 0, 0) {
+            Ok(me) => Ok(me),
+            Err(RingBufferFromCountersError::RingBufferNewError(e)) => Err(e),
+            // Should be impossible
+            Err(other_error) => panic!("{other_error:?}"),
+        }
+    }
+
+    /// Construct a new [Self] from the buffer length, with counters set to zero.
+    ///
+    /// # Panic
+    ///
+    /// Panics if buf_len > [Self::MAX_BUF_LEN]
+    pub fn new(buf_len: u64) -> Self {
+        Self::try_new(buf_len).unwrap()
+    }
+
+    /// Construct a ring buffer with specific counter values
+    ///
+    /// Non-panicking variant of [Self::from_counters]
+    pub fn try_from_counters(
+        buf_len: u64,
+        items_written: u64,
+        items_read: u64,
+    ) -> Result<Self, RingBufferFromCountersError> {
+        let r = Self::new_raw(buf_len, items_written, items_read);
+        r.demand_soundness()?;
+        Ok(r)
+    }
+
+    /// Construct a ring buffer scheduler from the buffer length and the current values of the
+    ///
+    /// Counters are taken modulo `2 * buf_len` upon creation.
+    ///
+    /// # Panic
+    ///
+    /// Panics if [Self::try_from_counters] would throw an error. See
+    /// [RingBufferFromCountersError].
+    pub fn from_counters(buf_len: u64, items_written: u64, items_read: u64) -> Self {
+        Self::try_from_counters(buf_len, items_written, items_read).unwrap()
+    }
+
+    /// Create a differential over two ring buffer schedulers
+    pub fn diff_old(&self, old: &Self) -> RingBufferSchedulerDiff {
+        RingBufferSchedulerDiff::new(old.copy(), self.copy())
+    }
+
+    /// Notify the ring buffer about a read having been made
+    #[allow(clippy::double_must_use)]
+    #[must_use]
+    pub fn try_register_read(&self, len: u64) -> Result<Self, RingBufferRegisterOpError> {
+        self.try_register_operation_manually(OperationType::Read, len)
+    }
+
+    /// Notify the ring buffer about a write having been made.
+    ///
+    /// Returns an error, if the write is longer than it could have currently supported.
+    #[allow(clippy::double_must_use)]
+    #[must_use]
+    pub fn try_register_write(&self, len: u64) -> Result<Self, RingBufferRegisterOpError> {
+        self.try_register_operation_manually(OperationType::Write, len)
+    }
+
+    /// Calls [Self::register_read]/[Self::register_write]
+    /// based on the operation given
+    #[rustfmt::skip]
+    #[allow(clippy::double_must_use)]
+    #[must_use]
+    pub fn try_register_operation_manually(
+        &self,
+        op: OperationType,
+        len: u64,
+    ) -> Result<Self, RingBufferRegisterOpError> {
+        let max_op_len = self.max_operation_len(op);
+        if len > max_op_len {
+            return Err(RingBufferRegisterOpError::OperationTooLarge {
+                op_type: op,
+                op_len: len,
+                max_len: max_op_len,
+            });
+        }
+
+        let m = match self.buf_double_modulus() {
+            None => return self.copy().ok(), // Zero-sized
+            Some(m) => m,
+        };
+
+        self.copy().mutating(|v| {
+            v.operation_counter_mut(op).mutate(|ctr| {
+                m.formula([ctr, len], |[ctr, len]| {
+                    ctr + len
+                })
+            });
+        }).ok()
+    }
+
+    /// Notify the ring buffer about a read having been made
+    ///
+    /// # Panic
+    ///
+    /// Panics if the read is longer than currently possible according to [Self::data_avail()]
+    #[must_use]
+    pub fn register_read(&self, len: u64) -> Self {
+        self.try_register_read(len).unwrap()
+    }
+
+    /// Notify the ring buffer about a write having been made.
+    ///
+    /// # Panic
+    ///
+    /// Panics if the read is longer than currently possible according to [Self::space_avail()]
+    #[must_use]
+    pub fn register_write(&self, len: u64) -> Self {
+        self.try_register_write(len).unwrap()
+    }
+
+    /// Calls [Self::register_read]/[Self::register_write]
+    /// according to the operation given
+    ///
+    /// # Panics
+    ///
+    /// If [Self::try_register_operation_manually] would return an error
+    #[must_use]
+    pub fn register_operation_manually(&self, op: OperationType, len: u64) -> Self {
+        self.try_register_operation_manually(op, len).unwrap()
+    }
+
+    /// Used to register an operation generated using [Self::schedule_next_write]/[Self::schedule_next_read]/[Self::schedule_reads]/[Self::schedule_next_write],
+    /// provided the operation was executed faithfully and for the full length indicated in the
+    /// operation
+    ///
+    /// Slightly easier than calling [Self::try_register_write]/[Self::try_register_read] manually.
+    ///
+    /// # Panics
+    ///
+    /// If [Self::try_register_operation] would return an error
+    #[must_use]
+    pub fn register_operation<Op: RegisterableOperation>(&self, op: &Op) -> Self {
+        self.try_register_operation(op).unwrap()
+    }
+
+    /// Non-panicking variant of [Self::register_operation]
+    #[must_use]
+    #[allow(clippy::double_must_use)]
+    pub fn try_register_operation<Op: RegisterableOperation>(
+        &self,
+        op: &Op,
+    ) -> Result<Self, <Op as RegisterableOperation>::Error> {
+        op.register(self.copy())
+    }
+
+    /// Number of total items written to the ring buffer (mod 2 * buf_len); this exactly the value passed to
+    /// [Self::new]
+    pub fn items_read(&self) -> u64 {
+        self.items_read
+    }
+
+    /// Number of total items read forom the ring buffer (mod 2 * buf_len); this exactly the value passed to
+    /// [Self::new]
+    pub fn items_written(&self) -> u64 {
+        self.items_written
+    }
+
+    /// Calls [Self::items_written]/[Self::items_read] according to the
+    /// operation given
+    pub fn operation_counter(&self, op: OperationType) -> u64 {
+        match op {
+            OperationType::Write => self.items_written,
+            OperationType::Read => self.items_read,
+        }
+    }
+
+    /// Like [Self::operation_counter], but returns a mutable reference
+    fn operation_counter_mut(&mut self, op: OperationType) -> &mut u64 {
+        match op {
+            OperationType::Write => &mut self.items_written,
+            OperationType::Read => &mut self.items_read,
+        }
+    }
+
+    /// Calls [Self::read_off]/[Self::write_off] according to the
+    /// operation given
+    pub fn operation_offset(&self, op: OperationType) -> u64 {
+        let ctr = self.operation_counter(op);
+        match self.is_zero_sized() {
+            false => ctr % self.buf_len(),
+            true => {
+                assert_eq!(ctr, 0); // Purely defensive
+                0
+            }
+        }
+    }
+
+    /// Read offset in the ring buffer;
+    ///
+    /// ```txt
+    /// read_off = items_read % buf_len
+    /// ```
+    pub fn read_off(&self) -> u64 {
+        self.operation_offset(OperationType::Read)
+    }
+
+    /// Write offset in the ring buffer;
+    ///
+    /// ```txt
+    /// write_off = items_written % buf_len
+    /// ```
+    pub fn write_off(&self) -> u64 {
+        self.operation_offset(OperationType::Write)
+    }
+
+    /// Length of the ring buffer; this exactly the value passed to
+    /// [Self::new]
+    pub fn buf_len(&self) -> u64 {
+        self.buf_len
+    }
+
+    /// Check whether [Self::buf_len()] == 0
+    pub fn is_zero_sized(&self) -> bool {
+        self.buf_len() == 0
+    }
+
+    /// [Self::buf_len] converted to [Modulus], for internal use
+    fn buf_modulus(&self) -> Option<Modulus<u64>> {
+        // Won't panic, because we checked in [Self::try_new] that the buffer is small enough
+        match self.buf_len() {
+            0 => None,
+            l => Some(Modulus::new_or_panic(l)),
+        }
+    }
+
+    /// [Self::buf_modulus()].[double()](Modulus::double).[unwrap()](Result::unwrap); we know this
+    /// can not panic because we ensured the buffer is small enough in [Self::try_new()].
+    fn buf_double_modulus(&self) -> Option<Modulus<u64>> {
+        self.buf_modulus().and_then(|m| m.double())
+    }
+
+    /// Calls [Self::data_avail] for reads or [Self::space_avail] for writes for writes
+    pub fn max_operation_len(&self, op: OperationType) -> u64 {
+        match op {
+            OperationType::Read => self.data_avail(),
+            OperationType::Write => self.space_avail(),
+        }
+    }
+
+    /// How many items can be read from the ring buffer
+    ///
+    /// ```txt
+    /// data_avail =
+    ///     if items_written == items_read then 0
+    ///     if items_written != items_read then write_off - read_off (mod buf_len)
+    /// ```
+    ///
+    /// It would be simpler to calculate data_avail directly from items_read/written
+    ///
+    /// ```rust,ignore
+    /// items_written - items_read
+    /// ```
+    ///
+    /// unfortunately, this method breaks when the underlying u64 value is overflowing.
+    #[rustfmt::skip]
+    pub fn data_avail(&self) -> u64 {
+        self.buf_double_modulus().map(|bm2| {
+            bm2.formula([self.items_written(), self.items_read()], |[w, r]| {
+                w - r
+            })
+        }).unwrap_or(0)
+    }
+
+    /// How many items can be written to the ring buffer
+    ///
+    /// ```txt
+    /// space_avail = buf_len - data_avail
+    ///             = buf_len - (items_written - items_read)
+    /// ```
+    pub fn space_avail(&self) -> u64 {
+        self.buf_len() - self.data_avail()
+    }
+
+    /// How full the ring buffer is
+    pub fn fill_state(&self) -> BufferFillState {
+        use BufferFillState as F;
+        match (self.is_empty(), self.is_full()) {
+            (true, false) => F::Empty,
+            (false, false) => F::Partial,
+            (false, true) => F::Full,
+            (true, true) => panic!(
+                "Contradiction! Buffer can not be both full and empty. This is a developer error."
+            ),
+        }
+    }
+
+    /// Whether the ring buffer is empty
+    pub fn is_empty(&self) -> bool {
+        self.data_avail() == 0
+    }
+
+    /// Whether the ring buffer is full
+    pub fn is_full(&self) -> bool {
+        self.space_avail() == 0
+    }
+
+    /// Whether the ring buffer not empty
+    pub fn is_nonempty(&self) -> bool {
+        !self.is_empty()
+    }
+
+    /// Whether the ring buffer not full
+    pub fn is_nonfull(&self) -> bool {
+        !self.is_full()
+    }
+
+    /// Offset of Block 0 in the buffer
+    ///
+    /// See [Self] for more information on the ring buffer memory layout
+    pub fn block_0_off(&self) -> u64 {
+        0
+    }
+
+    /// Offset of Block 1 in the buffer
+    ///
+    /// See [Self] for more information on the ring buffer memory layout
+    pub fn block_1_off(&self) -> u64 {
+        std::cmp::min(self.read_off(), self.write_off())
+    }
+
+    /// Offset of Block 2 in the buffer
+    ///
+    /// See [Self] for more information on the ring buffer memory layout
+    pub fn block_2_off(&self) -> u64 {
+        std::cmp::max(self.read_off(), self.write_off())
+    }
+
+    /// Length of Block 0
+    ///
+    /// See [Self] for more information on the ring buffer memory layout
+    pub fn block_0_len(&self) -> u64 {
+        self.block_1_off() - self.block_0_off()
+    }
+
+    /// Length of Block 1
+    ///
+    /// See [Self] for more information on the ring buffer memory layout
+    pub fn block_1_len(&self) -> u64 {
+        self.block_2_off() - self.block_1_off()
+    }
+
+    /// Length of Block 2
+    ///
+    /// See [Self] for more information on the ring buffer memory layout
+    pub fn block_2_len(&self) -> u64 {
+        self.buf_len() - self.block_2_off()
+    }
+
+    /// Ring buffer layout
+    ///
+    /// See [Self] for more information on the ring buffer memory layout
+    pub fn layout(&self) -> BufferLayout {
+        let ord = std::cmp::Ord::cmp(&self.read_off(), &self.write_off());
+        let fill = self.fill_state();
+
+        use BufferFillState as F;
+        use std::cmp::Ordering as O;
+        match (ord, fill) {
+            (O::Less, F::Partial) => BufferLayout::FreeDataFree,
+            (O::Greater, F::Partial) => BufferLayout::DataFreeData,
+            (O::Equal, F::Empty) => BufferLayout::FreeDataFree,
+            (O::Equal, F::Full) => BufferLayout::DataFreeData,
+            (ord, fill) => panic!(
+                "\
+                Contradictory buffer layout. \
+                Ordering cmp(read_off_mod = {}, write_off_mod = {}) = {ord:?}, but \
+                fill state is {fill:?}. This is a developer error.\
+                ",
+                self.read_off(),
+                self.write_off(),
+            ),
+        }
+    }
+
+    /// Access meta data about Block 0
+    ///
+    /// See [Self] for more information on the ring buffer memory layout
+    pub fn block_0(&self) -> Block {
+        let (typ, no) = match self.layout() {
+            BufferLayout::DataFreeData => (BlockType::Data, Bit::One),
+            BufferLayout::FreeDataFree => (BlockType::Free, Bit::One),
+        };
+        Block::new(typ, no, self.block_0_off(), self.block_0_len())
+    }
+
+    /// Access meta data about Block 1
+    ///
+    /// See [Self] for more information on the ring buffer memory layout
+    pub fn block_1(&self) -> Block {
+        let (typ, no) = match self.layout() {
+            BufferLayout::DataFreeData => (BlockType::Free, Bit::Zero),
+            BufferLayout::FreeDataFree => (BlockType::Data, Bit::Zero),
+        };
+        Block::new(typ, no, self.block_1_off(), self.block_1_len())
+    }
+
+    /// Access meta data about Block 2
+    ///
+    /// See [Self] for more information on the ring buffer memory layout
+    pub fn block_2(&self) -> Block {
+        let (typ, no) = match self.layout() {
+            BufferLayout::DataFreeData => (BlockType::Data, Bit::Zero),
+            BufferLayout::FreeDataFree => (BlockType::Free, Bit::Zero),
+        };
+        Block::new(typ, no, self.block_2_off(), self.block_2_len())
+    }
+
+    /// Access meta data about all Blocks in the ring buffer
+    ///
+    /// See [Self] for more information on the ring buffer memory layout
+    pub fn blocks(&self) -> [Block; 3] {
+        [self.block_0(), self.block_1(), self.block_2()]
+    }
+
+    /// Which contiguous memory block to use for the next operation
+    ///
+    /// See [Self] for more information on the ring buffer memory layout.
+    ///
+    /// Calls [Self::next_read_block]/[Self::next_write_block] as specified by the operation.
+    ///
+    /// Note that the resulting block can be zero-sized if the ring buffer is empty/full.
+    pub fn next_operation_block(&self, op: OperationType) -> Block {
+        use BufferLayout as L;
+        use OperationType as O;
+
+        match (self.layout(), op) {
+            (L::DataFreeData, O::Read) => self.block_2(),
+            (L::FreeDataFree, O::Read) => self.block_1(),
+            (L::DataFreeData, O::Write) => self.block_1(),
+            (L::FreeDataFree, O::Write) => self.block_2(),
+        }
+    }
+
+    /// Which contiguous memory block to use for the next read operation
+    ///
+    /// See [Self] for more information on the ring buffer memory layout
+    ///
+    /// Note that the resulting block can be zero-sized if the ring buffer is empty.
+    pub fn next_read_block(&self) -> Block {
+        self.next_operation_block(OperationType::Read)
+    }
+
+    /// Which contiguous memory block to use for the next write operation
+    ///
+    /// See [Self] for more information on the ring buffer memory layout
+    ///
+    /// Note that the resulting block can be zero-sized if the ring buffer is full.
+    pub fn next_write_block(&self) -> Block {
+        self.next_operation_block(OperationType::Write)
+    }
+
+    /// Schedule an operation on the ring buffer.
+    ///
+    /// Calls [Self::schedule_next_read]/[Self::schedule_next_write] as per
+    /// the operation given.
+    pub fn schedule_next_contigous_operation<Size: TruncateIntoU64USize>(
+        &self,
+        op: OperationType,
+        max_len: Size,
+    ) -> Option<ScheduledOperation> {
+        let max_len = max_len.truncate_to_u64usize().u64();
+        let block = self.next_operation_block(op);
+        let len = std::cmp::min(block.len, max_len);
+        let op = ScheduledOperation::new(op, block.off, U64USize::new_or_panic(len));
+        (len > 0).then_some(op)
+    }
+
+    /// Schedule a contiguous read operation on the ring buffer.
+    ///
+    /// Will return [None] if the ring buffer is empty.
+    ///
+    /// The result takes the destination length into account and can be immediately used
+    /// for reads from the ring buffer into a contiguous slice of memory.
+    ///
+    /// Passing arbitrarily large destination sizes is valid; passing [usize]::MAX as the
+    /// destination length is explicitly supported and will just yield the maximum possible
+    /// contiguous read supported by the ring buffer.
+    ///
+    /// Note that this function will never schedule operations of a length that can not be represented
+    /// in both a u64 and a usize. For 64 bit systems, this is not a limitation in practice. For 32
+    /// bit systems it means that scheduled operations are restricted to around 4GB of data
+    /// transferred in one go.
+    pub fn schedule_next_read<Size: TruncateIntoU64USize>(
+        &self,
+        dst_len: Size,
+    ) -> Option<ScheduledOperation> {
+        self.schedule_next_contigous_operation(OperationType::Read, dst_len)
+    }
+
+    /// Schedule a contiguous write operation on the ring buffer.
+    ///
+    /// Will return [None] if the ring buffer is full.
+    ///
+    /// The result takes the destination length into account and can be immediately used
+    /// for writes from the ring buffer into a contiguous slice of memory.
+    ///
+    /// Passing arbitrarily large destination sizes is valid; passing [usize]::MAX or [u64]::MAX as the
+    /// destination length is explicitly supported and will just yield the maximum possible
+    /// contiguous read supported by the ring buffer.
+    ///
+    /// Note that this function will never schedule operations of a length that can not be represented
+    /// in both a u64 and a usize. For 64 bit systems, this is not a limitation in practice. For 32
+    /// bit systems it means that scheduled operations are restricted to around 4GB of data
+    /// transferred in one go.
+    pub fn schedule_next_write<Size: TruncateIntoU64USize>(
+        &self,
+        src_len: Size,
+    ) -> Option<ScheduledOperation> {
+        self.schedule_next_contigous_operation(OperationType::Write, src_len)
+    }
+
+    /// Schedule multiple contiguous operations
+    ///
+    /// Note that this function will never schedule operations of a length that can not be represented
+    /// in both a u64 and a usize. For 64 bit systems, this is not a limitation in practice. For 32
+    /// bit systems it means that the total size of scheduled operations is restricted to around 4GB of data.
+    pub fn schedule_contigous_operations<Size: TruncateIntoU64USize>(
+        &self,
+        op_type: OperationType,
+        max_len: Size,
+    ) -> ScheduledOperations {
+        let max_len = max_len.truncate_to_u64usize();
+        let op1 = self.schedule_next_contigous_operation(op_type, max_len);
+        let op2 = op1.and_then(|op1| {
+            self.register_operation(&op1)
+                .schedule_next_contigous_operation(op_type, max_len.u64() - op1.len.u64())
+        });
+
+        let cont = [op1, op2].iter().filter_map(|maybe_op| *maybe_op).collect();
+
+        // Wont panic, since we truncated max_len
+        ScheduledOperations::new_or_panic(cont)
+    }
+
+    /// Like [Self::schedule_next_read()], but returns between zero and two scheduled operations,
+    /// potentially draining the entire ring buffer.
+    pub fn schedule_reads<Size: TruncateIntoU64USize>(&self, dst_len: Size) -> ScheduledOperations {
+        self.schedule_contigous_operations(OperationType::Read, dst_len)
+    }
+
+    /// Like [Self::schedule_next_write()], but returns between zero and two scheduled operations,
+    /// potentially filling the entire ring buffer.
+    pub fn schedule_writes<Size: TruncateIntoU64USize>(
+        &self,
+        src_len: Size,
+    ) -> ScheduledOperations {
+        self.schedule_contigous_operations(OperationType::Write, src_len)
+    }
+}
+
+impl std::fmt::Debug for RingBufferScheduler {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("RingBufferScheduler")
+            .field("buf_len()", &self.buf_len())
+            .field("read_off()", &self.items_read())
+            .field("read_off_mod()", &self.read_off())
+            .field("write_off()", &self.items_written())
+            .field("write_off_mod()", &self.write_off())
+            .field("data_avail()", &self.data_avail())
+            .field("space_avail()", &self.space_avail())
+            .field("fill_state()", &self.fill_state())
+            .field("is_empty()", &self.is_empty())
+            .field("is_full()", &self.is_full())
+            .field("block_1()", &self.block_0())
+            .field("block_2()", &self.block_1())
+            .field("block_3()", &self.block_2())
+            .field("layout()", &self.layout())
+            .field("next_read_block()", &self.next_read_block())
+            .field("next_write_block()", &self.next_write_block())
+            .finish()
+    }
+}

--- a/rosenpass/src/internal/util/rustix/error.rs
+++ b/rosenpass/src/internal/util/rustix/error.rs
@@ -1,10 +1,88 @@
 //! Rustix extensions for error handling
 
-use anyhow::bail;
-use rustix::io::fcntl_dupfd_cloexec;
-use std::os::fd::{AsFd, BorrowedFd, FromRawFd, OwnedFd, RawFd};
+/// Provides access to the last system error number
+///
+/// > The integer variable errno is set by system calls and some library functions in the event of an error to indicate what went wrong.
+///
+/// -- `man 3 errno`
+///
+/// # Panics
+///
+/// This function panics if there is no system error to retrieve
+/// (the system error number, errno = 0).
+///
+/// # Examples
+///
+/// ```rust
+///
+/// use rustix::io::Errno as E;
+/// use rosenpass::internal::util::rustix::{errno, try_errno, last_os_result};
+///
+/// // Open a path below /dev/null; /dev/null is a character device, not a
+/// // directory, so this reliably fails with ENOTDIR on any system and,
+/// // being a read-only open, has no side effects.
+/// let res = unsafe { libc::open(c"/dev/null/rosenpass-errno-doctest".as_ptr(), libc::O_RDONLY) };
+/// assert_eq!(res, -1);
+/// assert_eq!(errno(), E::NOTDIR);
+/// assert_eq!(try_errno(), Some(E::NOTDIR));
+/// assert_eq!(last_os_result(), Err(E::NOTDIR));
+///
+/// // Deliberately clear the system error
+/// unsafe { libc::__errno_location().write(0) };
+/// // assert_eq!(errno(), _); // PANICS
+/// assert_eq!(try_errno(), None);
+/// assert_eq!(last_os_result(), Ok(()));
+/// ```
+///
+/// Calling errno() when there is no error causes a panic:
+///
+/// ```rust,should_panic
+///
+/// use rustix::io::Errno as E;
+/// use rosenpass::internal::util::rustix::errno;
+///
+/// // Deliberately clear the system error
+/// unsafe { libc::__errno_location().write(0) };
+/// errno(); // PANICS
+/// ```
+pub fn errno() -> rustix::io::Errno {
+    match try_errno() {
+        None => panic!(
+            "Tried to retrieve last system error, but there was no system error (the system error number, errno = 0)"
+        ),
+        Some(errno) => errno,
+    }
+}
 
-use crate::internal::util::{mem::Forgetting, result::OkExt};
+/// Provides access to the last system error number.
+///
+/// Variant of [errno()] that will return None if there was no system error.
+///
+/// # Examples
+///
+/// See [errno()].
+pub fn try_errno() -> Option<rustix::io::Errno> {
+    let raw = unsafe { libc::__errno_location().read() };
+    match raw {
+        0 => None,
+        _ => Some(rustix::io::Errno::from_raw_os_error(raw)),
+    }
+}
+
+/// Provides access to the last system error number.
+///
+/// Variant of [errno()] that will return `Err(errno)` if there
+/// was a system error and `Ok(())` otherwise.
+///
+/// # Examples
+///
+/// See [errno()].
+pub fn last_os_result() -> Result<(), rustix::io::Errno> {
+    match try_errno() {
+        None => Ok(()),
+        Some(errno) => Err(errno),
+    }
+}
 
 /// Convert low level errors into std::io::Error
 ///

--- a/rosenpass/src/internal/util/rustix/memfd.rs
+++ b/rosenpass/src/internal/util/rustix/memfd.rs
@@ -1,0 +1,90 @@
+//! Utilities for working with memory based file descriptors
+
+use std::os::fd::OwnedFd;
+
+use rustix::fs::MemfdFlags;
+use rustix::io::Errno;
+use rustix::path::Arg as Path;
+
+use bitflags::bitflags;
+
+use crate::internal::util::convert::IntoTypeExt;
+
+use super::SyscallResult;
+
+/// Create an anonymous file
+/// using the memfd_create(2) syscall
+///
+/// Just forwards to [rustix::fs::memfd_create]
+pub fn memfd_create<P: Path>(name: P, flags: MemfdFlags) -> rustix::io::Result<OwnedFd> {
+    rustix::fs::memfd_create(name, flags)
+}
+
+bitflags! {
+    /// `FD_*` constants for use with [memfd_secret].
+    #[repr(transparent)]
+    #[derive(Copy, Clone, Eq, PartialEq, Hash, Debug)]
+    pub struct MemfdSecretFlags: std::ffi::c_uint {
+        /// FD_CLOEXEC
+        const CLOEXEC = libc::FD_CLOEXEC as std::ffi::c_uint;
+    }
+}
+
+/// Errors for [memfd_secret()]
+#[derive(Copy, Clone, Debug, thiserror::Error)]
+pub enum MemfdSecretError {
+    /// memfd_secret(2) not supported on system
+    #[error(
+        "Could not create secret memory segment using memfd_secret(2): not supported on your system"
+    )]
+    NotSupported,
+    /// Other error
+    #[error("Could not create secret memory segment using memfd_secret(2): underlying system error: {:?}", .0)]
+    SystemError(Errno),
+}
+
+impl From<Errno> for MemfdSecretError {
+    fn from(value: Errno) -> Self {
+        match value {
+            Errno::NOSYS => Self::NotSupported,
+            e => Self::SystemError(e),
+        }
+    }
+}
+
+/// Create an anonymous RAM-based file to access secret memory regions
+/// using the memfd_secret(2) syscall
+///
+/// # Examples
+///
+/// ```
+/// use rustix::io::Errno;
+/// use rustix::fs::ftruncate;
+///
+/// use rosenpass::internal::util::rustix::{memfd_secret, MemfdSecretFlags, IntoStdioErr, MemfdSecretError};
+/// use rosenpass::internal::util::io::handle_interrupted;
+///
+/// let res = memfd_secret(MemfdSecretFlags::empty());
+///
+/// use MemfdSecretError as E;
+/// let fd = match res {
+///     Ok(fd) => fd,
+///     // The system might not have memfd_secret enabled; abort the test
+///     Err(E::NotSupported) => return Ok(()),
+///     Err(E::SystemError(err)) => return Err(err)?,
+/// };
+///
+/// handle_interrupted(|| { ftruncate(&fd, 8192).into_stdio_err() })?;
+///
+/// Ok::<(), anyhow::Error>(())
+/// ```
+pub fn memfd_secret(flags: MemfdSecretFlags) -> Result<rustix::fd::OwnedFd, MemfdSecretError> {
+    let res = unsafe {
+        use libc::{SYS_memfd_secret, syscall};
+        syscall(SYS_memfd_secret, flags)
+            .into_type::<SyscallResult>()
+            .claim_fd()
+    };
+
+    res.map_err(MemfdSecretError::from)
+}

--- a/rosenpass/src/internal/util/rustix/mod.rs
+++ b/rosenpass/src/internal/util/rustix/mod.rs
@@ -8,3 +8,9 @@ pub use fd::*;
 
 mod stat;
 pub use stat::*;
+
+mod syscall;
+pub use syscall::*;
+
+mod memfd;
+pub use memfd::*;

--- a/rosenpass/src/internal/util/rustix/syscall.rs
+++ b/rosenpass/src/internal/util/rustix/syscall.rs
@@ -1,0 +1,46 @@
+//! Helpers for performing system calls
+
+use std::os::fd::FromRawFd;
+
+use super::errno;
+
+/// Wrapper type around [libc::c_long] that indicates that this value represents
+/// the result of a system call
+#[repr(transparent)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub struct SyscallResult(pub libc::c_long);
+
+impl SyscallResult {
+    /// Access to [Self::0]
+    pub fn raw_value(&self) -> libc::c_long {
+        self.0
+    }
+
+    /// Claim the system call result as a file descriptor
+    ///
+    /// - If [Self::raw_value] < 0, then [errno()] is called to retrieve the error type
+    /// - If [Self::raw_value] > [i32::MAX], panics
+    /// - Otherwise, this just forwards to [rustix::fd::OwnedFd::from_raw_fd]
+    ///
+    /// # Panic
+    ///
+    /// Panics if [Self::raw_value] > [i32::MAX].
+    ///
+    /// # Safety
+    ///
+    /// Refer to [rustix::fd::OwnedFd::from_raw_fd].
+    pub unsafe fn claim_fd(&self) -> Result<rustix::fd::OwnedFd, rustix::io::Errno> {
+        let fde = self.0;
+        match fde {
+            e if e < 0 => Err(errno()),
+            fd if fd > i32::MAX.into() => panic!("File descriptor `{fd}` is out of bounds!"),
+            fd => Ok(unsafe { rustix::fd::OwnedFd::from_raw_fd(fd as i32) }),
+        }
+    }
+}
+
+impl From<libc::c_long> for SyscallResult {
+    fn from(value: libc::c_long) -> Self {
+        Self(value)
+    }
+}

--- a/rosenpass/src/internal/util/secret_memory/fd.rs
+++ b/rosenpass/src/internal/util/secret_memory/fd.rs
@@ -1,0 +1,204 @@
+//! Creation of secret memory file descriptors.
+//!
+//! This essentially provides a higher_level API for [memfd_secret()] and [memfd_create()]
+
+// Tests: This uses nix-based integration tests
+
+use std::{os::fd::OwnedFd, sync::OnceLock};
+
+use rustix::{fs::MemfdFlags, io::Errno};
+
+use crate::internal::util::rustix::{
+    MemfdSecretError, MemfdSecretFlags, memfd_create, memfd_secret,
+};
+use crate::internal::util::{mem::CopyExt, result::OkExt};
+
+/// Cache for [memfd_secret_supported]
+static MEMFD_SECRET_SUPPORTED: OnceLock<bool> = OnceLock::new();
+
+/// Check whether support for memfd_secret is available
+pub fn memfd_secret_supported() -> Result<bool, Errno> {
+    match MEMFD_SECRET_SUPPORTED.get() {
+        Some(v) => return Ok(*v),
+        _ => {} // Continue
+    };
+
+    use MemfdSecretError as E;
+    let is_supported = match memfd_secret(MemfdSecretFlags::empty()) {
+        Ok(_) => true,
+        Err(E::NotSupported) => false,
+        Err(E::SystemError(e)) => return Err(e),
+    };
+
+    // We are deliberately using get_or_init here to make sure that the entire application
+    // never sees different values here
+    MEMFD_SECRET_SUPPORTED
+        .get_or_init(|| is_supported)
+        .copy()
+        .ok()
+}
+
+/// How secure memory file descriptors should be allocated
+#[derive(Debug, Clone, Copy, PartialEq, PartialOrd, Ord, Eq)]
+pub enum SecretMemfdPolicy {
+    /// Use memfd_secret(2) if available, otherwise fall back to less
+    /// secure options
+    Opportunistic,
+    /// Enforce the use of memfd_secret(2)
+    UseMemfdSecret,
+    /// Never use memfd_secret(2)
+    DisableMemfdSecret,
+}
+
+impl Default for SecretMemfdPolicy {
+    fn default() -> Self {
+        Self::Opportunistic
+    }
+}
+
+impl SecretMemfdPolicy {
+    /// Create a SecretMemfdPolicy with the default policy
+    ///
+    /// Currently [Self::Opportunistic]
+    pub const fn default_const() -> Self {
+        Self::Opportunistic
+    }
+
+    /// Enforce the use of the highest security configuration available
+    ///
+    /// This might not work on some systems, which is why this is not used
+    /// by default.
+    ///
+    /// Currently [Self::UseMemfdSecret]
+    pub const fn enforce_high_security() -> Self {
+        Self::UseMemfdSecret
+    }
+}
+
+/// Which mechanism to us use when allocating secret memory file descriptors
+#[derive(Debug, Clone, Copy, PartialEq, PartialOrd, Ord, Eq)]
+pub enum SecretMemfdMechanism {
+    /// The less secure memfd_create(2) will be used
+    MemfdCreate,
+    /// The more secure memfd_secret(2) will be used
+    MemfdSecret,
+}
+
+impl SecretMemfdMechanism {
+    /// Decide which mechanism to use, based on the given [SecretMemfdPolicy]
+    /// and [memfd_secret_supported()].
+    ///
+    /// If [SecretMemfdPolicy::UseMemfdSecret] is used, then [SecretMemfdMechanism::MemfdSecret]
+    /// will be returned, regardless of whether it is supported.
+    ///
+    /// Likewise, if [SecretMemfdPolicy::DisableMemfdSecret] is used, then
+    /// [SecretMemfdMechanism::MemfdCreate] will be used unconditionally.
+    pub fn decide_with_policy(policy: SecretMemfdPolicy) -> Result<Self, Errno> {
+        use SecretMemfdMechanism as M;
+        use SecretMemfdPolicy as P;
+
+        match policy {
+            P::UseMemfdSecret => return Ok(M::MemfdSecret),
+            P::DisableMemfdSecret => return Ok(M::MemfdCreate),
+            P::Opportunistic => {}
+        };
+
+        match memfd_secret_supported()? {
+            true => Ok(M::MemfdSecret),
+            false => Ok(M::MemfdCreate),
+        }
+    }
+}
+
+/// Errors for [SecretMemfdConfig::create()]
+#[derive(Copy, Clone, Debug, thiserror::Error)]
+pub enum SecretMemfdWithConfigError {
+    /// Call to [memfd_secret()] failed
+    #[error("{:?}", .0)]
+    MemfdSecretError(#[from] MemfdSecretError),
+    /// Call to [memfd_create()] failed
+    #[error("Could not create secret memory segment using memfd_create(2) due to underlying system error: {:?}", .0)]
+    MemfdCreateError(Errno),
+    /// Some other (system) error occurred that prevented us from determining whether
+    /// memfd_secret(2) is supported.
+    #[error("Failed to determine whether memfd_secret(2) is supported due to underlying system error: {:?}", .0)]
+    FailedToDetectSupport(Errno),
+}
+
+/// Robustly configure and create secret memory file descriptors
+///
+/// Whereas [memfd_secret] will always use memfd_secret(2), this construction allows multiple
+/// file descriptor back ends to be used to support different usage scenarios.
+///
+/// This is necessary, because older systems do not support memfd_secret(2) and using it might not
+/// always be desirable, as memfd_secret for instance also inhibits hibernation.
+#[derive(Default, Debug, Clone, Copy, PartialEq, PartialOrd, Ord, Eq)]
+pub struct SecretMemfdConfig {
+    /// Enable  the  close-on-exec flag for the new file descriptor.
+    pub close_on_exec: bool,
+    /// Security mechanism to use
+    pub policy: SecretMemfdPolicy,
+}
+
+impl SecretMemfdConfig {
+    /// Create a new, default [Self]
+    pub const fn new() -> Self {
+        let close_on_exec = false;
+        let policy = SecretMemfdPolicy::default_const();
+        Self {
+            close_on_exec,
+            policy,
+        }
+    }
+
+    /// Set the [Self::close_on_exec] flag to true
+    pub const fn cloexec(&self) -> Self {
+        let mut r = *self;
+        r.close_on_exec = true;
+        r
+    }
+
+    /// Set `self.policy = SecretMemoryFdPolicy::UseMemfdSecret`
+    pub const fn enforce_high_security(&self) -> Self {
+        let mut r = *self;
+        r.policy = SecretMemfdPolicy::enforce_high_security();
+        r
+    }
+
+    /// Whether memfd_secret will be used by [Self::create()]
+    pub fn mechanism(&self) -> Result<SecretMemfdMechanism, Errno> {
+        SecretMemfdMechanism::decide_with_policy(self.policy)
+    }
+
+    /// Allocate a secret file descriptor based on the configuration
+    pub fn create(&self) -> Result<OwnedFd, SecretMemfdWithConfigError> {
+        use SecretMemfdWithConfigError as E;
+        let mech = self.mechanism().map_err(E::FailedToDetectSupport)?;
+
+        use SecretMemfdMechanism as M;
+        match (mech, self.close_on_exec) {
+            (M::MemfdCreate, cloexec) => {
+                let flags = match cloexec {
+                    true => MemfdFlags::CLOEXEC,
+                    false => MemfdFlags::empty(),
+                };
+                memfd_create("rosenpass secret memory segment", flags).map_err(E::MemfdCreateError)
+            }
+            (M::MemfdSecret, cloexec) => {
+                let flags = match cloexec {
+                    true => MemfdSecretFlags::CLOEXEC,
+                    false => MemfdSecretFlags::empty(),
+                };
+                memfd_secret(flags).map_err(E::MemfdSecretError)
+            }
+        }
+    }
+}
+
+/// Create a secret memory file descriptor using the default policy
+///
+/// Shorthand for
+/// [`SecretMemfdConfig::new()`] followed by [`SecretMemfdConfig::create()`]
+pub fn memfd_for_secrets_with_default_policy() -> Result<OwnedFd, SecretMemfdWithConfigError> {
+    SecretMemfdConfig::new().create()
+}

--- a/rosenpass/src/internal/util/secret_memory/mmap.rs
+++ b/rosenpass/src/internal/util/secret_memory/mmap.rs
@@ -1,0 +1,415 @@
+//! This module takes care of allocating memory segments for
+//! file descriptors created with [super::fd::memfd_for_secrets_with_default_policy]
+//! and anonymous memory segments
+
+// Tests: Nix based integration tests
+
+#![deny(unsafe_op_in_unsafe_fn)]
+
+use std::os::fd::{AsFd, AsRawFd, BorrowedFd, RawFd};
+use std::ptr::null_mut;
+
+use crate::internal::util::mem::CopyExt;
+
+/// Size of the memory mapping for [MappableFd]
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub enum MMapSizePolicy {
+    /// Size is assumed to be this particular value; [MappableFd::mmap] will simply
+    /// use this value without checking whether its matches the size of the underlying
+    /// data
+    Assumed(u64),
+    /// Size is assumed to be this particular value; [MappableFd::mmap] will check the
+    /// size of the underlying data and raise an error if the size of data and this value
+    /// do not match
+    Checked(u64),
+    /// Size is defined to be this particular value; [MappableFd::mmap] will explicitly resize
+    /// the underlying file descriptor to be this particular size when called.
+    Resize(u64),
+}
+
+impl MMapSizePolicy {
+    /// The numeric value of the size
+    pub fn size_value(&self) -> u64 {
+        match *self {
+            Self::Assumed(v) => v,
+            Self::Checked(v) => v,
+            Self::Resize(v) => v,
+        }
+    }
+}
+
+/// Configuration for [MappableFd::mmap]
+#[derive(Default, Debug, Clone, Copy, PartialEq, Eq)]
+pub struct MapFdConfig {
+    /// The memory region can not be read from
+    pub unreadable: bool,
+    /// The memory region can not be written to
+    pub immutable: bool,
+    /// The memory region can be executed
+    pub executable: bool,
+    /// The memory region is shared-memory; other mappings of the same
+    /// region within and outside this process can see the modifications
+    /// to the memory region (as long as they also set the shared flag)
+    pub shared: bool,
+    /// How [MappableFd::mmap] will determine the size to be used fo
+    ///
+    /// You should usually set this value through [Self::set_size_policy], [Self::assume_size_without_checking],
+    /// [Self::expected_size], or [Self::resize_on_mmap].
+    pub size_policy: Option<MMapSizePolicy>,
+}
+
+impl MapFdConfig {
+    /// New MapFdConfig with all settings turned off
+    ///
+    /// You still must set [Self::size_policy], otherwise [MappableFd::mmap] will raise
+    /// an error when called
+    pub const fn new() -> Self {
+        MapFdConfig {
+            unreadable: false,
+            immutable: false,
+            executable: false,
+            shared: false,
+            size_policy: None,
+        }
+    }
+
+    /// New MappableFdConfig with shared memory turned on
+    pub const fn shared_memory() -> Self {
+        Self::new().set_shared()
+    }
+
+    /// Set the [Self::unreadable] flag
+    pub const fn set_unreadable(&self) -> Self {
+        let mut r = *self;
+        r.unreadable = true;
+        r
+    }
+
+    /// Set the [Self::immutable] flag
+    pub const fn set_immutable(&self) -> Self {
+        let mut r = *self;
+        r.immutable = true;
+        r
+    }
+
+    /// Set the [Self::shared] flag
+    pub const fn set_shared(&self) -> Self {
+        let mut r = *self;
+        r.shared = true;
+        r
+    }
+
+    /// Create a [MappableFd] instance with this configuration
+    pub fn mappable_fd<Fd: AsFd>(&self, fd: Fd) -> MappableFd<Fd> {
+        MappableFd::new(fd, self.copy())
+    }
+
+    /// Calculate [rustix::mm::ProtFlags] for this configuration
+    pub const fn mmap_prot(&self) -> rustix::mm::ProtFlags {
+        use rustix::mm::ProtFlags as P;
+
+        let p_read = match self.unreadable {
+            true => P::empty(),
+            false => P::READ,
+        };
+
+        let p_write = match self.immutable {
+            true => P::empty(),
+            false => P::WRITE,
+        };
+
+        let p_exec = match self.executable {
+            true => P::EXEC,
+            false => P::empty(),
+        };
+
+        p_read.union(p_write).union(p_exec)
+    }
+
+    /// Calculate [rustix::mm::MapFlags] for this configuration
+    pub const fn mmap_flags(&self) -> rustix::mm::MapFlags {
+        use rustix::mm::MapFlags as M;
+        match self.shared {
+            true => M::SHARED,
+            false => M::empty(),
+        }
+    }
+
+    /// Set [Self::size_policy] to the given value
+    pub const fn set_size_policy(&self, size_policy: MMapSizePolicy) -> Self {
+        let mut r = *self;
+        r.size_policy = Some(size_policy);
+        r
+    }
+
+    /// Set [Self::size_policy] to [MMapSizePolicy::Assumed] with the given value
+    pub const fn assume_size_without_checking(&self, size: u64) -> Self {
+        self.set_size_policy(MMapSizePolicy::Assumed(size))
+    }
+
+    /// Set [Self::size_policy] to [MMapSizePolicy::Checked] with the given value
+    pub const fn expected_size(&self, size: u64) -> Self {
+        self.set_size_policy(MMapSizePolicy::Checked(size))
+    }
+
+    /// Set [Self::size_policy] to [MMapSizePolicy::Resize] with the given value
+    pub const fn resize_on_mmap(&self, size: u64) -> Self {
+        self.set_size_policy(MMapSizePolicy::Resize(size))
+    }
+}
+
+/// Error returned by MappableFd::mmap
+#[derive(thiserror::Error, Debug, Copy, Clone, PartialEq, Eq)]
+pub enum MMapError {
+    /// Error converting between usize & f64
+    #[error("Requested memory map of size {requested_len} but maximum supported size is {max_supported_len}. \
+        This is a low level error that usually arises on architectures where the integer type usize ({} bytes) can not \
+        represent all values in u64 ({} bytes). Are you possibly on 32 bit CPU architecture requesting a buffer bigger than 4 GB?\n\
+          Error: {err:?}",
+        (usize::BITS as f64)/8f64, (u64::BITS as f64)/8f64
+    )]
+    OutOfBounds {
+        /// Underlying error
+        err: <u64 as TryInto<usize>>::Error,
+        /// The size of the memory map requested
+        requested_len: u64,
+        /// Maximum supported size
+        max_supported_len: usize,
+    },
+    /// Tried to map a file descriptor into memory, but the size policy was never set. Developer
+    /// error.
+    #[error(
+        "Tried to map a file descriptor into memory, but the size policy was never set. This is a developer error."
+    )]
+    MissingSizePolicy,
+    /// fseek(3)/ftell(3) system call failed
+    #[error("Tried to map file descriptor into memory, but failed to determine the size of the file descriptor: {:?}", .0)]
+    CouldNotDetermineSize(rustix::io::Errno),
+    /// Mismatch between expected and actual size of the file descriptor
+    #[error(
+        "Tried to map file descriptor into memory with expected size {expected:?}, instead we found that the true size is {actual:?}"
+    )]
+    IncorrectSize {
+        /// Expected file descriptor size (given by caller)
+        expected: u64,
+        /// Actual file descriptor size
+        actual: u64,
+    },
+    /// Negative size reported by fstat(2)
+    #[error(
+        "Tried to determine the size of the underlying file descriptor, but failed to determine the size of the file descriptor because the size ({size}) is negative: {err:?}"
+    )]
+    InvalidSize {
+        /// Underlying error
+        err: <i64 as TryInto<u64>>::Error,
+        /// Reported size of the file descriptor
+        size: i64,
+    },
+    /// ftruncate(2) system call failed
+    #[error("Tried to resize the underlying file descriptor, but failed: {:?}", .0)]
+    ResizeError(rustix::io::Errno),
+    /// mmap(2) system call failed
+    #[error("Tried to map file descriptor into memory, but mmap(2) system call failed: {:?}", .0)]
+    MMapError(rustix::io::Errno),
+}
+
+/// Handle mapping a file descriptor into memory
+pub struct MappableFd<Fd: AsFd> {
+    /// The file descriptor this struct refers to
+    fd: Fd,
+    /// The configuration for mmap
+    config: MapFdConfig,
+}
+
+impl<Fd: AsFd> AsFd for MappableFd<Fd> {
+    fn as_fd(&self) -> BorrowedFd<'_> {
+        self.fd.as_fd()
+    }
+}
+
+impl<Fd: AsFd> AsRawFd for MappableFd<Fd> {
+    fn as_raw_fd(&self) -> RawFd {
+        self.as_fd().as_raw_fd()
+    }
+}
+
+impl<Fd: AsFd> MappableFd<Fd> {
+    /// Create a [MappableFd] using the default configuration ([MapFdConfig])
+    pub fn from_fd(fd: Fd) -> Self {
+        Self::new(fd, MapFdConfig::default())
+    }
+
+    /// Create a new [MappableFd] for an existing file descriptor
+    pub fn new(fd: Fd, config: MapFdConfig) -> Self {
+        Self { fd, config }
+    }
+
+    /// Extract the underlying file descriptor
+    pub fn into_fd(self) -> Fd {
+        self.fd
+    }
+
+    /// Access the [MapFdConfig] associated with Self
+    pub fn config(&self) -> MapFdConfig {
+        self.config
+    }
+
+    /// Access the [MapFdConfig] associated with Self
+    pub fn config_mut(&mut self) -> &mut MapFdConfig {
+        &mut self.config
+    }
+
+    /// Modify the [MapFdConfig] associated with Self, chainable
+    pub fn with_config(mut self, config: MapFdConfig) -> Self {
+        self.config = config;
+        self
+    }
+
+    /// Determine the size of the data associated with the file descriptor
+    pub fn size_of_underlying_data(&self) -> Result<u64, MMapError> {
+        use MMapError as E;
+        let size = rustix::fs::fstat(self)
+            .map_err(E::CouldNotDetermineSize)?
+            .st_size;
+        size.try_into().map_err(|err| E::InvalidSize { err, size })
+    }
+
+    /// Map the file into memory
+    ///
+    /// # Determining the size of the mapping.
+    ///
+    /// Before calling this function, [MapFdConfig::size_policy] must be set.
+    ///
+    /// Note that [Self::from_fd] and [Self::new] still allow you to create a [Self] with
+    /// [MapFdConfig::size_policy] set to [None], so you can use [Self::size_of_underlying_data]
+    /// to auto-detect the size of the mapping.
+    ///
+    /// This functionality is not implemented by default, as its crucial to validate the size of
+    /// the data being mapped into memory somehow; otherwise, the party that created the file
+    /// descriptor can trigger a denial-of-service attack against our process by allocating an
+    /// excessively large, sparse file. If you implement size auto-detection facilities, you should
+    /// still enforce some bounds on the size.
+    ///
+    /// # Safety
+    ///
+    /// If there exist any Rust references referring to the memory region, or if you subsequently create a Rust reference referring to the resulting region, it is your responsibility to ensure that the Rust reference invariants are preserved, including ensuring that the memory is not mutated in a way that a Rust reference would not expect.
+    pub fn mmap(&self) -> Result<MappedSegment, MMapError> {
+        use MMapError as E;
+        use rustix::mm::mmap;
+
+        let prot = self.config().mmap_prot();
+        let flags = self.config().mmap_flags();
+
+        // Determine the size of the mapping to be used as u64
+        let requested_size = match self.config().size_policy {
+            None => return Err(E::MissingSizePolicy),
+            Some(MMapSizePolicy::Assumed(size)) => size,
+            Some(MMapSizePolicy::Resize(size)) => {
+                rustix::fs::ftruncate(self, size).map_err(E::ResizeError)?;
+                size
+            }
+            Some(MMapSizePolicy::Checked(expected)) => {
+                let actual = self.size_of_underlying_data()?;
+                if expected != actual {
+                    return Err(E::IncorrectSize { expected, actual });
+                }
+                expected
+            }
+        };
+
+        // Cast the size of the mapping to be used to usize, raising an error if the
+        // requested_size can not be represented as usize (this should never happen in general,
+        // but it could conceivably be thrown on 32 bit systems when very large mappings (>= 4GB)
+        // are requested
+        let len = requested_size.try_into().map_err(|err| {
+            let max_supported_len = usize::MAX;
+            E::OutOfBounds {
+                err,
+                requested_len: requested_size,
+                max_supported_len,
+            }
+        })?;
+
+        let ptr = unsafe { mmap(null_mut(), len, prot, flags, self, 0) };
+        let ptr = ptr.map_err(E::MMapError)?;
+        let ptr = unsafe { MappedSegment::from_raw_parts(ptr.cast(), len) };
+
+        Ok(ptr)
+    }
+}
+
+/// Represents exclusive ownership of a memory segment mapped into memory
+///
+/// Automatically unmaps the memory segment as this goes out of scope
+///
+/// # Panic
+///
+/// If the munmap(2) call fails, the destructor will panic. You can avoid this and use explicit
+/// error handling by calling [Self::unmap] instead
+#[derive(Debug)]
+pub struct MappedSegment {
+    /// The location of the memory segment
+    ptr: *mut u8,
+    /// Length of the segment in bytes
+    len: usize,
+}
+
+unsafe impl Send for MappedSegment {}
+
+impl MappedSegment {
+    /// Construct a new [Self] from a pointer and a length
+    ///
+    /// `ptr` is the address of the memory segment and `len` is its length in bytes
+    ///
+    /// # Safety
+    ///
+    /// It is the responsibility of the caller to make sure that any pointer P such that `P = ptr.add(n)`,
+    /// where `n < len` is a valid pointer. See #safety in [std::ptr].
+    pub unsafe fn from_raw_parts(ptr: *mut u8, len: usize) -> Self {
+        Self { ptr, len }
+    }
+
+    /// Decompose a MappedSegment into its raw components: Pointer and length
+    pub fn into_raw_parts(self) -> (*mut u8, usize) {
+        let r = (self.ptr(), self.len());
+        std::mem::forget(self);
+        r
+    }
+
+    /// The location of the memory segment
+    pub fn ptr(&self) -> *mut u8 {
+        self.ptr
+    }
+
+    /// Length of the segment in bytes
+    #[allow(clippy::len_without_is_empty)]
+    pub fn len(&self) -> usize {
+        self.len
+    }
+
+    /// Release the memory segment
+    ///
+    /// Compared to using the destructor which panics if unmapping fails, this allows explicit error handling to be used.
+    ///
+    /// If this returns an error, the memory segment has not been freed. The values from
+    /// [Self::into_raw_parts()] are returned as part of the error value so the caller has
+    /// some chance to free the memory some other way (or to leak it if they so choose)
+    pub fn unmap(self) -> Result<(), (rustix::io::Errno, *mut u8, usize)> {
+        let (ptr, len) = self.into_raw_parts();
+        let res = unsafe { rustix::mm::munmap(ptr.cast(), len) };
+        res.map_err(|errno| (errno, ptr, len))
+    }
+}
+
+impl Drop for MappedSegment {
+    fn drop(&mut self) {
+        let mut owned = MappedSegment {
+            ptr: null_mut(),
+            len: 0,
+        };
+        std::mem::swap(self, &mut owned);
+        if let Err((errno, _ptr, _len)) = owned.unmap() {
+            panic!("Failed to unmap MappedSegment: {errno:?}")
+        }
+    }
+}

--- a/rosenpass/src/internal/util/secret_memory/mod.rs
+++ b/rosenpass/src/internal/util/secret_memory/mod.rs
@@ -1,3 +1,4 @@
 //! Utilities for allocating secret memory
 
 pub mod fd;
+pub mod mmap;

--- a/rosenpass/src/internal/util/secret_memory/mod.rs
+++ b/rosenpass/src/internal/util/secret_memory/mod.rs
@@ -1,0 +1,3 @@
+//! Utilities for allocating secret memory
+
+pub mod fd;

--- a/rosenpass/src/internal/util/sync/atomic/abstract_atomic.rs
+++ b/rosenpass/src/internal/util/sync/atomic/abstract_atomic.rs
@@ -1,0 +1,107 @@
+//! Traits for types with atomic access semantics
+
+use std::sync::atomic::Ordering;
+
+/// A trait for types with atomic access semantics
+///
+/// Using this trait allows us to achieve two goals:
+///
+/// 1. We can implement atomic semantics for types where
+///    there is no platform support for atomic semantics
+///    (e.g. by using a Mutex)
+/// 2. We can reuse implementations of concurrent data structures
+///    efficiently for the non-concurrent case. E.g. we could
+///    build a thread-local ring buffer using
+///    [crate::internal::util::ringbuf::concurrent::framework::ConcurrentPipeWriter]/
+///    [crate::internal::util::ringbuf::concurrent::framework::ConcurrentPipeReader]
+///    by supplying some sort `Immediate<u64>` type for the atomics
+///    in [crate::internal::util::ringbuf::concurrent::framework::ConcurrentPipeCore] that implements
+///    this trait by using a [std::cell::Cell]. It may seem counter
+///    intuitive, but this setup implements perfectly fine atomic-appearing
+///    semantics just as long as the cell is thread-local.
+pub trait AbstractAtomic<T> {
+    /// Like [std::sync::atomic::AtomicU64::load()]
+    fn load(&self, order: Ordering) -> T;
+
+    /// Like [std::sync::atomic::AtomicU64::compare_exchange_weak()].
+    ///
+    /// The default implementation just calls [AbstractAtomic::compare_exchange()].
+    fn compare_exchange_weak(
+        &self,
+        current: T,
+        new: T,
+        success: Ordering,
+        failure: Ordering,
+    ) -> Result<T, T> {
+        self.compare_exchange(current, new, success, failure)
+    }
+
+    /// Like [std::sync::atomic::AtomicU64::compare_exchange()].
+    fn compare_exchange(
+        &self,
+        current: T,
+        new: T,
+        success: Ordering,
+        failure: Ordering,
+    ) -> Result<T, T>;
+}
+
+/// Implements a default type for [AbstractAtomic]
+///
+/// This in essence is to [AbstractAtomic], as [std::ops::Deref] is to [std::borrow::Borrow];
+/// the same functionality, except with a
+pub trait AbstractAtomicType: AbstractAtomic<Self::ValueType> {
+    /// The underlying atomic value
+    type ValueType;
+}
+
+/// Implementing [AbstractAtomic] and [AbstractAtomicType] for standard atomics
+macro_rules! impl_abstract_atomic_for_atomic {
+    ($($Atomic:ty : $Value:ty),*) => {
+        $(
+            impl AbstractAtomicType for $Atomic {
+                type ValueType = $Value;
+            }
+
+            impl AbstractAtomic<$Value> for $Atomic {
+                fn load(&self, order: Ordering) -> $Value {
+                    <$Atomic>::load(&self, order)
+                }
+
+                fn compare_exchange_weak(
+                    &self,
+                    current: $Value,
+                    new: $Value,
+                    success: Ordering,
+                    failure: Ordering,
+                ) -> Result<$Value, $Value> {
+                    <$Atomic>::compare_exchange_weak(&self, current, new, success, failure)
+                }
+
+                fn compare_exchange(
+                    &self,
+                    current: $Value,
+                    new: $Value,
+                    success: Ordering,
+                    failure: Ordering,
+                ) -> Result<$Value, $Value> {
+                    <$Atomic>::compare_exchange(&self, current, new, success, failure)
+                }
+            }
+        )*
+    };
+}
+
+impl_abstract_atomic_for_atomic! {
+    std::sync::atomic::AtomicBool: bool,
+    std::sync::atomic::AtomicI8: i8,
+    std::sync::atomic::AtomicI16: i16,
+    std::sync::atomic::AtomicI32: i32,
+    std::sync::atomic::AtomicI64: i64,
+    std::sync::atomic::AtomicIsize: isize,
+    std::sync::atomic::AtomicU8: u8,
+    std::sync::atomic::AtomicU16: u16,
+    std::sync::atomic::AtomicU32: u32,
+    std::sync::atomic::AtomicU64: u64,
+    std::sync::atomic::AtomicUsize: usize
+}

--- a/rosenpass/src/internal/util/sync/atomic/mod.rs
+++ b/rosenpass/src/internal/util/sync/atomic/mod.rs
@@ -1,0 +1,5 @@
+//! Synchronization using atomic semantics for multi-threaded programs.
+//!
+//! Analogous to [std::sync::atomic].
+
+pub mod abstract_atomic;

--- a/rosenpass/src/internal/util/sync/mod.rs
+++ b/rosenpass/src/internal/util/sync/mod.rs
@@ -1,0 +1,5 @@
+//! Synchronization for multi-threaded programs.
+//!
+//! Analogous to [std::sync].
+
+pub mod atomic;

--- a/rosenpass/src/internal/util/tokio/janitor.rs
+++ b/rosenpass/src/internal/util/tokio/janitor.rs
@@ -437,7 +437,7 @@ pub struct EnsureJanitorResult<T, E> {
     /// - `Some(Ok(()))` if a new janitor had to be created and it exited successfully
     /// - `Some(Err(...))` if a new janitor had to be created and it exited with an error
     pub janitor_result: Option<anyhow::Result<()>>,
-    /// See [EnterJanitorResult::callee]
+    /// See [EnterJanitorResult::callee_result]
     pub callee_result: Result<T, E>,
 }
 

--- a/rosenpass/src/internal/util/zerocopy/mod.rs
+++ b/rosenpass/src/internal/util/zerocopy/mod.rs
@@ -5,11 +5,11 @@
 #![cfg_attr(
     feature = "expose_internal_modules",
     doc = r#"
-- [`RefMaker`]: A helper structure for safely creating `zerocopy::Ref` references from byte slices.
-- [`ZerocopyEmancipateExt`]: A trait to convert `Ref<B, T>` into a borrowed `Ref<&[u8], T>`.
-- [`ZerocopyEmancipateMutExt`]: A trait to convert `Ref<B, T>` into a borrowed mutable `Ref<&mut [u8], T>`.
-- [`ZerocopySliceExt`]: Extension methods for parsing byte slices into zero-copy references.
-- [`ZerocopyMutSliceExt`]: Extension methods for parsing and zeroizing byte slices into zero-copy references.
+- [`RefMaker`](crate::internal::util::zerocopy::RefMaker): A helper structure for safely creating `zerocopy::Ref` references from byte slices.
+- [`ZerocopyEmancipateExt`](crate::internal::util::zerocopy::ZerocopyEmancipateExt): A trait to convert `Ref<B, T>` into a borrowed `Ref<&[u8], T>`.
+- [`ZerocopyEmancipateMutExt`](crate::internal::util::zerocopy::ZerocopyEmancipateMutExt): A trait to convert `Ref<B, T>` into a borrowed mutable `Ref<&mut [u8], T>`.
+- [`ZerocopySliceExt`](crate::internal::util::zerocopy::ZerocopySliceExt): Extension methods for parsing byte slices into zero-copy references.
+- [`ZerocopyMutSliceExt`](crate::internal::util::zerocopy::ZerocopyMutSliceExt): Extension methods for parsing and zeroizing byte slices into zero-copy references.
 "#
 )]
 #![cfg_attr(

--- a/rosenpass/src/internal/util/zeroize/mod.rs
+++ b/rosenpass/src/internal/util/zeroize/mod.rs
@@ -1,13 +1,16 @@
 //!
 //! This module provides the extension trait
-#![cfg_attr(feature = "expose_internal_modules", doc = "[`ZeroizedExt`],")]
+#![cfg_attr(
+    feature = "expose_internal_modules",
+    doc = "[`ZeroizedExt`](crate::internal::util::zeroize::ZeroizedExt),"
+)]
 #![cfg_attr(not(feature = "expose_internal_modules"), doc = "`ZeroizedExt`,")]
 //! for all types implementing the
 //! `zeroize::Zeroize` trait.
 //! It introduces the
 #![cfg_attr(
     feature = "expose_internal_modules",
-    doc = "[`zeroized`](ZeroizedExt::zeroized)"
+    doc = "[`zeroized`](crate::internal::util::zeroize::ZeroizedExt::zeroized)"
 )]
 #![cfg_attr(not(feature = "expose_internal_modules"), doc = "`zeroized`")]
 //! method, which zeroizes a value in place and returns it, making it convenient

--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -805,6 +805,10 @@ criteria = "safe-to-deploy"
 version = "2.0.20"
 criteria = "safe-to-deploy"
 
+[[exemptions.tinyvec]]
+version = "1.10.0"
+criteria = "safe-to-deploy"
+
 [[exemptions.tokio]]
 version = "1.53.1"
 criteria = "safe-to-deploy"


### PR DESCRIPTION
This merges the work done in 2025 to introduce a security-focused communications backend for the shared memory API. The code has been rebased and cleaned up. It is preliminary work necessary before implementing the API itself.

In practice we are adding a lot generic of utilities for inter process communications, mostly focused around memfd-secret backed, memory-mapped buffers.

We can use the same utilities introduced here as a new back end for the secret memory allocation code.